### PR TITLE
Rearrange makefile to separate sudo-required steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,19 @@ endif
 
 all: rtimv
 
-rtimv:
+makefile.librtimv:
 	$(QMAKE) -makefile librtimv.pro
-	sudo $(MAKE) -f makefile.librtimv install
+makefile.rtimv:
 	$(QMAKE) -makefile rtimv.pro
+
+rtimv: makefile.librtimv makefile.rtimv
+	$(MAKE) -f makefile.librtimv
 	$(MAKE) -f makefile.rtimv
 
-install: rtimv
-	$(MAKE) -f makefile.librtimv install
-	$(MAKE) -f makefile.rtimv install 
+
+install: makefile.librtimv makefile.rtimv rtimv
+	sudo $(MAKE) -f makefile.librtimv install
+	sudo $(MAKE) -f makefile.rtimv install
 
 clean:
 	rm -f obj/*.o *~

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,20 @@ endif
 
 ##############################
 
-all: rtimv
+all: bin/librtimv.so bin/rtimv
 
-makefile.librtimv:
+makefile.librtimv: librtimv.pro
 	$(QMAKE) -makefile librtimv.pro
-makefile.rtimv:
+makefile.rtimv: rtimv.pro
 	$(QMAKE) -makefile rtimv.pro
 
-rtimv: makefile.librtimv makefile.rtimv
+bin/librtimv.so: makefile.librtimv
 	$(MAKE) -f makefile.librtimv
+
+bin/rtimv: makefile.rtimv
 	$(MAKE) -f makefile.rtimv
 
-
-install: makefile.librtimv makefile.rtimv rtimv
+install: makefile.librtimv makefile.rtimv bin/librtimv.so bin/rtimv
 	sudo $(MAKE) -f makefile.librtimv install
 	sudo $(MAKE) -f makefile.rtimv install
 
@@ -41,3 +42,5 @@ clean:
 	rm -f makefile.rtimv
 	rm -f bin/librtimv.so
 	rm -f bin/rtimv
+
+.PHONY: all install clean


### PR DESCRIPTION
This change makes it so that the makefiles are not regenerated every time triggering a rebuild when you go to install