### PR TITLE
Add -fPIC for librtimv

### DIFF
--- a/librtimv.pro
+++ b/librtimv.pro
@@ -14,7 +14,7 @@ CONFIG(release, debug|release) {
 
 #CONFIG += c++14
 
-QMAKE_CXXFLAGS += -std=c++20
+QMAKE_CXXFLAGS += -std=c++20 -fPIC
 
 CONFIG += -O3
 


### PR DESCRIPTION
This fixes a build error with GCC 15 on Fedora 42:

```
g++ -Wl,-O1 -Wl,-rpath-link,/usr/lib64 -shared -Wl,-soname,librtimv.so.1 -o librtimv.so.1.0.0 obj/rtimvGraphicsView.o obj/StretchBox.o obj/StretchCircle.o obj/StretchLine.o obj/moc_rtimvGraphicsView.o obj/moc_StretchBox.o obj/moc_StretchCircle.o obj/moc_StretchLine.o  /usr/lib64/libQt6Widgets.so /usr/lib64/libQt6Gui.so /usr/lib64/libQt6Core.so -lpthread -lGLX -lOpenGL
/usr/bin/ld: obj/moc_rtimvGraphicsView.o: relocation R_X86_64_32 against symbol `_ZN17rtimvGraphicsView16staticMetaObjectE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[1]: *** [makefile.librtimv:168: bin/librtimv.so.1.0.0] Error 1
```