### PR TITLE
Handle ImagePlease shutdown synchronization in rtimvClientBase

### DIFF
--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -46,7 +46,13 @@ rtimvClientBase::~rtimvClientBase()
 
     {
         std::unique_lock<std::mutex> lock( m_imageRequestMutex );
-        m_imageRequestCv.wait( lock, [this] { return !m_imageRequestPending; } );
+        while( m_imageRequestPending )
+        {
+            if( m_imageRequestCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
+            {
+                std::cerr << "rtimvClient: waiting for ImagePlease callback during shutdown.\n";
+            }
+        }
     }
 
     if( m_configReq )
@@ -501,8 +507,6 @@ void rtimvClientBase::Configure()
     }
 }
 
-using namespace std::chrono_literals;
-
 void rtimvClientBase::ImagePlease()
 {
     updateAge();
@@ -530,6 +534,7 @@ void rtimvClientBase::ImagePlease()
     }
 
     m_ImagePleaseContext = new grpc::ClientContext;
+    m_ImagePleaseContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 2000 ) );
 
     // The actual RPC.
     stub_->async()->ImagePlease( m_ImagePleaseContext,

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -34,6 +34,21 @@ rtimvClientBase::rtimvClientBase()
 
 rtimvClientBase::~rtimvClientBase()
 {
+    {
+        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
+        m_shuttingDown = true;
+
+        if( m_ImagePleaseContext )
+        {
+            m_ImagePleaseContext->TryCancel();
+        }
+    }
+
+    {
+        std::unique_lock<std::mutex> lock( m_imageRequestMutex );
+        m_imageRequestCv.wait( lock, [this] { return !m_imageRequestPending; } );
+    }
+
     if( m_configReq )
     {
         delete m_configReq;
@@ -496,6 +511,11 @@ void rtimvClientBase::ImagePlease()
 
     std::lock_guard<std::mutex> lock( m_imageRequestMutex );
 
+    if( m_shuttingDown )
+    {
+        return;
+    }
+
     if( m_imageRequestPending )
     {
 
@@ -522,6 +542,14 @@ void rtimvClientBase::ImagePlease()
 
 void rtimvClientBase::ImageReceived()
 {
+    {
+        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
+        if( m_shuttingDown )
+        {
+            return;
+        }
+    }
+
     uint32_t nx, ny, nz;
     float fpsEst;
     double imageTime;
@@ -656,6 +684,7 @@ void rtimvClientBase::ImageReceived()
 void rtimvClientBase::ImagePlease_callback( grpc::Status status )
 {
     int action = -1;
+    bool shuttingDown = false;
 
     {
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
@@ -699,6 +728,14 @@ void rtimvClientBase::ImagePlease_callback( grpc::Status status )
         m_ImagePleaseContext = nullptr;
 
         m_imageRequestPending = false;
+        shuttingDown = m_shuttingDown;
+    }
+
+    m_imageRequestCv.notify_all();
+
+    if( shuttingDown )
+    {
+        return;
     }
 
     if( action == 0 )

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -29,7 +29,7 @@
 rtimvClientBase::rtimvClientBase()
 {
     m_foundation = new rtimvBaseObject( this, nullptr );
-    m_foundation->m_connectionTimer.start(1000);
+    m_foundation->m_connectionTimer.start( 1000 );
 }
 
 rtimvClientBase::~rtimvClientBase()
@@ -443,9 +443,9 @@ bool rtimvClientBase::connected()
 
 void rtimvClientBase::reconnect()
 {
-    sharedLockT lock(m_connectedMutex);
+    sharedLockT lock( m_connectedMutex );
 
-    if(m_connected)
+    if( m_connected )
     {
         return;
     }
@@ -457,7 +457,7 @@ void rtimvClientBase::reconnect()
     lock.lock();
 
     // start getting images again
-    if(m_connected)
+    if( m_connected )
     {
         m_foundation->emit_ImageNeeded();
     }
@@ -493,7 +493,7 @@ void rtimvClientBase::Configure()
     else
     {
         m_connected = false;
-        if(!m_connectionFailReported)
+        if( !m_connectionFailReported )
         {
             std::cerr << "rtimvClient: " << status.error_message() << std::endl;
             m_connectionFailReported = true;

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -144,6 +144,10 @@ public:
   protected:
     std::mutex m_imageRequestMutex;
 
+    std::condition_variable m_imageRequestCv;
+
+    bool m_shuttingDown{ false };
+
     bool m_imageRequestPending{ false };
 
     remote_rtimv::ImageRequest m_grpcImageRequest;

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -96,14 +96,16 @@ class rtimvClientBase : public mx::app::application
      */
 
   protected:
-    /// Flag used to indicate that the client is connected to the server.  Setting to false triggers an attempt to reconnect.
+    /// Flag used to indicate that the client is connected to the server.  Setting to false triggers an attempt to
+    /// reconnect.
     bool m_connected{ false };
 
-    /// Counter to track connection attemps.  Used to prevent threads from re-requesting re-connections for the same event.
-    uint64_t m_connections {0};
+    /// Counter to track connection attemps.  Used to prevent threads from re-requesting re-connections for the same
+    /// event.
+    uint64_t m_connections{ 0 };
 
     /// Flag to prevent repeating connection failure reports.
-    bool m_connectionFailReported {false};
+    bool m_connectionFailReported{ false };
 
     std::shared_mutex m_connectedMutex;
 
@@ -124,34 +126,40 @@ class rtimvClientBase : public mx::app::application
      */
     bool connected();
 
-public slots:
+  public slots:
 
     void reconnect();
 
-protected:
+  protected:
     /// Context for the ImagePlease rpc.
     /** This has to stay alive until the rpc finishes and can not be reused
      *
      */
     grpc::ClientContext *m_ImagePleaseContext{ nullptr };
 
-public:
+  public:
     /// Configure the server
     /**
      */
     void Configure();
 
   protected:
+    /// Mutex guarding asynchronous image request state.
     std::mutex m_imageRequestMutex;
 
+    /// Condition variable used to signal completion of pending image requests.
     std::condition_variable m_imageRequestCv;
 
+    /// Flag indicating client teardown is in progress.
     bool m_shuttingDown{ false };
 
+    /// True while an ImagePlease RPC is outstanding.
     bool m_imageRequestPending{ false };
 
+    /// Request payload for the ImagePlease RPC.
     remote_rtimv::ImageRequest m_grpcImageRequest;
 
+    /// Last ImagePlease response payload from the server.
     remote_rtimv::Image m_grpcImage;
 
   public:
@@ -692,7 +700,7 @@ public:
     /**
      * The cal mutex must be unlocked before calling
      */
-    void mtxUL_autoScale(bool as /**< [in] the new value of the auto scale flag */);
+    void mtxUL_autoScale( bool as /**< [in] the new value of the auto scale flag */ );
 
     /// Get the auto scale flag value
     /**


### PR DESCRIPTION
Work was done by GPT-5.3-Codex, verified by running rtimvClient with xrif2hmim running.

## Summary
- add shutdown-aware cancellation/synchronization for outstanding `ImagePlease` RPCs
- prevent new image requests while shutdown is in progress
- notify/wait on request completion to avoid teardown races
- add Doxygen docs for image-request synchronization members
- run `clang-format` on touched client base files

## Commits
- `02ac174` Handle ImagePlease shutdown cancellation and synchronization
- `fc9d6b5` Add ImagePlease member docs and run clang-format

## Validation
- built successfully in `_build` with `make -j$(nproc)`

## Update
Added a follow-up hardening change for shutdown behavior:

- set an explicit deadline on `ImagePlease` RPC requests (`2000 ms`)
- switched destructor wait to timed `wait_for` loop with periodic logging, while still waiting for callback completion to preserve safety

## Validation
- local build succeeded in `_build` with `make -j$(nproc)`
- manual runtime test: repeated `rtimvClient` connect/shutdown cycles against `rtimvServer` completed cleanly
