### PR TITLE
Refactor control panel docs/member naming and remove direct mutex dependency

### DIFF
--- a/agent_context.md
+++ b/agent_context.md
@@ -1,0 +1,56 @@
+Follow these code style and documentation rules exactly.
+
+1) File-Level Documentation
+- Each header/source should have a top Doxygen file block:
+  - \file
+  - \brief
+  - \author (if project uses it)
+
+2) Include Guards and Includes
+- Match existing project include-guard naming convention.
+- Keep include ordering consistent with project style.
+- Do not introduce new include style unless project already uses it.
+
+3) Function Declaration Documentation
+- Every function declaration must have a brief `///` summary.
+- Add a short `/** ... */` details block only when needed.
+- Document every parameter inline at declaration site using:
+  - `type name /**< [in] description */`
+- Apply to normal methods, constructors, slots, and signals.
+- Keep return-value docs where project uses them.
+
+4) Member Variable Documentation
+- Document non-trivial class members with `///`.
+- Describe role/ownership/state, not just type.
+
+5) Naming and Structure
+- Use project member naming convention (e.g. `m_` prefix).
+- Keep declaration ordering/grouping stable:
+  - public/protected/private
+  - slots/signals grouped consistently.
+- Leave a blank line between declarations for readability.
+
+6) Mutex/Locking API Convention
+- `mtxL_*` functions require lock already held by caller.
+- `mtxUL_*` functions acquire lock internally then call `mtxL_*`.
+- Prefer calling `mtxUL_*` from UI/controller code.
+- Avoid passing mutex pointers through UI classes unless unavoidable.
+
+7) Header vs Source Placement
+- Keep non-trivial definitions out of headers.
+- Move implementations to `.cpp` unless intentionally inline.
+
+8) Editing Discipline
+- Preserve existing behavior unless explicitly requested.
+- When renaming members/APIs, update all dependent call sites.
+- Keep changes minimal and scoped.
+
+9) Formatting and Verification
+- Run `clang-format` on touched files.
+- Ensure docs and naming are consistent after formatting.
+- Report any places where project style is ambiguous before making assumptions.
+
+When you finish:
+- Summarize what changed.
+- List affected files.
+- Note any follow-up items or potential edge cases.

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -1,5 +1,9 @@
 #include "rtimvControlPanel.hpp"
 
+rtimvControlPanel::rtimvControlPanel()
+{
+}
+
 rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, std::shared_mutex *calMutex, Qt::WindowFlags f )
     : QWidget( 0, f )
 {
@@ -10,92 +14,91 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, std::shared_mutex *cal
         throw std::invalid_argument( "calMutex can't be null" );
     }
 
-    ui.setupUi( this );
-    imv = v;
+    m_ui.setupUi( this );
+    m_imv = v;
 
     setupMode();
     setupCombos();
-    ui.tabWidget->setCurrentIndex( 0 );
+    m_ui.tabWidget->setCurrentIndex( 0 );
 
-    qgs_view = new QGraphicsScene();
-    qgs_empty = new QGraphicsScene();
+    m_qgsView = new QGraphicsScene();
+    m_qgsEmpty = new QGraphicsScene();
 
-    ui.pointerView->setScene( qgs_empty );
-    PointerViewEmpty = true;
+    m_ui.pointerView->setScene( m_qgsEmpty );
+    m_pointerViewEmpty = true;
 
-    qpmi_view = qgs_view->addPixmap( *( v->getPixmap() ) );
+    m_qpmiView = m_qgsView->addPixmap( *( v->getPixmap() ) );
 
-    ui.viewView->setScene( qgs_view );
+    m_ui.viewView->setScene( m_qgsView );
 
-    viewLineVert = qgs_view->addLine( QLineF( .5 * imv->nx(), 0, .5 * imv->nx(), imv->ny() ), QColor( "lime" ) );
-    viewLineHorz = qgs_view->addLine( QLineF( 0, .5 * imv->ny(), imv->nx(), .5 * imv->ny() ), QColor( "lime" ) );
-    // viewBox = qgs_view->addRect(QRectF(0,0, imv->get_nx(), imv->get_ny()), QColor("lime"));
-    viewBox = new StretchBox( 0, 0, imv->nx(), imv->ny() );
-    viewBox->setPen( QPen( "lime" ) );
-    viewBox->setFlag( QGraphicsItem::ItemIsSelectable, true );
-    viewBox->setFlag( QGraphicsItem::ItemIsMovable, true );
-    viewBox->setStretchable( false );
-    viewBox->setEdgeTol( imv->nx() ); // 5.*imv->nx()/ui.viewView->width() < 5 ? 5 : 5.*imv->nx()/ui.viewView->width()
-                                      // );
-    qgs_view->addItem( viewBox );
+    m_viewLineVert =
+        m_qgsView->addLine( QLineF( .5 * m_imv->nx(), 0, .5 * m_imv->nx(), m_imv->ny() ), QColor( "lime" ) );
+    m_viewLineHorz =
+        m_qgsView->addLine( QLineF( 0, .5 * m_imv->ny(), m_imv->nx(), .5 * m_imv->ny() ), QColor( "lime" ) );
+    m_viewBox = new StretchBox( 0, 0, m_imv->nx(), m_imv->ny() );
+    m_viewBox->setPen( QPen( "lime" ) );
+    m_viewBox->setFlag( QGraphicsItem::ItemIsSelectable, true );
+    m_viewBox->setFlag( QGraphicsItem::ItemIsMovable, true );
+    m_viewBox->setStretchable( false );
+    m_viewBox->setEdgeTol(
+        m_imv->nx() );
+    m_qgsView->addItem( m_viewBox );
 
-    double viewZoom = (double)ui.viewView->width() / (double)imv->nx();
-    ui.viewView->scale( viewZoom, viewZoom );
+    double viewZoom = (double)m_ui.viewView->width() / (double)m_imv->nx();
+    m_ui.viewView->scale( viewZoom, viewZoom );
 
-    PointerViewFixed = false;
-    PointerViewWaiting = false;
+    m_pointerViewFixed = false;
+    m_pointerViewWaiting = false;
 
-    connect( imv, SIGNAL( showToolTipCoordsChanged( bool ) ), this, SLOT( showToolTipCoordsChanged( bool ) ) );
-    connect( this, SIGNAL( showToolTipCoords( bool ) ), imv, SLOT( showToolTipCoords( bool ) ) );
-    connect( imv, SIGNAL( showStaticCoordsChanged( bool ) ), this, SLOT( showStaticCoordsChanged( bool ) ) );
-    connect( this, SIGNAL( showStaticCoords( bool ) ), imv, SLOT( showStaticCoords( bool ) ) );
+    connect( m_imv, SIGNAL( showToolTipCoordsChanged( bool ) ), this, SLOT( showToolTipCoordsChanged( bool ) ) );
+    connect( this, SIGNAL( showToolTipCoords( bool ) ), m_imv, SLOT( showToolTipCoords( bool ) ) );
+    connect( m_imv, SIGNAL( showStaticCoordsChanged( bool ) ), this, SLOT( showStaticCoordsChanged( bool ) ) );
+    connect( this, SIGNAL( showStaticCoords( bool ) ), m_imv, SLOT( showStaticCoords( bool ) ) );
 
-    connect( imv, SIGNAL( targetXcChanged( float ) ), this, SLOT( targetXcChanged( float ) ) );
-    connect( imv, SIGNAL( targetYcChanged( float ) ), this, SLOT( targetYcChanged( float ) ) );
-    connect( imv, SIGNAL( targetVisibleChanged( bool ) ), this, SLOT( targetVisibleChanged( bool ) ) );
+    connect( m_imv, SIGNAL( targetXcChanged( float ) ), this, SLOT( targetXcChanged( float ) ) );
+    connect( m_imv, SIGNAL( targetYcChanged( float ) ), this, SLOT( targetYcChanged( float ) ) );
+    connect( m_imv, SIGNAL( targetVisibleChanged( bool ) ), this, SLOT( targetVisibleChanged( bool ) ) );
 
-    connect( this, SIGNAL( targetXc( float ) ), imv, SLOT( targetXc( float ) ) );
-    connect( this, SIGNAL( targetYc( float ) ), imv, SLOT( targetYc( float ) ) );
-    connect( this, SIGNAL( targetVisible( bool ) ), imv, SLOT( targetVisible( bool ) ) );
+    connect( this, SIGNAL( targetXc( float ) ), m_imv, SLOT( targetXc( float ) ) );
+    connect( this, SIGNAL( targetYc( float ) ), m_imv, SLOT( targetYc( float ) ) );
+    connect( this, SIGNAL( targetVisible( bool ) ), m_imv, SLOT( targetVisible( bool ) ) );
 
     init_panel();
 
-    // connect(viewBox, SIGNAL(moved(const QRectF & )), this, SLOT(viewBoxMoved(const QRectF &)));
-
-    statsBoxButtonState = false;
+    m_statsBoxButtonState = false;
 }
 
 void rtimvControlPanel::setupMode()
 {
-    ViewViewMode = ViewViewNoImage;       // ViewViewEnabled;
-    PointerViewMode = PointerViewOnPress; // PointerViewEnabled;
+    m_viewViewMode = ViewViewNoImage;       // ViewViewEnabled;
+    m_pointerViewMode = PointerViewOnPress; // PointerViewEnabled;
 }
 
 void rtimvControlPanel::setupCombos()
 {
-    ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::minmaxglobal ), "Min/Max Global" );
-    ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::minmaxbox ), "Min/Max Box" );
-    ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::user ), "User" );
-    ui.scaleModeCombo->setCurrentIndex( static_cast<int>( rtimv::colormode::user ) );
+    m_ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::minmaxglobal ), "Min/Max Global" );
+    m_ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::minmaxbox ), "Min/Max Box" );
+    m_ui.scaleModeCombo->insertItem( static_cast<int>( rtimv::colormode::user ), "User" );
+    m_ui.scaleModeCombo->setCurrentIndex( static_cast<int>( rtimv::colormode::user ) );
 
-    ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::linear ), "Linear" );
-    ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::log ), "Log" );
-    ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::pow ), "Power" );
-    ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::sqrt ), "Square Root" );
-    ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::square ), "Squared" );
+    m_ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::linear ), "Linear" );
+    m_ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::log ), "Log" );
+    m_ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::pow ), "Power" );
+    m_ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::sqrt ), "Square Root" );
+    m_ui.scaleTypeCombo->insertItem( static_cast<int>( rtimv::stretch::square ), "Squared" );
 
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::grey ), "Grey" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::jet ), "Jet" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::hot ), "Hot" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::bone ), "Bone" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::red ), "Red" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::green ), "Green" );
-    ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::blue ), "Blue" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::grey ), "Grey" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::jet ), "Jet" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::hot ), "Hot" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::bone ), "Bone" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::red ), "Red" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::green ), "Green" );
+    m_ui.colorbarCombo->insertItem( static_cast<int>( rtimv::colorbar::blue ), "Blue" );
 
-    ui.pointerViewModecomboBox->insertItem( PointerViewEnabled, "Enabled" );
-    ui.pointerViewModecomboBox->insertItem( PointerViewOnPress, "On mouse press" );
-    ui.pointerViewModecomboBox->insertItem( PointerViewDisabled, "Disabled" );
-    ui.pointerViewModecomboBox->setCurrentIndex( PointerViewOnPress );
+    m_ui.pointerViewModecomboBox->insertItem( PointerViewEnabled, "Enabled" );
+    m_ui.pointerViewModecomboBox->insertItem( PointerViewOnPress, "On mouse press" );
+    m_ui.pointerViewModecomboBox->insertItem( PointerViewDisabled, "Disabled" );
+    m_ui.pointerViewModecomboBox->setCurrentIndex( PointerViewOnPress );
 }
 
 void rtimvControlPanel::init_panel()
@@ -104,14 +107,14 @@ void rtimvControlPanel::init_panel()
     update_panel();
 
     // initialize the button state for coordinate displays
-    showToolTipCoordsChanged( imv->showToolTipCoords() );
-    showStaticCoordsChanged( imv->showStaticCoords() );
+    showToolTipCoordsChanged( m_imv->showToolTipCoords() );
+    showStaticCoordsChanged( m_imv->showStaticCoords() );
 
-    targetXcChanged( imv->targetXc() );
-    targetYcChanged( imv->targetYc() );
-    targetVisibleChanged( imv->targetVisible() );
+    targetXcChanged( m_imv->targetXc() );
+    targetYcChanged( m_imv->targetYc() );
+    targetVisibleChanged( m_imv->targetVisible() );
 
-    ui.imtimerspinBox->setValue( imv->imageTimeout() );
+    m_ui.imtimerspinBox->setValue( m_imv->imageTimeout() );
 }
 
 void rtimvControlPanel::update_panel()
@@ -135,122 +138,122 @@ void rtimvControlPanel::update_panel()
 
     update_contrastSlider();
 
-    ui.scaleTypeCombo->blockSignals( true );
-    ui.scaleTypeCombo->setCurrentIndex( static_cast<int>( imv->stretch() ) );
-    ui.scaleTypeCombo->blockSignals( false );
+    m_ui.scaleTypeCombo->blockSignals( true );
+    m_ui.scaleTypeCombo->setCurrentIndex( static_cast<int>( m_imv->stretch() ) );
+    m_ui.scaleTypeCombo->blockSignals( false );
 
-    ui.scaleModeCombo->blockSignals( true );
-    ui.scaleModeCombo->setCurrentIndex( static_cast<int>( imv->colormode() ) );
-    ui.scaleModeCombo->blockSignals( false );
+    m_ui.scaleModeCombo->blockSignals( true );
+    m_ui.scaleModeCombo->setCurrentIndex( static_cast<int>( m_imv->colormode() ) );
+    m_ui.scaleModeCombo->blockSignals( false );
 
-    ui.colorbarCombo->blockSignals( true );
-    ui.colorbarCombo->setCurrentIndex( static_cast<int>( imv->colorbar() ) );
-    ui.colorbarCombo->blockSignals( false );
+    m_ui.colorbarCombo->blockSignals( true );
+    m_ui.colorbarCombo->setCurrentIndex( static_cast<int>( m_imv->colorbar() ) );
+    m_ui.colorbarCombo->blockSignals( false );
 }
 
 void rtimvControlPanel::update_ZoomSlider()
 {
-    ui.ZoomSlider->blockSignals( true );
-    ui.ZoomSlider->setSliderPosition(
-        (int)( ( imv->zoomLevel() - imv->zoomLevelMin() ) / ( imv->zoomLevelMax() - imv->zoomLevelMin() ) *
-                   ( ui.ZoomSlider->maximum() - ui.ZoomSlider->minimum() ) +
+    m_ui.ZoomSlider->blockSignals( true );
+    m_ui.ZoomSlider->setSliderPosition(
+        (int)( ( m_imv->zoomLevel() - m_imv->zoomLevelMin() ) / ( m_imv->zoomLevelMax() - m_imv->zoomLevelMin() ) *
+                   ( m_ui.ZoomSlider->maximum() - m_ui.ZoomSlider->minimum() ) +
                .5 ) );
-    ui.ZoomSlider->blockSignals( false );
+    m_ui.ZoomSlider->blockSignals( false );
 }
 
 void rtimvControlPanel::update_ZoomEntry()
 {
     char newz[10];
-    sprintf( newz, "%4.2f", imv->zoomLevel() );
+    sprintf( newz, "%4.2f", m_imv->zoomLevel() );
 
-    ui.ZoomEntry->blockSignals( true );
-    ui.ZoomEntry->setText( newz );
-    ui.ZoomEntry->blockSignals( false );
+    m_ui.ZoomEntry->blockSignals( true );
+    m_ui.ZoomEntry->setText( newz );
+    m_ui.ZoomEntry->blockSignals( false );
 }
 
 void rtimvControlPanel::on_ZoomSlider_valueChanged( int value )
 {
     double zl;
-    zl = imv->zoomLevelMin() +
-         ( (double)value / ( (double)ui.ZoomSlider->maximum() - (double)ui.ZoomSlider->minimum() ) ) *
-             ( imv->zoomLevelMax() - imv->zoomLevelMin() );
-    imv->zoomLevel( zl );
+    zl = m_imv->zoomLevelMin() +
+         ( (double)value / ( (double)m_ui.ZoomSlider->maximum() - (double)m_ui.ZoomSlider->minimum() ) ) *
+             ( m_imv->zoomLevelMax() - m_imv->zoomLevelMin() );
+    m_imv->zoomLevel( zl );
 
     update_ZoomEntry();
 }
 
 void rtimvControlPanel::on_Zoom1_clicked()
 {
-    imv->zoomLevel( 1.0 );
+    m_imv->zoomLevel( 1.0 );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_Zoom2_clicked()
 {
-    imv->zoomLevel( 2.0 );
+    m_imv->zoomLevel( 2.0 );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_Zoom4_clicked()
 {
-    imv->zoomLevel( 4.0 );
+    m_imv->zoomLevel( 4.0 );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_Zoom8_clicked()
 {
-    imv->zoomLevel( 8.0 );
+    m_imv->zoomLevel( 8.0 );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_Zoom16_clicked()
 {
-    imv->zoomLevel( 16.0 );
+    m_imv->zoomLevel( 16.0 );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_ZoomEntry_editingFinished()
 {
-    imv->zoomLevel( ui.ZoomEntry->text().toDouble() );
+    m_imv->zoomLevel( m_ui.ZoomEntry->text().toDouble() );
     update_ZoomSlider();
 }
 
 void rtimvControlPanel::on_overZoom1_clicked()
 {
-    imv->setPointerOverZoom( 1.0 );
+    m_imv->setPointerOverZoom( 1.0 );
 }
 
 void rtimvControlPanel::on_overZoom2_clicked()
 {
-    imv->setPointerOverZoom( 2.0 );
+    m_imv->setPointerOverZoom( 2.0 );
 }
 
 void rtimvControlPanel::on_overZoom4_clicked()
 {
-    imv->setPointerOverZoom( 4.0 );
+    m_imv->setPointerOverZoom( 4.0 );
 }
 
 void rtimvControlPanel::set_ViewViewMode( int vvm )
 {
     if( vvm < 0 || vvm >= ViewViewModeMax )
     {
-        ViewViewMode = ViewViewEnabled;
+        m_viewViewMode = ViewViewEnabled;
     }
     else
-        ViewViewMode = vvm;
+        m_viewViewMode = vvm;
 
-    if( ViewViewMode == ViewViewEnabled )
+    if( m_viewViewMode == ViewViewEnabled )
     {
-        qpmi_view = qgs_view->addPixmap( *( imv->getPixmap() ) );
-        viewBox->setEdgeTol( 5. * imv->nx() / qgs_view->width() );
+        m_qpmiView = m_qgsView->addPixmap( *( m_imv->getPixmap() ) );
+        m_viewBox->setEdgeTol( 5. * m_imv->nx() / m_qgsView->width() );
 
-        qpmi_view->stackBefore( viewLineVert );
+        m_qpmiView->stackBefore( m_viewLineVert );
     }
-    if( ViewViewMode == ViewViewNoImage && qpmi_view )
+    if( m_viewViewMode == ViewViewNoImage && m_qpmiView )
     {
-        qgs_view->removeItem( qpmi_view );
-        delete qpmi_view;
-        qpmi_view = 0;
+        m_qgsView->removeItem( m_qpmiView );
+        delete m_qpmiView;
+        m_qpmiView = 0;
     }
 }
 
@@ -258,43 +261,43 @@ void ::rtimvControlPanel::update_xycenEntry()
 {
     char tmps[10];
 
-    if( !ui.xcenEntry->hasFocus() )
+    if( !m_ui.xcenEntry->hasFocus() )
     {
-        snprintf( tmps, 10, "%.1f", imv->get_xcen() );
+        snprintf( tmps, 10, "%.1f", m_imv->get_xcen() );
 
-        ui.xcenEntry->blockSignals( true );
-        ui.xcenEntry->setText( tmps );
-        ui.xcenEntry->blockSignals( false );
+        m_ui.xcenEntry->blockSignals( true );
+        m_ui.xcenEntry->setText( tmps );
+        m_ui.xcenEntry->blockSignals( false );
     }
-    if( !ui.ycenEntry->hasFocus() )
+    if( !m_ui.ycenEntry->hasFocus() )
     {
-        snprintf( tmps, 10, "%.1f", imv->get_ycen() );
+        snprintf( tmps, 10, "%.1f", m_imv->get_ycen() );
 
-        ui.ycenEntry->blockSignals( true );
-        ui.ycenEntry->setText( tmps );
-        ui.ycenEntry->blockSignals( false );
+        m_ui.ycenEntry->blockSignals( true );
+        m_ui.ycenEntry->setText( tmps );
+        m_ui.ycenEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_whEntry()
 {
     char tmps[10];
-    if( !ui.widthEntry->hasFocus() )
+    if( !m_ui.widthEntry->hasFocus() )
     {
-        snprintf( tmps, 10, "%.1f", ( (double)imv->nx() ) / imv->zoomLevel() );
+        snprintf( tmps, 10, "%.1f", ( (double)m_imv->nx() ) / m_imv->zoomLevel() );
 
-        ui.widthEntry->blockSignals( true );
-        ui.widthEntry->setText( tmps );
-        ui.widthEntry->blockSignals( false );
+        m_ui.widthEntry->blockSignals( true );
+        m_ui.widthEntry->setText( tmps );
+        m_ui.widthEntry->blockSignals( false );
     }
 
-    if( !ui.heightEntry->hasFocus() )
+    if( !m_ui.heightEntry->hasFocus() )
     {
-        snprintf( tmps, 10, "%.1f", ( (double)imv->ny() ) / imv->zoomLevel() );
+        snprintf( tmps, 10, "%.1f", ( (double)m_imv->ny() ) / m_imv->zoomLevel() );
 
-        ui.heightEntry->blockSignals( true );
-        ui.heightEntry->setText( tmps );
-        ui.heightEntry->blockSignals( false );
+        m_ui.heightEntry->blockSignals( true );
+        m_ui.heightEntry->setText( tmps );
+        m_ui.heightEntry->blockSignals( false );
     }
 }
 
@@ -314,145 +317,148 @@ void rtimvControlPanel::enableViewViewMode( int state )
 void rtimvControlPanel::on_xcenEntry_editingFinished()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( ui.xcenEntry->text().toDouble() / imv->nx(), imv->get_ycen(), lock );
-    ;
+    m_imv->mtxL_setViewCen( m_ui.xcenEntry->text().toDouble() / m_imv->nx(), m_imv->get_ycen(), lock );
 }
 
 void rtimvControlPanel::on_ycenEntry_editingFinished()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen(), ui.ycenEntry->text().toDouble() / imv->ny(), lock );
+    m_imv->mtxL_setViewCen( m_imv->get_xcen(), m_ui.ycenEntry->text().toDouble() / m_imv->ny(), lock );
 }
 
 void rtimvControlPanel::on_widthEntry_editingFinished()
 {
     double newzoom;
-    newzoom = ( (double)imv->nx() ) / ui.widthEntry->text().toDouble();
-    imv->zoomLevel( newzoom );
+    newzoom = ( (double)m_imv->nx() ) / m_ui.widthEntry->text().toDouble();
+    m_imv->zoomLevel( newzoom );
     update_panel();
 }
 
 void rtimvControlPanel::on_heightEntry_editingFinished()
 {
     double newzoom;
-    newzoom = ( (double)imv->ny() ) / ui.heightEntry->text().toDouble();
-    imv->zoomLevel( newzoom );
+    newzoom = ( (double)m_imv->ny() ) / m_ui.heightEntry->text().toDouble();
+    m_imv->zoomLevel( newzoom );
     update_panel();
 }
 
 void rtimvControlPanel::on_view_center_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( .5, .5, lock );
+    m_imv->mtxL_setViewCen( .5, .5, lock );
 }
 
 void rtimvControlPanel::on_view_ul_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() - 1. / imv->zoomLevel(),
-                          imv->get_ycen() / imv->ny() - 1. / imv->zoomLevel(),
-                          lock );
+    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
+                            m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(),
+                            lock );
 }
 
 void rtimvControlPanel::on_view_up_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx(), imv->get_ycen() / imv->ny() - 1. / imv->zoomLevel(), lock );
+    m_imv->mtxL_setViewCen(
+        m_imv->get_xcen() / m_imv->nx(), m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(), lock );
 }
 
 void rtimvControlPanel::on_view_ur_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() + 1. / imv->zoomLevel(),
-                          imv->get_ycen() / imv->ny() - 1. / imv->zoomLevel(),
-                          lock );
+    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
+                            m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(),
+                            lock );
 }
 
 void rtimvControlPanel::on_view_right_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() + 1. / imv->zoomLevel(), imv->get_ycen() / imv->ny(), lock );
+    m_imv->mtxL_setViewCen(
+        m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(), m_imv->get_ycen() / m_imv->ny(), lock );
 }
 
 void rtimvControlPanel::on_view_dr_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() + 1. / imv->zoomLevel(),
-                          imv->get_ycen() / imv->ny() + 1. / imv->zoomLevel(),
-                          lock );
+    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
+                            m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(),
+                            lock );
 }
 
 void rtimvControlPanel::on_view_down_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx(), imv->get_ycen() / imv->ny() + 1. / imv->zoomLevel(), lock );
+    m_imv->mtxL_setViewCen(
+        m_imv->get_xcen() / m_imv->nx(), m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(), lock );
 }
 
 void rtimvControlPanel::on_view_dl_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() - 1. / imv->zoomLevel(),
-                          imv->get_ycen() / imv->ny() + 1. / imv->zoomLevel(),
-                          lock );
+    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
+                            m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(),
+                            lock );
 }
 
 void rtimvControlPanel::on_view_left_clicked()
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( imv->get_xcen() / imv->nx() - 1. / imv->zoomLevel(), imv->get_ycen() / imv->ny(), lock );
+    m_imv->mtxL_setViewCen(
+        m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(), m_imv->get_ycen() / m_imv->ny(), lock );
 }
 
 void rtimvControlPanel::updateMouseCoords( double x, double y, double v )
 {
-    if( !PointerViewFixed )
+    if( !m_pointerViewFixed )
     {
         char tmpr[15];
         sprintf( tmpr, "%8.2f", x );
 
-        ui.TextCoordX->blockSignals( true );
-        ui.TextCoordX->setText( tmpr );
-        ui.TextCoordX->blockSignals( false );
+        m_ui.TextCoordX->blockSignals( true );
+        m_ui.TextCoordX->setText( tmpr );
+        m_ui.TextCoordX->blockSignals( false );
 
         sprintf( tmpr, "%8.2f", y );
 
-        ui.TextCoordY->blockSignals( true );
-        ui.TextCoordY->setText( tmpr );
-        ui.TextCoordY->blockSignals( false );
+        m_ui.TextCoordY->blockSignals( true );
+        m_ui.TextCoordY->setText( tmpr );
+        m_ui.TextCoordY->blockSignals( false );
 
         sprintf( tmpr, "%8.2f", v );
 
-        ui.TextPixelVal->blockSignals( true );
-        ui.TextPixelVal->setText( tmpr );
-        ui.TextPixelVal->blockSignals( false );
+        m_ui.TextPixelVal->blockSignals( true );
+        m_ui.TextPixelVal->setText( tmpr );
+        m_ui.TextPixelVal->blockSignals( false );
 
-        if( PointerViewEmpty && PointerViewMode == PointerViewEnabled )
+        if( m_pointerViewEmpty && m_pointerViewMode == PointerViewEnabled )
         {
-            ui.pointerView->setScene( imv->get_qgs() );
-            PointerViewEmpty = false;
+            m_ui.pointerView->setScene( m_imv->get_qgs() );
+            m_pointerViewEmpty = false;
         }
 
-        ui.pointerView->centerOn( x, y );
+        m_ui.pointerView->centerOn( x, y );
     }
 }
 
 void rtimvControlPanel::nullMouseCoords()
 {
-    if( !PointerViewFixed )
+    if( !m_pointerViewFixed )
     {
-        ui.pointerView->setScene( qgs_empty );
-        PointerViewEmpty = true;
+        m_ui.pointerView->setScene( m_qgsEmpty );
+        m_pointerViewEmpty = true;
 
-        ui.TextCoordX->blockSignals( true );
-        ui.TextCoordX->setText( "" );
-        ui.TextCoordX->blockSignals( false );
+        m_ui.TextCoordX->blockSignals( true );
+        m_ui.TextCoordX->setText( "" );
+        m_ui.TextCoordX->blockSignals( false );
 
-        ui.TextCoordY->blockSignals( true );
-        ui.TextCoordY->setText( "" );
-        ui.TextCoordY->blockSignals( false );
+        m_ui.TextCoordY->blockSignals( true );
+        m_ui.TextCoordY->setText( "" );
+        m_ui.TextCoordY->blockSignals( false );
 
-        ui.TextPixelVal->blockSignals( true );
-        ui.TextPixelVal->setText( "" );
-        ui.TextPixelVal->blockSignals( false );
+        m_ui.TextPixelVal->blockSignals( true );
+        m_ui.TextPixelVal->setText( "" );
+        m_ui.TextPixelVal->blockSignals( false );
     }
 }
 
@@ -460,25 +466,25 @@ void rtimvControlPanel::viewLeftPressed( QPointF mp )
 {
     static_cast<void>( mp );
 
-    if( PointerViewMode == PointerViewOnPress )
+    if( m_pointerViewMode == PointerViewOnPress )
     {
-        ui.pointerView->setScene( imv->get_qgs() );
-        PointerViewEmpty = false;
-        if( PointerViewFixed )
+        m_ui.pointerView->setScene( m_imv->get_qgs() );
+        m_pointerViewEmpty = false;
+        if( m_pointerViewFixed )
         {
-            ui.pointerView->centerOn( pointerViewCen.x(), pointerViewCen.y() );
+            m_ui.pointerView->centerOn( m_pointerViewCen.x(), m_pointerViewCen.y() );
         }
     }
 }
 
 void rtimvControlPanel::viewLeftClicked( QPointF mp )
 {
-    if( PointerViewMode == PointerViewOnPress )
+    if( m_pointerViewMode == PointerViewOnPress )
     {
-        ui.pointerView->setScene( qgs_empty );
-        PointerViewEmpty = true;
+        m_ui.pointerView->setScene( m_qgsEmpty );
+        m_pointerViewEmpty = true;
     }
-    if( PointerViewWaiting )
+    if( m_pointerViewWaiting )
     {
         set_pointerViewCen( mp );
     }
@@ -488,21 +494,21 @@ void rtimvControlPanel::set_PointerViewMode( int pvm )
 {
     if( pvm < 0 || pvm >= PointerViewModeMax || pvm == PointerViewEnabled )
     {
-        PointerViewMode = PointerViewEnabled;
-        ui.pointerView->setScene( imv->get_qgs() );
-        PointerViewEmpty = false;
+        m_pointerViewMode = PointerViewEnabled;
+        m_ui.pointerView->setScene( m_imv->get_qgs() );
+        m_pointerViewEmpty = false;
     }
     if( pvm == PointerViewOnPress )
     {
-        PointerViewMode = PointerViewOnPress;
-        ui.pointerView->setScene( qgs_empty );
-        PointerViewEmpty = true;
+        m_pointerViewMode = PointerViewOnPress;
+        m_ui.pointerView->setScene( m_qgsEmpty );
+        m_pointerViewEmpty = true;
     }
     if( pvm == PointerViewDisabled )
     {
-        PointerViewMode = PointerViewDisabled;
-        ui.pointerView->setScene( qgs_empty );
-        PointerViewEmpty = true;
+        m_pointerViewMode = PointerViewDisabled;
+        m_ui.pointerView->setScene( m_qgsEmpty );
+        m_pointerViewEmpty = true;
     }
 }
 
@@ -513,16 +519,16 @@ void rtimvControlPanel::on_pointerViewModecomboBox_activated( int pvm )
 
 void rtimvControlPanel::on_pointerSetLocButton_clicked()
 {
-    if( !PointerViewFixed )
+    if( !m_pointerViewFixed )
     {
-        PointerViewWaiting = true;
-        ui.pointerSetLocButton->setText( "Waiting" );
+        m_pointerViewWaiting = true;
+        m_ui.pointerSetLocButton->setText( "Waiting" );
     }
     else
     {
-        ui.pointerSetLocButton->setText( "Set Location" );
-        PointerViewWaiting = false;
-        PointerViewFixed = false;
+        m_ui.pointerSetLocButton->setText( "Set Location" );
+        m_pointerViewWaiting = false;
+        m_pointerViewFixed = false;
     }
 }
 
@@ -530,80 +536,82 @@ void rtimvControlPanel::set_pointerViewCen( QPointF mp )
 {
     std::cerr << mp.x() << " " << mp.y() << "\n";
 
-    pointerViewCen = mp;
-    ui.pointerSetLocButton->setText( "Clear Location" );
-    PointerViewWaiting = false;
-    PointerViewFixed = true;
+    m_pointerViewCen = mp;
+    m_ui.pointerSetLocButton->setText( "Clear Location" );
+    m_pointerViewWaiting = false;
+    m_pointerViewFixed = true;
 }
 
 void rtimvControlPanel::on_scaleTypeCombo_activated( int ct )
 {
-    imv->stretch( static_cast<rtimv::stretch>( ct ) );
+    m_imv->stretch( static_cast<rtimv::stretch>( ct ) );
 
-    imv->mtxUL_recolor();
+    m_imv->mtxUL_recolor();
 }
 
 void rtimvControlPanel::on_colorbarCombo_activated( int cb )
 {
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_load_colorbar( static_cast<rtimv::colorbar>( cb ), true, lock );
+    m_imv->mtxL_load_colorbar( static_cast<rtimv::colorbar>( cb ), true, lock );
 }
 
 void rtimvControlPanel::update_mindatSlider()
 {
     int pos;
 
-    pos = (int)( ui.mindatSlider->minimum() +
-                 ( imv->minScaleData() - imv->minImageData() ) / ( imv->maxImageData() - imv->minImageData() ) *
-                     ( ui.mindatSlider->maximum() - ui.mindatSlider->minimum() ) +
+    pos = (int)( m_ui.mindatSlider->minimum() +
+                 ( m_imv->minScaleData() - m_imv->minImageData() ) / ( m_imv->maxImageData() - m_imv->minImageData() ) *
+                     ( m_ui.mindatSlider->maximum() - m_ui.mindatSlider->minimum() ) +
                  .5 );
 
-    ui.mindatSlider->blockSignals( true );
-    ui.mindatSlider->setSliderPosition( pos );
-    ui.mindatSlider->blockSignals( false );
+    m_ui.mindatSlider->blockSignals( true );
+    m_ui.mindatSlider->setSliderPosition( pos );
+    m_ui.mindatSlider->blockSignals( false );
 }
 
 void rtimvControlPanel::update_mindatEntry()
 {
     char tmps[15];
-    if( !ui.mindatEntry->hasFocus() )
+    if( !m_ui.mindatEntry->hasFocus() )
     {
-        sprintf( tmps, "%14.1f", imv->minScaleData() );
+        sprintf( tmps, "%14.1f", m_imv->minScaleData() );
 
-        ui.mindatEntry->blockSignals( true );
-        ui.mindatEntry->setText( tmps );
-        ui.mindatEntry->blockSignals( false );
+        m_ui.mindatEntry->blockSignals( true );
+        m_ui.mindatEntry->setText( tmps );
+        m_ui.mindatEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_mindatRelEntry()
 {
     char tmps[15];
-    if( !ui.mindatRelEntry->hasFocus() )
+    if( !m_ui.mindatRelEntry->hasFocus() )
     {
         sprintf( tmps,
                  "%5.3f",
-                 ( imv->minScaleData() - imv->minImageData() ) / ( imv->maxImageData() - imv->minImageData() ) );
+                 ( m_imv->minScaleData() - m_imv->minImageData() ) /
+                     ( m_imv->maxImageData() - m_imv->minImageData() ) );
 
-        ui.mindatRelEntry->blockSignals( true );
-        ui.mindatRelEntry->setText( tmps );
-        ui.mindatRelEntry->blockSignals( false );
+        m_ui.mindatRelEntry->blockSignals( true );
+        m_ui.mindatRelEntry->setText( tmps );
+        m_ui.mindatRelEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_maxdatSlider()
 {
-    if( !ui.maxdatSlider->hasFocus() )
+    if( !m_ui.maxdatSlider->hasFocus() )
     {
         int pos;
-        pos = (int)( ui.maxdatSlider->minimum() +
-                     ( imv->maxScaleData() - imv->minImageData() ) / ( imv->maxImageData() - imv->minImageData() ) *
-                         ( ui.maxdatSlider->maximum() - ui.maxdatSlider->minimum() ) +
+        pos = (int)( m_ui.maxdatSlider->minimum() +
+                     ( m_imv->maxScaleData() - m_imv->minImageData() ) /
+                         ( m_imv->maxImageData() - m_imv->minImageData() ) *
+                         ( m_ui.maxdatSlider->maximum() - m_ui.maxdatSlider->minimum() ) +
                      .5 );
 
-        ui.maxdatSlider->blockSignals( true );
-        ui.maxdatSlider->setSliderPosition( pos );
-        ui.maxdatSlider->blockSignals( false );
+        m_ui.maxdatSlider->blockSignals( true );
+        m_ui.maxdatSlider->setSliderPosition( pos );
+        m_ui.maxdatSlider->blockSignals( false );
     }
 }
 
@@ -612,114 +620,116 @@ void rtimvControlPanel::update_maxdatSlider()
 void rtimvControlPanel::update_maxdatEntry()
 {
     char tmps[15];
-    if( !ui.maxdatEntry->hasFocus() )
+    if( !m_ui.maxdatEntry->hasFocus() )
     {
-        sprintf( tmps, "%14.1f", imv->maxScaleData() );
+        sprintf( tmps, "%14.1f", m_imv->maxScaleData() );
 
-        ui.maxdatEntry->blockSignals( true );
-        ui.maxdatEntry->setText( tmps );
-        ui.maxdatEntry->blockSignals( false );
+        m_ui.maxdatEntry->blockSignals( true );
+        m_ui.maxdatEntry->setText( tmps );
+        m_ui.maxdatEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_maxdatRelEntry()
 {
     char tmps[15];
-    if( !ui.maxdatRelEntry->hasFocus() )
+    if( !m_ui.maxdatRelEntry->hasFocus() )
     {
         sprintf( tmps,
                  "%5.3f",
-                 ( imv->maxScaleData() - imv->minImageData() ) / ( imv->maxImageData() - imv->minImageData() ) );
+                 ( m_imv->maxScaleData() - m_imv->minImageData() ) /
+                     ( m_imv->maxImageData() - m_imv->minImageData() ) );
 
-        ui.maxdatRelEntry->blockSignals( true );
-        ui.maxdatRelEntry->setText( tmps );
-        ui.maxdatRelEntry->blockSignals( false );
+        m_ui.maxdatRelEntry->blockSignals( true );
+        m_ui.maxdatRelEntry->setText( tmps );
+        m_ui.maxdatRelEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_biasSlider()
 {
-    if( !ui.biasSlider->hasFocus() )
+    if( !m_ui.biasSlider->hasFocus() )
     {
         int pos;
-        pos = (int)( ui.biasSlider->minimum() +
-                     ( .5 * ( imv->maxScaleData() + imv->minScaleData() ) - imv->minImageData() ) /
-                         ( imv->maxImageData() - imv->minImageData() ) *
-                         ( ui.biasSlider->maximum() - ui.biasSlider->minimum() ) +
+        pos = (int)( m_ui.biasSlider->minimum() +
+                     ( .5 * ( m_imv->maxScaleData() + m_imv->minScaleData() ) - m_imv->minImageData() ) /
+                         ( m_imv->maxImageData() - m_imv->minImageData() ) *
+                         ( m_ui.biasSlider->maximum() - m_ui.biasSlider->minimum() ) +
                      .5 );
 
-        ui.biasSlider->blockSignals( true );
-        ui.biasSlider->setSliderPosition( pos );
-        ui.biasSlider->blockSignals( false );
+        m_ui.biasSlider->blockSignals( true );
+        m_ui.biasSlider->setSliderPosition( pos );
+        m_ui.biasSlider->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_biasEntry()
 {
     char tmps[15];
-    if( !ui.biasEntry->hasFocus() )
+    if( !m_ui.biasEntry->hasFocus() )
     {
-        sprintf( tmps, "%14.1f", 0.5 * ( imv->maxScaleData() + imv->minScaleData() ) );
+        sprintf( tmps, "%14.1f", 0.5 * ( m_imv->maxScaleData() + m_imv->minScaleData() ) );
 
-        ui.biasEntry->blockSignals( true );
-        ui.biasEntry->setText( tmps );
-        ui.biasEntry->blockSignals( false );
+        m_ui.biasEntry->blockSignals( true );
+        m_ui.biasEntry->setText( tmps );
+        m_ui.biasEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_biasRelEntry()
 {
     char tmps[15];
-    if( !ui.biasRelEntry->hasFocus() )
+    if( !m_ui.biasRelEntry->hasFocus() )
     {
         sprintf( tmps,
                  "%5.3f",
-                 ( 0.5 * ( imv->maxScaleData() + imv->minScaleData() ) - imv->minImageData() ) /
-                     ( imv->maxImageData() - imv->minImageData() ) );
+                 ( 0.5 * ( m_imv->maxScaleData() + m_imv->minScaleData() ) - m_imv->minImageData() ) /
+                     ( m_imv->maxImageData() - m_imv->minImageData() ) );
 
-        ui.biasRelEntry->blockSignals( true );
-        ui.biasRelEntry->setText( tmps );
-        ui.biasRelEntry->blockSignals( false );
+        m_ui.biasRelEntry->blockSignals( true );
+        m_ui.biasRelEntry->setText( tmps );
+        m_ui.biasRelEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_contrastSlider()
 {
     int pos;
-    pos = (int)( ui.contrastSlider->minimum() +
-                 ( imv->maxScaleData() - imv->minScaleData() ) / ( imv->maxImageData() - imv->minImageData() ) *
-                     ( ui.biasSlider->maximum() - ui.biasSlider->minimum() ) +
+    pos = (int)( m_ui.contrastSlider->minimum() +
+                 ( m_imv->maxScaleData() - m_imv->minScaleData() ) / ( m_imv->maxImageData() - m_imv->minImageData() ) *
+                     ( m_ui.biasSlider->maximum() - m_ui.biasSlider->minimum() ) +
                  .5 );
 
-    ui.contrastSlider->blockSignals( true );
-    ui.contrastSlider->setSliderPosition( pos );
-    ui.contrastSlider->blockSignals( false );
+    m_ui.contrastSlider->blockSignals( true );
+    m_ui.contrastSlider->setSliderPosition( pos );
+    m_ui.contrastSlider->blockSignals( false );
 }
 
 void rtimvControlPanel::update_contrastEntry()
 {
     char tmps[15];
-    if( !ui.contrastEntry->hasFocus() )
+    if( !m_ui.contrastEntry->hasFocus() )
     {
-        sprintf( tmps, "%14.1f", ( imv->maxScaleData() - imv->minScaleData() ) );
+        sprintf( tmps, "%14.1f", ( m_imv->maxScaleData() - m_imv->minScaleData() ) );
 
-        ui.contrastEntry->blockSignals( true );
-        ui.contrastEntry->setText( tmps );
-        ui.contrastEntry->blockSignals( false );
+        m_ui.contrastEntry->blockSignals( true );
+        m_ui.contrastEntry->setText( tmps );
+        m_ui.contrastEntry->blockSignals( false );
     }
 }
 
 void rtimvControlPanel::update_contrastRelEntry()
 {
     char tmps[15];
-    if( !ui.contrastRelEntry->hasFocus() )
+    if( !m_ui.contrastRelEntry->hasFocus() )
     {
-        sprintf(
-            tmps, "%5.1f", imv->maxImageData() - imv->minImageData() / ( imv->maxScaleData() - imv->minScaleData() ) );
+        sprintf( tmps,
+                 "%5.1f",
+                 m_imv->maxImageData() - m_imv->minImageData() / ( m_imv->maxScaleData() - m_imv->minScaleData() ) );
 
-        ui.contrastRelEntry->blockSignals( true );
-        ui.contrastRelEntry->setText( tmps );
-        ui.contrastRelEntry->blockSignals( false );
+        m_ui.contrastRelEntry->blockSignals( true );
+        m_ui.contrastRelEntry->setText( tmps );
+        m_ui.contrastRelEntry->blockSignals( false );
     }
 }
 
@@ -727,142 +737,139 @@ void rtimvControlPanel::on_scaleModeCombo_activated( int index )
 {
     if( static_cast<rtimv::colormode>( index ) == rtimv::colormode::minmaxglobal )
     {
-        imv->mtxUL_colormode( rtimv::colormode::minmaxglobal );
+        m_imv->mtxUL_colormode( rtimv::colormode::minmaxglobal );
     }
     else if( static_cast<rtimv::colormode>( index ) == rtimv::colormode::user )
     {
-        imv->mtxUL_colormode( rtimv::colormode::user );
+        m_imv->mtxUL_colormode( rtimv::colormode::user );
     }
     else if( static_cast<rtimv::colormode>( index ) == rtimv::colormode::minmaxbox )
     {
-        imv->toggleColorBoxOn();
+        m_imv->toggleColorBoxOn();
     }
     else
     {
-        imv->mtxUL_colormode( rtimv::colormode::minmaxglobal );
+        m_imv->mtxUL_colormode( rtimv::colormode::minmaxglobal );
     }
 }
 
 void rtimvControlPanel::on_mindatSlider_valueChanged( int value )
 {
-    double sc = ( (double)( value - ui.mindatSlider->minimum() ) ) /
-                ( (double)( ui.mindatSlider->maximum() - ui.mindatSlider->minimum() ) );
+    double sc = ( (double)( value - m_ui.mindatSlider->minimum() ) ) /
+                ( (double)( m_ui.mindatSlider->maximum() - m_ui.mindatSlider->minimum() ) );
 
-    imv->minScaleData( imv->minImageData() + ( imv->maxImageData() - imv->minImageData() ) * sc );
+    m_imv->minScaleData( m_imv->minImageData() + ( m_imv->maxImageData() - m_imv->minImageData() ) * sc );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_mindatEntry_editingFinished()
 {
-    imv->minScaleData( ui.mindatEntry->text().toDouble() );
+    m_imv->minScaleData( m_ui.mindatEntry->text().toDouble() );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_maxdatSlider_valueChanged( int value )
 {
-    double sc = ( (double)( value - ui.maxdatSlider->minimum() ) ) /
-                ( (double)( ui.maxdatSlider->maximum() - ui.maxdatSlider->minimum() ) );
+    double sc = ( (double)( value - m_ui.maxdatSlider->minimum() ) ) /
+                ( (double)( m_ui.maxdatSlider->maximum() - m_ui.maxdatSlider->minimum() ) );
 
-    imv->maxScaleData( imv->minImageData() + ( imv->maxImageData() - imv->minImageData() ) * sc );
+    m_imv->maxScaleData( m_imv->minImageData() + ( m_imv->maxImageData() - m_imv->minImageData() ) * sc );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_maxdatEntry_editingFinished()
 {
-    imv->maxScaleData( ui.maxdatEntry->text().toDouble() );
+    m_imv->maxScaleData( m_ui.maxdatEntry->text().toDouble() );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_biasSlider_valueChanged( int value )
 {
-    double bias = ( (double)( value - ui.biasSlider->minimum() ) ) /
-                  ( (double)( ui.biasSlider->maximum() - ui.biasSlider->minimum() ) );
+    double bias = ( (double)( value - m_ui.biasSlider->minimum() ) ) /
+                  ( (double)( m_ui.biasSlider->maximum() - m_ui.biasSlider->minimum() ) );
 
-    imv->bias_rel( bias );
+    m_imv->bias_rel( bias );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_biasEntry_editingFinished()
 {
-    imv->bias( ui.biasEntry->text().toDouble() );
+    m_imv->bias( m_ui.biasEntry->text().toDouble() );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_contrastSlider_valueChanged( int value )
 {
-    double cont = ( (double)( value - ui.contrastSlider->minimum() ) ) /
-                  ( (double)( ui.contrastSlider->maximum() - ui.contrastSlider->minimum() ) );
+    double cont = ( (double)( value - m_ui.contrastSlider->minimum() ) ) /
+                  ( (double)( m_ui.contrastSlider->maximum() - m_ui.contrastSlider->minimum() ) );
 
-    cont = cont * ( imv->maxImageData() - imv->minImageData() );
+    cont = cont * ( m_imv->maxImageData() - m_imv->minImageData() );
 
-    imv->contrast( cont );
+    m_imv->contrast( cont );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_contrastEntry_editingFinished()
 {
-    imv->contrast( ui.contrastEntry->text().toDouble() );
+    m_imv->contrast( m_ui.contrastEntry->text().toDouble() );
 
-    imv->mtxUL_colormode( rtimv::colormode::user );
+    m_imv->mtxUL_colormode( rtimv::colormode::user );
 }
 
 void rtimvControlPanel::on_imtimerspinBox_valueChanged( int to )
 {
-    imv->imageTimeout( to );
+    m_imv->imageTimeout( to );
 }
 
 void rtimvControlPanel::on_statsBoxButton_clicked()
 {
-    if( statsBoxButtonState )
+    if( m_statsBoxButtonState )
     {
         emit hideStatsBox();
-        ui.statsBoxButton->setText( "Show Stats Box" );
-        statsBoxButtonState = false;
+        m_ui.statsBoxButton->setText( "Show Stats Box" );
+        m_statsBoxButtonState = false;
     }
     else
     {
         emit launchStatsBox();
-        ui.statsBoxButton->setText( "Hide Stats Box" );
-        statsBoxButtonState = true;
+        m_ui.statsBoxButton->setText( "Hide Stats Box" );
+        m_statsBoxButtonState = true;
     }
 }
 
 void rtimvControlPanel::viewBoxMoved( const QRectF &vbr )
 {
-    // QPointF newcenV = ui.viewView->mapFromScene(newcen);
-    // double viewZoom = (double)ui.viewView->width()/(double)imv->nx();
-    // QRectF vbr = viewBox->rect();
+    // QPointF newcenV = m_ui.viewView->mapFromScene(newcen);
+    // double viewZoom = (double)m_ui.viewView->width()/(double)m_imv->nx();
+    // QRectF vbr = m_viewBox->rect();
 
-    QPointF np = qpmi_view->mapFromItem( viewBox, QPointF( vbr.x(), vbr.y() ) );
-    QPointF np2 = qpmi_view->mapFromItem( viewBox, QPointF( vbr.bottom(), vbr.right() ) );
+    QPointF np = m_qpmiView->mapFromItem( m_viewBox, QPointF( vbr.x(), vbr.y() ) );
+    QPointF np2 = m_qpmiView->mapFromItem( m_viewBox, QPointF( vbr.bottom(), vbr.right() ) );
 
-    // std::cout <<  np.x() << " " << np.y() << " " << (np2.x()-np.x()) << " " << (np2.y()-np.y()) << "\n\n";
 
     double nxcen = np.x() + .5 * ( np2.x() - np.x() );
     double nycen = np.y() + .5 * ( np2.y() - np.y() );
-    // std::cout << nxcen/1024. << " " << nycen/1024. << " " << ui.viewView->width() << " " << ui.viewView->height() <<
-    // "\n";
 
     std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    imv->mtxL_setViewCen( nxcen / (double)imv->nx(), nycen / (double)imv->nx(), lock, true );
+    m_imv->mtxL_setViewCen( nxcen / (double)m_imv->nx(), nycen / (double)m_imv->nx(), lock, true );
 }
 
 void rtimvControlPanel::showToolTipCoordsChanged( bool sttc )
 {
     if( sttc )
     {
-        ui.toolTipCoordsButton->setText( "Hide Pointer Coords" );
+        m_ui.toolTipCoordsButton->setText( "Hide Pointer Coords" );
     }
     else
     {
-        ui.toolTipCoordsButton->setText( "Show Pointer Coords" );
+        m_ui.toolTipCoordsButton->setText( "Show Pointer Coords" );
     }
 }
 
@@ -870,62 +877,62 @@ void rtimvControlPanel::showStaticCoordsChanged( bool ssc )
 {
     if( ssc )
     {
-        ui.staticCoordsButton->setText( "Hide Static Coords" );
+        m_ui.staticCoordsButton->setText( "Hide Static Coords" );
     }
     else
     {
-        ui.staticCoordsButton->setText( "Show Static Coords" );
+        m_ui.staticCoordsButton->setText( "Show Static Coords" );
     }
 }
 
 void rtimvControlPanel::on_toolTipCoordsButton_clicked()
 {
     // Toggle
-    emit showToolTipCoords( !imv->showToolTipCoords() );
+    emit showToolTipCoords( !m_imv->showToolTipCoords() );
 }
 
 void rtimvControlPanel::on_staticCoordsButton_clicked()
 {
     // Toggle
-    emit showStaticCoords( !imv->showStaticCoords() );
+    emit showStaticCoords( !m_imv->showStaticCoords() );
 }
 
 void rtimvControlPanel::targetXcChanged( float txc )
 {
     char str[16];
     snprintf( str, sizeof( str ), "%0.3f", txc );
-    ui.lineEditTargetFractionX->setText( str );
+    m_ui.lineEditTargetFractionX->setText( str );
 
-    snprintf( str, sizeof( str ), "%0.2f", txc * ( imv->nx() ) - 0.5 );
-    ui.lineEditTargetPixelX->setText( str );
+    snprintf( str, sizeof( str ), "%0.2f", txc * ( m_imv->nx() ) - 0.5 );
+    m_ui.lineEditTargetPixelX->setText( str );
 }
 
 void rtimvControlPanel::targetYcChanged( float tyc )
 {
     char str[16];
     snprintf( str, sizeof( str ), "%0.3f", tyc );
-    ui.lineEditTargetFractionY->setText( str );
+    m_ui.lineEditTargetFractionY->setText( str );
 
-    snprintf( str, sizeof( str ), "%0.2f", tyc * ( imv->ny() ) - 0.5 );
-    ui.lineEditTargetPixelY->setText( str );
+    snprintf( str, sizeof( str ), "%0.2f", tyc * ( m_imv->ny() ) - 0.5 );
+    m_ui.lineEditTargetPixelY->setText( str );
 }
 
 void rtimvControlPanel::targetVisibleChanged( bool tv )
 {
     if( tv )
     {
-        ui.buttonTargetCross->setText( "hide" );
+        m_ui.buttonTargetCross->setText( "hide" );
     }
     else
     {
-        ui.buttonTargetCross->setText( "show" );
+        m_ui.buttonTargetCross->setText( "show" );
     }
 }
 
 void rtimvControlPanel::on_buttonTargetCross_clicked()
 {
     // toggle
-    emit targetVisible( !imv->targetVisible() );
+    emit targetVisible( !m_imv->targetVisible() );
 }
 
 void rtimvControlPanel::on_lineEditTargetPixelX_returnPressed()
@@ -934,7 +941,7 @@ void rtimvControlPanel::on_lineEditTargetPixelX_returnPressed()
     bool ok = false;
     try
     {
-        txc = ui.lineEditTargetPixelX->text().toFloat( &ok );
+        txc = m_ui.lineEditTargetPixelX->text().toFloat( &ok );
     }
     catch( ... )
     {
@@ -944,7 +951,7 @@ void rtimvControlPanel::on_lineEditTargetPixelX_returnPressed()
     if( txc == -1 || ok == false )
         return;
 
-    txc = ( txc + 0.5 ) / imv->nx();
+    txc = ( txc + 0.5 ) / m_imv->nx();
 
     emit targetXc( txc );
 }
@@ -955,7 +962,7 @@ void rtimvControlPanel::on_lineEditTargetPixelY_returnPressed()
     bool ok = false;
     try
     {
-        tyc = ui.lineEditTargetPixelY->text().toFloat( &ok );
+        tyc = m_ui.lineEditTargetPixelY->text().toFloat( &ok );
     }
     catch( ... )
     {
@@ -965,7 +972,7 @@ void rtimvControlPanel::on_lineEditTargetPixelY_returnPressed()
     if( tyc == -1 || ok == false )
         return;
 
-    tyc = ( tyc + 0.5 ) / imv->ny();
+    tyc = ( tyc + 0.5 ) / m_imv->ny();
 
     emit targetYc( tyc );
 }
@@ -976,7 +983,7 @@ void rtimvControlPanel::on_lineEditTargetFractionX_returnPressed()
     bool ok = false;
     try
     {
-        txc = ui.lineEditTargetFractionX->text().toFloat( &ok );
+        txc = m_ui.lineEditTargetFractionX->text().toFloat( &ok );
     }
     catch( ... )
     {
@@ -995,7 +1002,7 @@ void rtimvControlPanel::on_lineEditTargetFractionY_returnPressed()
     bool ok = false;
     try
     {
-        tyc = ui.lineEditTargetFractionY->text().toFloat( &ok );
+        tyc = m_ui.lineEditTargetFractionY->text().toFloat( &ok );
     }
     catch( ... )
     {

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -4,16 +4,8 @@ rtimvControlPanel::rtimvControlPanel()
 {
 }
 
-rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, std::shared_mutex *calMutex, Qt::WindowFlags f )
-    : QWidget( 0, f )
+rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : QWidget( 0, f )
 {
-    m_calMutex = calMutex;
-
-    if( m_calMutex == nullptr )
-    {
-        throw std::invalid_argument( "calMutex can't be null" );
-    }
-
     m_ui.setupUi( this );
     m_imv = v;
 
@@ -40,8 +32,7 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, std::shared_mutex *cal
     m_viewBox->setFlag( QGraphicsItem::ItemIsSelectable, true );
     m_viewBox->setFlag( QGraphicsItem::ItemIsMovable, true );
     m_viewBox->setStretchable( false );
-    m_viewBox->setEdgeTol(
-        m_imv->nx() );
+    m_viewBox->setEdgeTol( m_imv->nx() );
     m_qgsView->addItem( m_viewBox );
 
     double viewZoom = (double)m_ui.viewView->width() / (double)m_imv->nx();
@@ -316,14 +307,12 @@ void rtimvControlPanel::enableViewViewMode( int state )
 
 void rtimvControlPanel::on_xcenEntry_editingFinished()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_ui.xcenEntry->text().toDouble() / m_imv->nx(), m_imv->get_ycen(), lock );
+    m_imv->mtxUL_setViewCen( m_ui.xcenEntry->text().toDouble() / m_imv->nx(), m_imv->get_ycen() );
 }
 
 void rtimvControlPanel::on_ycenEntry_editingFinished()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_imv->get_xcen(), m_ui.ycenEntry->text().toDouble() / m_imv->ny(), lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen(), m_ui.ycenEntry->text().toDouble() / m_imv->ny() );
 }
 
 void rtimvControlPanel::on_widthEntry_editingFinished()
@@ -344,68 +333,55 @@ void rtimvControlPanel::on_heightEntry_editingFinished()
 
 void rtimvControlPanel::on_view_center_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( .5, .5, lock );
+    m_imv->mtxUL_setViewCen( .5, .5 );
 }
 
 void rtimvControlPanel::on_view_ul_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
-                            m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(),
-                            lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_up_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen(
-        m_imv->get_xcen() / m_imv->nx(), m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(), lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx(),
+                             m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_ur_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
-                            m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel(),
-                            lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() - 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_right_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen(
-        m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(), m_imv->get_ycen() / m_imv->ny(), lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() );
 }
 
 void rtimvControlPanel::on_view_dr_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
-                            m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(),
-                            lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() + 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_down_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen(
-        m_imv->get_xcen() / m_imv->nx(), m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(), lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx(),
+                             m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_dl_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
-                            m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel(),
-                            lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() + 1. / m_imv->zoomLevel() );
 }
 
 void rtimvControlPanel::on_view_left_clicked()
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen(
-        m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(), m_imv->get_ycen() / m_imv->ny(), lock );
+    m_imv->mtxUL_setViewCen( m_imv->get_xcen() / m_imv->nx() - 1. / m_imv->zoomLevel(),
+                             m_imv->get_ycen() / m_imv->ny() );
 }
 
 void rtimvControlPanel::updateMouseCoords( double x, double y, double v )
@@ -551,8 +527,7 @@ void rtimvControlPanel::on_scaleTypeCombo_activated( int ct )
 
 void rtimvControlPanel::on_colorbarCombo_activated( int cb )
 {
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_load_colorbar( static_cast<rtimv::colorbar>( cb ), true, lock );
+    m_imv->mtxUL_load_colorbar( static_cast<rtimv::colorbar>( cb ), true );
 }
 
 void rtimvControlPanel::update_mindatSlider()
@@ -853,12 +828,10 @@ void rtimvControlPanel::viewBoxMoved( const QRectF &vbr )
     QPointF np = m_qpmiView->mapFromItem( m_viewBox, QPointF( vbr.x(), vbr.y() ) );
     QPointF np2 = m_qpmiView->mapFromItem( m_viewBox, QPointF( vbr.bottom(), vbr.right() ) );
 
-
     double nxcen = np.x() + .5 * ( np2.x() - np.x() );
     double nycen = np.y() + .5 * ( np2.y() - np.y() );
 
-    std::shared_lock<std::shared_mutex> lock( *m_calMutex );
-    m_imv->mtxL_setViewCen( nxcen / (double)m_imv->nx(), nycen / (double)m_imv->nx(), lock, true );
+    m_imv->mtxUL_setViewCen( nxcen / (double)m_imv->nx(), nycen / (double)m_imv->nx(), true );
 }
 
 void rtimvControlPanel::showToolTipCoordsChanged( bool sttc )

--- a/src/gui/rtimvControlPanel.hpp
+++ b/src/gui/rtimvControlPanel.hpp
@@ -8,8 +8,6 @@
 #ifndef rtimv_rtimvControlPanel_hpp
 #define rtimv_rtimvControlPanel_hpp
 
-#include <shared_mutex>
-
 #include <QWidget>
 
 #include "rtimvMainWindow.hpp"
@@ -29,15 +27,11 @@ class rtimvControlPanel : public QWidget
   public:
     /// Construct the control panel and bind it to the main window model.
     rtimvControlPanel( rtimvMainWindow *imv /**< [in] the main window/model*/,
-                       std::shared_mutex *calMutex /**< [in] calibration/data mutex shared with main window*/,
                        Qt::WindowFlags f = Qt::WindowFlags() /**< [in] Qt window flags*/ );
 
   protected:
     /// Pointer to the main window/model this control panel drives.
     rtimvMainWindow *m_imv;
-
-    /// Shared calibration/data mutex from the main window.
-    std::shared_mutex *m_calMutex{ nullptr };
 
     /// Initialize internal default mode state.
     void setupMode();

--- a/src/gui/rtimvControlPanel.hpp
+++ b/src/gui/rtimvControlPanel.hpp
@@ -1,10 +1,20 @@
+/** \file rtimvControlPanel.hpp
+ * \brief Declarations for the rtimvControlPanel GUI class.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
 
-#ifndef __imviewercontrolpanel_h__
-#define __imviewercontrolpanel_h__
+#ifndef rtimv_rtimvControlPanel_hpp
+#define rtimv_rtimvControlPanel_hpp
 
-#include "ui_rtimvControlPanel.h"
+#include <shared_mutex>
+
+#include <QWidget>
+
 #include "rtimvMainWindow.hpp"
 #include "StretchBox.hpp"
+#include "ui_rtimvControlPanel.h"
 
 class rtimvMainWindow;
 
@@ -13,161 +23,296 @@ class rtimvControlPanel : public QWidget
     Q_OBJECT
 
   private:
-    rtimvControlPanel()
-    {
-    }
+    /// Private default constructor is disabled for normal use.
+    rtimvControlPanel();
 
   public:
-    rtimvControlPanel( rtimvMainWindow *imv, std::shared_mutex *calMutex, Qt::WindowFlags f = Qt::WindowFlags() );
+    /// Construct the control panel and bind it to the main window model.
+    rtimvControlPanel( rtimvMainWindow *imv /**< [in] the main window/model*/,
+                       std::shared_mutex *calMutex /**< [in] calibration/data mutex shared with main window*/,
+                       Qt::WindowFlags f = Qt::WindowFlags() /**< [in] Qt window flags*/ );
 
   protected:
-    rtimvMainWindow *imv;
+    /// Pointer to the main window/model this control panel drives.
+    rtimvMainWindow *m_imv;
 
+    /// Shared calibration/data mutex from the main window.
     std::shared_mutex *m_calMutex{ nullptr };
 
+    /// Initialize internal default mode state.
     void setupMode();
+
+    /// Populate combo boxes with their available options.
     void setupCombos();
 
+    /// Initialize all UI fields from current model state.
     void init_panel();
 
   public:
+    /// Refresh all UI controls from the current model values.
     void update_panel();
 
     /*** Zoom Controls ***/
   public:
+    /// Synchronize zoom slider position from model zoom.
     void update_ZoomSlider();
+
+    /// Synchronize zoom entry text from model zoom.
     void update_ZoomEntry();
 
   protected slots:
-    void on_ZoomSlider_valueChanged( int value );
+    /// Handle zoom slider changes and apply zoom to the model.
+    void on_ZoomSlider_valueChanged( int value /**< [in] new slider value*/ );
+
+    /// Set zoom level to 1x.
     void on_Zoom1_clicked();
+
+    /// Set zoom level to 2x.
     void on_Zoom2_clicked();
+
+    /// Set zoom level to 4x.
     void on_Zoom4_clicked();
+
+    /// Set zoom level to 8x.
     void on_Zoom8_clicked();
+
+    /// Set zoom level to 16x.
     void on_Zoom16_clicked();
+
+    /// Apply zoom value entered in the zoom text field.
     void on_ZoomEntry_editingFinished();
 
+    /// Set pointer over-zoom factor to 1x.
     void on_overZoom1_clicked();
+
+    /// Set pointer over-zoom factor to 2x.
     void on_overZoom2_clicked();
+
+    /// Set pointer over-zoom factor to 4x.
     void on_overZoom4_clicked();
 
   public:
     /*** The zoom box view ***/
-    QGraphicsScene *qgs_view;
-    QGraphicsScene *qgs_empty;
-    QGraphicsPixmapItem *qpmi_view; // = 0;
-    QGraphicsLineItem *viewLineVert;
-    QGraphicsLineItem *viewLineHorz;
-    // QGraphicsRectItem * viewBox;
-    StretchBox *viewBox;
+    /// Scene containing the overview image and selection graphics.
+    QGraphicsScene *m_qgsView;
 
-    int ViewViewMode; // options: ViewViewEnabled ViewViewNoImage
-    void set_ViewViewMode( int );
+    /// Empty scene shown when overview/pointer views are disabled.
+    QGraphicsScene *m_qgsEmpty;
 
+    /// Pixmap item for the overview image.
+    QGraphicsPixmapItem *m_qpmiView; // = 0;
+
+    /// Vertical center guideline in overview mode.
+    QGraphicsLineItem *m_viewLineVert;
+
+    /// Horizontal center guideline in overview mode.
+    QGraphicsLineItem *m_viewLineHorz;
+
+    /// Movable viewport rectangle in the overview scene.
+    StretchBox *m_viewBox;
+
+    /// Current overview mode (ViewViewEnabled/ViewViewNoImage).
+    int m_viewViewMode; // options: ViewViewEnabled ViewViewNoImage
+
+    /// Set the view-overview display mode.
+    void set_ViewViewMode( int vvm /**< [in] requested view-overview mode*/ );
+
+    /// Update overview center coordinate entries.
     void update_xycenEntry();
+
+    /// Update overview width/height entries.
     void update_whEntry();
 
   protected slots:
-    void on_ViewViewModecheckBox_stateChanged( int );
-    void enableViewViewMode( int );
+    /// Handle checkbox state changes for overview mode.
+    void on_ViewViewModecheckBox_stateChanged( int state /**< [in] new checkbox state*/ );
 
+    /// Enable or disable overview mode from UI state.
+    void enableViewViewMode( int state /**< [in] non-zero enables overview mode*/ );
+
+    /// Apply edited x-center value.
     void on_xcenEntry_editingFinished();
+
+    /// Apply edited y-center value.
     void on_ycenEntry_editingFinished();
 
+    /// Apply edited viewport width.
     void on_widthEntry_editingFinished();
+
+    /// Apply edited viewport height.
     void on_heightEntry_editingFinished();
 
+    /// Center viewport on full-frame center.
     void on_view_center_clicked();
+
+    /// Move viewport up-left.
     void on_view_ul_clicked();
+
+    /// Move viewport up.
     void on_view_up_clicked();
+
+    /// Move viewport up-right.
     void on_view_ur_clicked();
+
+    /// Move viewport right.
     void on_view_right_clicked();
+
+    /// Move viewport down-right.
     void on_view_dr_clicked();
+
+    /// Move viewport down.
     void on_view_down_clicked();
+
+    /// Move viewport down-left.
     void on_view_dl_clicked();
+
+    /// Move viewport left.
     void on_view_left_clicked();
 
   public:
     /*** The pointer tip view ***/
-    QPointF pointerViewCen;
-    int PointerViewMode; // options: PointerViewEnabled PointerViewOnPress PointerViewDisabled
+    /// Fixed pointer-view center in scene coordinates.
+    QPointF m_pointerViewCen;
+
+    /// Current pointer-view mode state.
+    int m_pointerViewMode; // options: PointerViewEnabled PointerViewOnPress PointerViewDisabled
 
   protected:
-    bool PointerViewEmpty;
-    bool PointerViewFixed;
-    bool PointerViewWaiting;
+    /// True when pointer view is displaying the empty scene.
+    bool m_pointerViewEmpty;
+
+    /// True when pointer view location is user-fixed.
+    bool m_pointerViewFixed;
+
+    /// True while waiting for a click to set fixed pointer location.
+    bool m_pointerViewWaiting;
 
   public:
-    void updateMouseCoords( double x, double y, double v );
+    /// Update mouse coordinate and value displays.
+    void updateMouseCoords( double x /**< [in] x coordinate in image pixels*/,
+                            double y /**< [in] y coordinate in image pixels*/,
+                            double v /**< [in] pixel value at x,y*/ );
+
+    /// Clear mouse coordinate and value displays.
     void nullMouseCoords();
-    void viewLeftPressed( QPointF mp );
-    void viewLeftClicked( QPointF mp );
+
+    /// Handle left-button press in the main view.
+    void viewLeftPressed( QPointF mp /**< [in] mouse position in scene coordinates*/ );
+
+    /// Handle left-button click/release in the main view.
+    void viewLeftClicked( QPointF mp /**< [in] mouse position in scene coordinates*/ );
 
   public slots:
-    void set_PointerViewMode( int );
-    void on_pointerViewModecomboBox_activated( int );
+    /// Set pointer-view mode policy.
+    void set_PointerViewMode( int pvm /**< [in] pointer view mode*/ );
+
+    /// Handle pointer-view mode combo selection.
+    void on_pointerViewModecomboBox_activated( int pvm /**< [in] selected pointer view mode*/ );
+
+    /// Toggle pointer location locking workflow.
     void on_pointerSetLocButton_clicked();
-    void set_pointerViewCen( QPointF mp );
 
-    void viewBoxMoved( const QRectF &newcen );
+    /// Set the pointer-view center location.
+    void set_pointerViewCen( QPointF mp /**< [in] new pointer-view center in scene coordinates*/ );
 
-    /*** Color Controls ***/
-    /*void setScaleMode( int sm )
-    {
-        ui.scaleModeCombo->setCurrentIndex( sm );
-    }*/
+    /// Update model center after overview box movement.
+    void viewBoxMoved( const QRectF &newcen /**< [in] updated overview selection rectangle*/ );
 
   protected slots:
-    void on_scaleTypeCombo_activated( int );
-    void on_colorbarCombo_activated( int );
+    /// Handle stretch type combo selection.
+    void on_scaleTypeCombo_activated( int ct /**< [in] selected stretch type index*/ );
+
+    /// Handle colorbar combo selection.
+    void on_colorbarCombo_activated( int cb /**< [in] selected colorbar index*/ );
 
     /* scale controls */
   protected:
+    /// Synchronize min-data slider from model state.
     void update_mindatSlider();
+
+    /// Synchronize min-data absolute entry from model state.
     void update_mindatEntry();
+
+    /// Synchronize min-data relative entry from model state.
     void update_mindatRelEntry();
 
+    /// Synchronize max-data slider from model state.
     void update_maxdatSlider();
+
+    /// Synchronize max-data absolute entry from model state.
     void update_maxdatEntry();
+
+    /// Synchronize max-data relative entry from model state.
     void update_maxdatRelEntry();
 
+    /// Synchronize bias slider from model state.
     void update_biasSlider();
+
+    /// Synchronize bias absolute entry from model state.
     void update_biasEntry();
+
+    /// Synchronize bias relative entry from model state.
     void update_biasRelEntry();
 
+    /// Synchronize contrast slider from model state.
     void update_contrastSlider();
+
+    /// Synchronize contrast absolute entry from model state.
     void update_contrastEntry();
+
+    /// Synchronize contrast relative entry from model state.
     void update_contrastRelEntry();
 
   public slots:
-    void on_scaleModeCombo_activated( int index );
+    /// Handle color mode combo selection.
+    void on_scaleModeCombo_activated( int index /**< [in] selected color mode index*/ );
 
-    void on_mindatSlider_valueChanged( int value );
+    /// Handle minimum data slider changes.
+    void on_mindatSlider_valueChanged( int value /**< [in] new minimum slider value*/ );
+
+    /// Handle minimum data entry edits.
     void on_mindatEntry_editingFinished();
 
-    void on_maxdatSlider_valueChanged( int value );
+    /// Handle maximum data slider changes.
+    void on_maxdatSlider_valueChanged( int value /**< [in] new maximum slider value*/ );
+
+    /// Handle maximum data entry edits.
     void on_maxdatEntry_editingFinished();
 
-    void on_biasSlider_valueChanged( int value );
+    /// Handle bias slider changes.
+    void on_biasSlider_valueChanged( int value /**< [in] new bias slider value*/ );
+
+    /// Handle bias entry edits.
     void on_biasEntry_editingFinished();
 
-    void on_contrastSlider_valueChanged( int value );
+    /// Handle contrast slider changes.
+    void on_contrastSlider_valueChanged( int value /**< [in] new contrast slider value*/ );
+
+    /// Handle contrast entry edits.
     void on_contrastEntry_editingFinished();
 
   public:
     /*** Real Time Controls ***/
-    bool statsBoxButtonState;
+    /// Tracks whether the stats box is currently shown.
+    bool m_statsBoxButtonState;
 
   public slots:
-    void on_imtimerspinBox_valueChanged( int );
+    /// Handle image timer update interval changes.
+    void on_imtimerspinBox_valueChanged( int timeout /**< [in] new image timeout value*/ );
+
+    /// Toggle stats box visibility.
     void on_statsBoxButton_clicked();
 
   signals:
+    /// Request stats box creation/display.
     void launchStatsBox();
+
+    /// Request stats box hide/close.
     void hideStatsBox();
 
   public:
-    Ui::rtimvControlPanel ui;
+    /// Generated Qt UI object for this panel.
+    Ui::rtimvControlPanel m_ui;
 
     /*--------- Mouse coordinates display ---------------*/
   public slots:
@@ -179,7 +324,7 @@ class rtimvControlPanel : public QWidget
     /// Receive signal that the static coords display flag has changed.
     /** Updates the button text.
      */
-    void showStaticCoordsChanged( bool /**< [in] the new value of the flag*/ );
+    void showStaticCoordsChanged( bool ssc /**< [in] the new value of the flag*/ );
 
     /// Toggle the tool tip coords display flag
     void on_toolTipCoordsButton_clicked();
@@ -189,10 +334,10 @@ class rtimvControlPanel : public QWidget
 
   signals:
     /// Request that the tool tip coords display flag change.
-    void showToolTipCoords( bool /**< [in] the new value of the flag*/ );
+    void showToolTipCoords( bool sttc /**< [in] the new value of the flag*/ );
 
     /// Request that the static coords display flag change.
-    void showStaticCoords( bool /**< [in] the new value of the flag*/ );
+    void showStaticCoords( bool ssc /**< [in] the new value of the flag*/ );
 
     /*--------- Target Cross ---------------*/
   public slots:
@@ -209,7 +354,7 @@ class rtimvControlPanel : public QWidget
     /// Notify that the target visibility has changed.
     /** This updates the push button text.
      */
-    void targetVisibleChanged( bool tv );
+    void targetVisibleChanged( bool tv /**< [in] the new target visibility state*/ );
 
     /// Toggle the target cross visibility when button pressed.
     void on_buttonTargetCross_clicked();
@@ -235,7 +380,7 @@ class rtimvControlPanel : public QWidget
     void targetYc( float tyc /**< [in] the new target y coordinate*/ );
 
     /// Request to set the target cross visibility
-    void targetVisible( bool tv );
+    void targetVisible( bool tv /**< [in] the new target visibility state*/ );
 };
 
-#endif //__imviewercontrolpanel_h__
+#endif // rtimv_rtimvControlPanel_hpp

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -360,10 +360,10 @@ void rtimvMainWindow::mtxL_postSetImsize( const uniqueLockT &lock )
     if( imcp )
     {
         QTransform transform;
-        float viewZoom = (float)imcp->ui.viewView->width() / (float)m_nx;
+        float viewZoom = (float)imcp->m_ui.viewView->width() / (float)m_nx;
 
         transform.scale( viewZoom, viewZoom );
-        imcp->ui.viewView->setTransform( transform );
+        imcp->m_ui.viewView->setTransform( transform );
     }
 
     statsBoxRemove( m_statsBox );
@@ -411,7 +411,7 @@ void rtimvMainWindow::post_zoomLevel()
     if( imcp )
     {
         transform.scale( pointerOverZoom, pointerOverZoom );
-        imcp->ui.pointerView->setTransform( transform );
+        imcp->m_ui.pointerView->setTransform( transform );
     }
 
     RTIMV_DEBUG_BREADCRUMB
@@ -587,16 +587,16 @@ void rtimvMainWindow::mtxL_postChangeImdata( const sharedLockT &lock )
 
     if( imcp )
     {
-        if( imcp->ViewViewMode == ViewViewEnabled )
+        if( imcp->m_viewViewMode == ViewViewEnabled )
         {
-            if( !imcp->qpmi_view )
+            if( !imcp->m_qpmiView )
             {
-                imcp->qpmi_view = imcp->qgs_view->addPixmap( m_qpm );
+                imcp->m_qpmiView = imcp->m_qgsView->addPixmap( m_qpm );
             }
 
-            imcp->qpmi_view->setPixmap( m_qpm );
+            imcp->m_qpmiView->setPixmap( m_qpm );
 
-            imcp->qpmi_view->stackBefore( imcp->viewLineVert );
+            imcp->m_qpmiView->stackBefore( imcp->m_viewLineVert );
         }
     }
 
@@ -825,22 +825,22 @@ void rtimvMainWindow::change_center( bool movezoombox )
 
     if( imcp )
     {
-        imcp->viewLineVert->setLine( ui.graphicsView->xCen(), 0, ui.graphicsView->xCen(), m_ny );
-        imcp->viewLineHorz->setLine( 0, ui.graphicsView->yCen(), m_nx, ui.graphicsView->yCen() );
+        imcp->m_viewLineVert->setLine( ui.graphicsView->xCen(), 0, ui.graphicsView->xCen(), m_ny );
+        imcp->m_viewLineHorz->setLine( 0, ui.graphicsView->yCen(), m_nx, ui.graphicsView->yCen() );
 
         if( zoomLevel() <= 1.0 )
-            imcp->viewBox->setVisible( false );
+            imcp->m_viewBox->setVisible( false );
         else
         {
-            imcp->viewBox->setVisible( true );
+            imcp->m_viewBox->setVisible( true );
             if( movezoombox )
             {
-                QPointF tmpp = imcp->viewBox->mapFromParent( ui.graphicsView->xCen() - .5 * m_nx / zoomLevel(),
-                                                             ui.graphicsView->yCen() - .5 * m_ny / zoomLevel() );
-                imcp->viewBox->setRect( tmpp.x(), tmpp.y(), m_nx / zoomLevel(), m_ny / zoomLevel() );
+                QPointF tmpp = imcp->m_viewBox->mapFromParent( ui.graphicsView->xCen() - .5 * m_nx / zoomLevel(),
+                                                               ui.graphicsView->yCen() - .5 * m_ny / zoomLevel() );
+                imcp->m_viewBox->setRect( tmpp.x(), tmpp.y(), m_nx / zoomLevel(), m_ny / zoomLevel() );
             }
         }
-        imcp->ui.viewView->centerOn( .5 * m_nx, .5 * m_ny );
+        imcp->m_ui.viewView->centerOn( .5 * m_nx, .5 * m_ny );
         imcp->update_panel();
     }
 }
@@ -1471,8 +1471,8 @@ void rtimvMainWindow::imStatsClosed( int result )
 
     if( imcp )
     {
-        imcp->statsBoxButtonState = false;
-        imcp->ui.statsBoxButton->setText( "Show Stats Box" );
+        imcp->m_statsBoxButtonState = false;
+        imcp->m_ui.statsBoxButton->setText( "Show Stats Box" );
     }
 }
 
@@ -2338,7 +2338,7 @@ void rtimvMainWindow::autoScale( bool as )
 
     mtxUL_autoScale( as );
 
-    //nb can't rely on m_autoScale updating immediately
+    // nb can't rely on m_autoScale updating immediately
     emit autoScaleUpdated( as );
 
     if( as )
@@ -2489,8 +2489,8 @@ void rtimvMainWindow::toggleStatsBox()
         mtxTry_fontLuminance( ui.graphicsView->zoomText() );
         if( imcp )
         {
-            imcp->statsBoxButtonState = false;
-            imcp->ui.statsBoxButton->setText( "Show Stats Box" );
+            imcp->m_statsBoxButtonState = false;
+            imcp->m_ui.statsBoxButton->setText( "Show Stats Box" );
         }
     }
     else
@@ -2500,8 +2500,8 @@ void rtimvMainWindow::toggleStatsBox()
         mtxTry_fontLuminance( ui.graphicsView->zoomText() );
         if( imcp )
         {
-            imcp->statsBoxButtonState = true;
-            imcp->ui.statsBoxButton->setText( "Hide Stats Box" );
+            imcp->m_statsBoxButtonState = true;
+            imcp->m_ui.statsBoxButton->setText( "Hide Stats Box" );
         }
     }
 }

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -637,7 +637,7 @@ void rtimvMainWindow::launchControlPanel()
 {
     if( !imcp )
     {
-        imcp = new rtimvControlPanel( this, &m_calMutex, Qt::Tool );
+        imcp = new rtimvControlPanel( this, Qt::Tool );
         connect( imcp, SIGNAL( launchStatsBox() ), this, SLOT( doLaunchStatsBox() ) );
         connect( imcp, SIGNAL( hideStatsBox() ), this, SLOT( doHideStatsBox() ) );
     }
@@ -859,6 +859,12 @@ void rtimvMainWindow::mtxL_setViewCen_impl( float x, float y, bool movezoombox )
     ui.graphicsView->mapCenterToScene( vp.x(), vp.y() );
 
     change_center( movezoombox );
+}
+
+void rtimvMainWindow::mtxUL_setViewCen( float x, float y, bool movezoombox )
+{
+    sharedLockT lock( m_calMutex );
+    mtxL_setViewCen( x, y, lock, movezoombox );
 }
 
 void rtimvMainWindow::mtxL_setViewCen( float x, float y, const uniqueLockT &lock, bool movezoombox )

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -217,6 +217,11 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     void mtxL_setViewCen_impl( float x, float y, bool movezoombox );
 
   public:
+    /// Lock m_calMutex, then update the viewport center.
+    void mtxUL_setViewCen( float x /**< [in] new x center in fractional image coordinates*/,
+                           float y /**< [in] new y center in fractional image coordinates*/,
+                           bool movezoombox = true /**< [in] whether to move the zoom box graphic*/ );
+
     void mtxL_setViewCen( float x, float y, const uniqueLockT &lock, bool movezoombox = true );
 
     void mtxL_setViewCen( float x, float y, const sharedLockT &lock, bool movezoombox = true );

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -1038,6 +1038,13 @@ void rtimvClientBase::mtxL_load_colorbar( rtimv::colorbar cb, bool update, const
     mtxL_load_colorbarImpl( cb, update );
 }
 
+void rtimvClientBase::mtxUL_load_colorbar( rtimv::colorbar cb, bool update )
+{
+    sharedLockT lock( m_calMutex );
+
+    mtxL_load_colorbar( cb, update, lock );
+}
+
 rtimv::colorbar rtimvClientBase::colorbar()
 {
     return m_colorbar;

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -504,6 +504,14 @@ class rtimvClientBase : public mx::app::application
                              const sharedLockT &lock /**< [in] a lock on m_calMutex */
     );
 
+    /// Set the color bar
+    /**
+     * This takes a shared lock on m_calMutex, then loads the color bar specified and (optionally) updates the image
+     */
+    void mtxUL_load_colorbar( rtimv::colorbar cb, /**< [in] the new color bar */
+                              bool update         /**< [in] whether or not to update the image*/
+    );
+
     rtimv::colorbar colorbar();
 
     ///@}


### PR DESCRIPTION
Work done by GPT-5.3-codex

## Summary

This PR cleans up `rtimvControlPanel` documentation/style and simplifies mutex usage from the control panel side.

### Documentation and style updates
- Added/normalized declaration-level docs in `rtimvControlPanel.hpp`, including slots/signals.
- Added file-level header documentation and updated include guard/include card style.
- Ensured declaration spacing/readability (blank lines between declarations).
- Renamed control panel member variables to `m_` style consistently.

### Mutex/API refactor
- Removed `m_calMutex` ownership from `rtimvControlPanel`.
- Added `rtimvMainWindow::mtxUL_setViewCen(...)`:
  - acquires `m_calMutex` internally
  - delegates to existing `mtxL_setViewCen(...)`.
- Updated control panel view-center actions to call `mtxUL_setViewCen(...)`.
- Switched colorbar change path in control panel to `mtxUL_load_colorbar(...)`.
- Updated `rtimvMainWindow` control panel construction to match new constructor signature.

### Client/base API completion
- Added missing `mtxUL_load_colorbar(...)` declaration + implementation in `rtimvClientBase`.
- Verified `rtimvBase` already had `mtxUL_load_colorbar(...)` declaration + implementation.

## Files touched

- `src/gui/rtimvControlPanel.hpp`
- `src/gui/rtimvControlPanel.cpp`
- `src/gui/rtimvMainWindow.hpp`
- `src/gui/rtimvMainWindow.cpp`
- `src/server/rtimvClientBase.hpp`
- `src/server/rtimvClientBase.cpp`

## Validation

- Builds successfully.
- Manual testing completed; behavior works as expected.
