### PR TITLE
Add cube-control RPCs and image-state synchronization updates

### DIFF
--- a/agent_context.md
+++ b/agent_context.md
@@ -50,6 +50,16 @@ Follow these code style and documentation rules exactly.
 - Ensure docs and naming are consistent after formatting.
 - Report any places where project style is ambiguous before making assumptions.
 
+10) gRPC Reactor Conventions
+- For unary reactors, use `static_cast<void>(...)` for intentionally unused parameters.
+- For image-dependent modification RPCs, guard with `if( !imageTh->connected() )` and return `Status::OK` early.
+- Keep image modification RPC declarations grouped after `ImagePlease` in `rtimv.proto` and corresponding server/client files.
+
+11) Client/Server State Synchronization
+- Treat `Image` as the authoritative state sync payload for frequently changing backend state.
+- When practical, include configuration/state fields in `Image` so clients can refresh passively on each `ImagePlease` response.
+- Prefer updating local cached client state from received `Image` fields instead of immediately mirroring local writes after set-RPC calls.
+
 When you finish:
 - Summarize what changed.
 - List affected files.

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -1,3 +1,10 @@
+/** \file rtimvBase.cpp
+ * \brief Definitions for the rtimvBase class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include "rtimvBase.hpp"
 #include "rtimvBaseObject.hpp"
 
@@ -1307,7 +1314,7 @@ void rtimvBase::mtxUL_autoScale( bool as )
         // On a change to true we trigger a re-color
         if( m_autoScale == true )
         {
-            //This changes us out of user mode
+            // This changes us out of user mode
             if( m_colormode == rtimv::colormode::user )
             {
                 m_colormode = rtimv::colormode::minmaxglobal;

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -690,6 +690,11 @@ void rtimvBase::cubeDir( int dir )
     m_foundation->emit_cubeDirUpdated( m_cubeDir );
 }
 
+int rtimvBase::cubeDir()
+{
+    return m_cubeDir;
+}
+
 void rtimvBase::cubeFrame( uint32_t fno )
 {
     if( m_images[0] != nullptr )

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -345,6 +345,9 @@ class rtimvBase : public mx::app::application
      */
     void cubeDir( int dir /**< [in] the new cube direction*/ );
 
+    /// Get the cube direction
+    int cubeDir();
+
     /// Set the current cube frame
     void cubeFrame( uint32_t fno /**< [in] the new frame number*/ );
 

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -769,7 +769,7 @@ class rtimvBase : public mx::app::application
     /**
      * The cal mutex must be unlocked before calling
      */
-    void mtxUL_autoScale(bool as /**< [in] the new value of the auto scale flag */);
+    void mtxUL_autoScale( bool as /**< [in] the new value of the auto scale flag */ );
 
     /// Get the auto scale flag value
     /**

--- a/src/common/rtimvBaseObject.cpp
+++ b/src/common/rtimvBaseObject.cpp
@@ -1,3 +1,10 @@
+/** \file rtimvBaseObject.cpp
+ * \brief Definitions for the rtimvBaseObject class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include "rtimvBaseObject.hpp"
 
 // #include "rtimvBase.hpp"
@@ -164,7 +171,6 @@ void rtimvBaseObject::updateCubeFrame()
     m_parent->updateCubeFrame();
 }
 
-
 void rtimvBaseObject::emit_ImageNeeded()
 {
     emit ImageNeeded();
@@ -221,6 +227,4 @@ void rtimvBaseObject::ImageReceived()
 
     #endif
     // clang-format on
-
 }
-

--- a/src/common/rtimvBaseObject.cpp
+++ b/src/common/rtimvBaseObject.cpp
@@ -130,12 +130,18 @@ void rtimvBaseObject::cubeFrameDelta( int32_t dfno )
 
 void rtimvBaseObject::updateImages()
 {
+    // clang-format off
+    #ifndef RTIMV_GRPC
+
     if( !m_parent )
     {
         return;
     }
 
     m_parent->updateImages();
+
+    #endif
+    // clang-format on
 }
 
 void rtimvBaseObject::updateCube()

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -16,6 +16,8 @@ service rtimv
 
     rpc SetMaxScale(ScaleRequest) returns (ScaleResponse);
 
+    rpc SetImageTimeout(ImageTimeoutRequest) returns (ImageTimeoutResponse);
+
     rpc Restretch(RestretchRequest) returns (RestretchResponse);
 
     rpc SetAutoscale(AutoscaleRequest) returns (AutoscaleResponse);
@@ -27,6 +29,10 @@ service rtimv
     rpc SetApplySatMask(ApplySatMaskRequest) returns (ApplySatMaskResponse);
 
     rpc ImagePlease(ImageRequest) returns (Image);
+
+    rpc UpdateCube(UpdateCubeRequest) returns (UpdateCubeResponse);
+
+    rpc CubeFrameDelta(CubeFrameDeltaRequest) returns (CubeFrameDeltaResponse);
 
     rpc GetPixel(Coord) returns(Pixel);
 
@@ -151,6 +157,15 @@ message ScaleResponse
 {
 }
 
+message ImageTimeoutRequest
+{
+    int32 timeout = 1;
+}
+
+message ImageTimeoutResponse
+{
+}
+
 message RestretchRequest
 {
 }
@@ -192,6 +207,23 @@ message ApplySatMaskRequest
 }
 
 message ApplySatMaskResponse
+{
+}
+
+message UpdateCubeRequest
+{
+}
+
+message UpdateCubeResponse
+{
+}
+
+message CubeFrameDeltaRequest
+{
+    int32 delta = 1;
+}
+
+message CubeFrameDeltaResponse
 {
 }
 
@@ -240,6 +272,8 @@ message Image
 //    bool apply_flat = 155;
     bool apply_mask = 160;
     bool apply_sat_mask = 165;
+
+    int32 image_timeout = 170;
 }
 
 message Coord

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -30,11 +30,17 @@ service rtimv
 
     rpc ImagePlease(ImageRequest) returns (Image);
 
+    rpc CubeDir(CubeDirRequest) returns (CubeDirResponse);
+
+    rpc CubeFrame(CubeFrameRequest) returns (CubeFrameResponse);
+
     rpc UpdateCube(UpdateCubeRequest) returns (UpdateCubeResponse);
 
     rpc CubeFrameDelta(CubeFrameDeltaRequest) returns (CubeFrameDeltaResponse);
 
     rpc GetPixel(Coord) returns(Pixel);
+
+    rpc GetImageNo(ImageNoRequest) returns (ImageNoResponse);
 
     rpc ColorBox(Box) returns (MinvalMaxval);
 
@@ -218,6 +224,24 @@ message UpdateCubeResponse
 {
 }
 
+message CubeDirRequest
+{
+    int32 dir = 1;
+}
+
+message CubeDirResponse
+{
+}
+
+message CubeFrameRequest
+{
+    uint32 frame = 1;
+}
+
+message CubeFrameResponse
+{
+}
+
 message CubeFrameDeltaRequest
 {
     int32 delta = 1;
@@ -274,6 +298,7 @@ message Image
     bool apply_sat_mask = 165;
 
     int32 image_timeout = 170;
+    int32 cube_dir = 175;
 }
 
 message Coord
@@ -286,6 +311,17 @@ message Pixel
 {
     bool valid = 1;
     float value = 2;
+}
+
+message ImageNoRequest
+{
+    uint32 image = 1;
+}
+
+message ImageNoResponse
+{
+    bool valid = 1;
+    uint32 no = 2;
 }
 
 message MinvalMaxval

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -1,3 +1,10 @@
+/** \file rtimvClientBase.cpp
+ * \brief Definitions for the rtimvClientBase class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include "rtimvClientBase.hpp"
 #include "rtimvColorGRPC.hpp"
 
@@ -1021,7 +1028,6 @@ void rtimvClientBase::setCurrImageTimeout()
         m_cubeFPS = 0;
 
         m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
-
     }
     else // it's a cube, cube mode is on, and FPS > 0
     {
@@ -1064,7 +1070,6 @@ void rtimvClientBase::setCurrImageTimeout()
 
         m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
     }
-
 }
 
 void rtimvClientBase::imageTimeout( int to )

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -560,6 +560,7 @@ void rtimvClientBase::ImageReceived()
     double imageTime;
     uint32_t saturated;
     float minsc, maxsc, minim, maxim;
+    int imageTimeout;
 
     remote_rtimv::Colorbar colorbar;
     remote_rtimv::Colormode colormode;
@@ -569,6 +570,7 @@ void rtimvClientBase::ImageReceived()
     bool subtractDark;
     bool applyMask;
     bool applySatMask;
+    bool hasImagePayload{ false };
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
@@ -605,8 +607,11 @@ void rtimvClientBase::ImageReceived()
             m_qim = new QImage;
         }
 
-        m_qim->loadFromData(
-            reinterpret_cast<const uchar *>( m_grpcImage.image().data() ), m_grpcImage.image().size(), "jpeg" );
+        if( m_grpcImage.image().size() > 0 )
+        {
+            hasImagePayload = m_qim->loadFromData(
+                reinterpret_cast<const uchar *>( m_grpcImage.image().data() ), m_grpcImage.image().size(), "jpeg" );
+        }
 
         imageTime = m_grpcImage.atime();
         fpsEst = m_grpcImage.fps();
@@ -627,6 +632,8 @@ void rtimvClientBase::ImageReceived()
         subtractDark = m_grpcImage.subtract_dark();
         applyMask = m_grpcImage.apply_mask();
         applySatMask = m_grpcImage.apply_sat_mask();
+
+        imageTimeout = m_grpcImage.image_timeout();
     }
 
     std::shared_mutex dummy; // Used just to satisfy the requirement, not needed
@@ -667,14 +674,22 @@ void rtimvClientBase::ImageReceived()
     m_subtractDark = subtractDark;
     m_applyMask = applyMask;
     m_applySatMask = applySatMask;
+    m_imageTimeout = imageTimeout;
 
-    mtxL_postRecolor( ulock );
+    if( hasImagePayload )
+    {
+        mtxL_postRecolor( ulock );
 
-    ulock.unlock();
-    sharedLockT slock( dummy );
-    mtxL_postChangeImdata( slock );
+        ulock.unlock();
+        sharedLockT slock( dummy );
+        mtxL_postChangeImdata( slock );
+    }
+    else
+    {
+        ulock.unlock();
+    }
 
-    if( resized )
+    if( resized && hasImagePayload )
     {
         // Always switch to zoom 1 after a resize occurs
         zoomLevel( 1 );
@@ -713,7 +728,7 @@ void rtimvClientBase::ImagePlease_callback( grpc::Status status )
             }
             else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_TIMEOUT )
             {
-                action = 1;
+                action = 0;
             }
             else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_NOT_CONFIGURED )
             {
@@ -874,7 +889,20 @@ void rtimvClientBase::cubeFrame( uint32_t fno )
 
 void rtimvClientBase::cubeFrameDelta( int32_t dfno )
 {
-    // send to server
+    SHARED_CONN_LOCK
+
+    remote_rtimv::CubeFrameDeltaRequest request;
+    remote_rtimv::CubeFrameDeltaResponse response;
+    grpc::ClientContext context;
+
+    request.set_delta( dfno );
+
+    grpc::Status status = stub_->CubeFrameDelta( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
 }
 
 void rtimvClientBase::updateImages()
@@ -888,17 +916,41 @@ void rtimvClientBase::updateImages()
 
 void rtimvClientBase::updateCube()
 {
-    // send to server
+    SHARED_CONN_LOCK
+
+    remote_rtimv::UpdateCubeRequest request;
+    remote_rtimv::UpdateCubeResponse response;
+    grpc::ClientContext context;
+
+    grpc::Status status = stub_->UpdateCube( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
 }
 
 void rtimvClientBase::updateCubeFrame()
 {
-    // m_foundation->emit_cubeFrameUpdated( imageNo() );
+    m_foundation->emit_cubeFrameUpdated( imageNo( 0 ) );
 }
 
 void rtimvClientBase::imageTimeout( int to )
 {
-    // send to server
+    SHARED_CONN_LOCK
+
+    remote_rtimv::ImageTimeoutRequest request;
+    remote_rtimv::ImageTimeoutResponse response;
+    grpc::ClientContext context;
+
+    request.set_timeout( to );
+
+    grpc::Status status = stub_->SetImageTimeout( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
 }
 
 int rtimvClientBase::imageTimeout()

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -863,23 +863,36 @@ uint32_t rtimvClientBase::nz()
 
 void rtimvClientBase::cubeMode( bool cm )
 {
-    // send to server
+    m_cubeMode = cm;
+
+    setCurrImageTimeout();
+
+    m_foundation->emit_cubeModeUpdated( m_cubeMode );
 }
 
 void rtimvClientBase::cubeFPS( float fps )
 {
-    // send to server
+    if( fps < 0 )
+    {
+        fps = 0;
+    }
+    m_desiredCubeFPS = fps;
+    setCurrImageTimeout();
+
+    m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
 }
 
 void rtimvClientBase::cubeFPSMult( float mult )
 {
-    // send to server
+    m_cubeFPSMult = mult;
+    setCurrImageTimeout();
+    m_foundation->emit_cubeFPSMultUpdated( m_cubeFPSMult );
 }
 
 void rtimvClientBase::cubeDir( int dir )
 {
     m_cubeDir = dir;
-    // m_foundation->emit_cubeDirUpdated( m_cubeDir );
+    m_foundation->emit_cubeDirUpdated( m_cubeDir );
 }
 
 void rtimvClientBase::cubeFrame( uint32_t fno )
@@ -905,15 +918,6 @@ void rtimvClientBase::cubeFrameDelta( int32_t dfno )
     }
 }
 
-void rtimvClientBase::updateImages()
-{
-    // If we aren't waiting on an image yet, sent ImagePlease
-    /*if( !m_imageWaiting )
-    {
-        ImagePlease();
-    }*/
-}
-
 void rtimvClientBase::updateCube()
 {
     SHARED_CONN_LOCK
@@ -933,6 +937,72 @@ void rtimvClientBase::updateCube()
 void rtimvClientBase::updateCubeFrame()
 {
     m_foundation->emit_cubeFrameUpdated( imageNo( 0 ) );
+}
+
+void rtimvClientBase::setCurrImageTimeout()
+{
+    int cubeTimeout;
+
+    if( m_desiredCubeFPS <= 0 || m_nz <= 1 )
+    {
+        m_foundation->m_cubeTimer.stop();
+
+        if( m_nz <= 1 )
+        {
+            m_foundation->m_cubeFrameUpdateTimer.stop();
+        }
+        else
+        {
+            m_foundation->m_cubeFrameUpdateTimer.start( 250 );
+        }
+
+        m_cubeFPS = 0;
+
+        m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
+
+    }
+    else // it's a cube, cube mode is on, and FPS > 0
+    {
+        // First get our wish
+        cubeTimeout = std::round( 1000. / ( m_desiredCubeFPS * m_cubeFPSMult ) );
+
+        if( cubeTimeout < 1 )
+        {
+            cubeTimeout = 1;
+        }
+
+        if( cubeTimeout < m_imageTimeout )
+        {
+            cubeTimeout = m_imageTimeout;
+        }
+
+        // Now get reality with imageTimeout
+        int f = std::round( ( 1.0 * cubeTimeout ) / m_imageTimeout );
+        if( f <= 0 )
+        {
+            f = 1;
+        }
+
+        // Report reality
+        m_cubeFPS = ( 1000.0 / ( f * m_imageTimeout ) ) / m_cubeFPSMult;
+
+        // Implement reality
+        cubeTimeout = std::round( 1000. / ( m_cubeFPS * m_cubeFPSMult ) );
+
+        if( m_cubeMode )
+        {
+            m_foundation->m_cubeTimer.start( cubeTimeout );
+            m_foundation->m_cubeFrameUpdateTimer.start( 250 );
+        }
+        else
+        {
+            m_cubeFPS = 0;
+            m_foundation->m_cubeTimer.stop();
+        }
+
+        m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
+    }
+
 }
 
 void rtimvClientBase::imageTimeout( int to )

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -556,6 +556,7 @@ void rtimvClientBase::ImageReceived()
     }
 
     uint32_t nx, ny, nz;
+    uint32_t imageNo;
     float fpsEst;
     double imageTime;
     uint32_t saturated;
@@ -570,6 +571,7 @@ void rtimvClientBase::ImageReceived()
     bool subtractDark;
     bool applyMask;
     bool applySatMask;
+    int cubeDir;
     bool hasImagePayload{ false };
 
     { // mutex scope
@@ -585,6 +587,7 @@ void rtimvClientBase::ImageReceived()
         nx = m_grpcImage.nx();
         ny = m_grpcImage.ny();
         nz = m_grpcImage.nz();
+        imageNo = m_grpcImage.no();
 
         // Always have at least one pixel
         if( nx == 0 )
@@ -634,6 +637,7 @@ void rtimvClientBase::ImageReceived()
         applySatMask = m_grpcImage.apply_sat_mask();
 
         imageTimeout = m_grpcImage.image_timeout();
+        cubeDir = m_grpcImage.cube_dir();
     }
 
     std::shared_mutex dummy; // Used just to satisfy the requirement, not needed
@@ -659,6 +663,7 @@ void rtimvClientBase::ImageReceived()
 
     m_fpsEst = fpsEst;
     m_imageTime = imageTime;
+    m_imageNo = imageNo;
     m_saturated = saturated;
     m_minImageData = minim;
     m_maxImageData = maxim;
@@ -675,6 +680,11 @@ void rtimvClientBase::ImageReceived()
     m_applyMask = applyMask;
     m_applySatMask = applySatMask;
     m_imageTimeout = imageTimeout;
+    if( m_cubeDir != cubeDir )
+    {
+        m_cubeDir = cubeDir;
+        m_foundation->emit_cubeDirUpdated( m_cubeDir );
+    }
 
     if( hasImagePayload )
     {
@@ -821,8 +831,35 @@ std::string rtimvClientBase::imageName( size_t n )
 
 uint32_t rtimvClientBase::imageNo( size_t n )
 {
-    // get from server?
-    return 0;
+    if( n == 0 )
+    {
+        return m_imageNo;
+    }
+
+    SHARED_CONN_LOCK_RET( 0 )
+
+    remote_rtimv::ImageNoRequest request;
+    remote_rtimv::ImageNoResponse response;
+    grpc::ClientContext context;
+
+    request.set_image( static_cast<uint32_t>( n ) );
+
+    grpc::Status status = stub_->GetImageNo( &context, request, &response );
+
+    if( status.ok() )
+    {
+        if( !response.valid() )
+        {
+            return 0;
+        }
+
+        return response.no();
+    }
+    else
+    {
+        REPORT_SERVER_DISCONNECTED
+        return 0;
+    }
 }
 
 std::vector<std::string> rtimvClientBase::info( size_t n )
@@ -835,7 +872,7 @@ void rtimvClientBase::mtxL_setImsize( uint32_t x, uint32_t y, uint32_t z, const 
 {
 
     m_nz = z;
-    // m_foundation->emit_nzUpdated( m_nz );
+    m_foundation->emit_nzUpdated( m_nz );
 
     if( m_nx != x || m_ny != y )
     {
@@ -891,13 +928,38 @@ void rtimvClientBase::cubeFPSMult( float mult )
 
 void rtimvClientBase::cubeDir( int dir )
 {
-    m_cubeDir = dir;
-    m_foundation->emit_cubeDirUpdated( m_cubeDir );
+    SHARED_CONN_LOCK
+
+    remote_rtimv::CubeDirRequest request;
+    remote_rtimv::CubeDirResponse response;
+    grpc::ClientContext context;
+
+    request.set_dir( dir );
+
+    grpc::Status status = stub_->CubeDir( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
 }
 
 void rtimvClientBase::cubeFrame( uint32_t fno )
 {
-    // send to server
+    SHARED_CONN_LOCK
+
+    remote_rtimv::CubeFrameRequest request;
+    remote_rtimv::CubeFrameResponse response;
+    grpc::ClientContext context;
+
+    request.set_frame( fno );
+
+    grpc::Status status = stub_->CubeFrame( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
 }
 
 void rtimvClientBase::cubeFrameDelta( int32_t dfno )

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -412,10 +412,6 @@ class rtimvClientBase : public mx::app::application
      * @{
      */
   public:
-    /// Check all images for updates
-    /** This is called on m_imageTimer expiration.
-     */
-    void updateImages();
 
     /// Increment the main image cube number
     /** This is on m_cubeTimer expiration

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -194,6 +194,8 @@ class rtimvClientBase : public mx::app::application
 
     double m_imageTime{ 0 };
 
+    uint32_t m_imageNo{ 0 };
+
     ///@}
 
     /** @name Image Status

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -414,7 +414,6 @@ class rtimvClientBase : public mx::app::application
      * @{
      */
   public:
-
     /// Increment the main image cube number
     /** This is on m_cubeTimer expiration
      */

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -230,6 +230,7 @@ ServerUnaryReactor *rtimvServer::SetColorbar( CallbackServerContext *context,
                                               remote_rtimv::ColorbarResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     rtimv::colorbar cb = rtimv::grpc2colorbar( request->colorbar() );
 
@@ -252,6 +253,7 @@ ServerUnaryReactor *rtimvServer::SetColormode( CallbackServerContext *context,
                                                remote_rtimv::ColormodeResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     rtimv::colormode cm = rtimv::grpc2colormode( request->colormode() );
 
@@ -275,6 +277,7 @@ ServerUnaryReactor *rtimvServer::SetColorstretch( CallbackServerContext *context
                                                   remote_rtimv::ColorstretchResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     rtimv::stretch cs = rtimv::grpc2stretch( request->colorstretch() );
 
@@ -296,6 +299,7 @@ ServerUnaryReactor *rtimvServer::SetMinScale( CallbackServerContext *context,
                                               remote_rtimv::ScaleResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->minScaleData( request->value() );
 
@@ -308,6 +312,7 @@ ServerUnaryReactor *rtimvServer::SetMaxScale( CallbackServerContext *context,
                                               remote_rtimv::ScaleResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->maxScaleData( request->value() );
 
@@ -320,6 +325,7 @@ ServerUnaryReactor *rtimvServer::SetImageTimeout( CallbackServerContext *context
                                                   remote_rtimv::ImageTimeoutResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->imageTimeout( request->timeout() );
 
@@ -332,6 +338,8 @@ ServerUnaryReactor *rtimvServer::Restretch( CallbackServerContext *context,
                                             remote_rtimv::RestretchResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( request );
+    static_cast<void>( reply );
 
     imageTh->mtxUL_reStretch();
 
@@ -344,6 +352,7 @@ ServerUnaryReactor *rtimvServer::SetAutoscale( CallbackServerContext *context,
                                              remote_rtimv::AutoscaleResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->mtxUL_autoScale( request->autoscale() );
 
@@ -356,6 +365,7 @@ ServerUnaryReactor *rtimvServer::SetSubDark( CallbackServerContext *context,
                                              remote_rtimv::SubDarkResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->subtractDark( request->subtract_dark() );
 
@@ -368,6 +378,7 @@ ServerUnaryReactor *rtimvServer::SetApplyMask( CallbackServerContext *context,
                                                remote_rtimv::ApplyMaskResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->applyMask( request->apply_mask() );
 
@@ -380,6 +391,7 @@ ServerUnaryReactor *rtimvServer::SetApplySatMask( CallbackServerContext *context
                                                   remote_rtimv::ApplySatMaskResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
 
     imageTh->applySatMask( request->apply_sat_mask() );
 
@@ -392,6 +404,7 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
                                               remote_rtimv::Image *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( request );
 
     // Check if image has been found
     if( !imageTh->connected() )
@@ -451,6 +464,7 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         reply->set_apply_sat_mask( imageTh->applySatMask() );
 
         reply->set_image_timeout( imageTh->imageTimeout() );
+        reply->set_cube_dir( imageTh->cubeDir() );
     };
 
     if( imageTh->newImage() == false )
@@ -498,6 +512,44 @@ ServerUnaryReactor *rtimvServer::UpdateCube( CallbackServerContext *context,
     }
 
     imageTh->updateCube();
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::CubeDir( CallbackServerContext *context,
+                                          const remote_rtimv::CubeDirRequest *request,
+                                          remote_rtimv::CubeDirResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    if( !imageTh->connected() )
+    {
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    imageTh->cubeDir( request->dir() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::CubeFrame( CallbackServerContext *context,
+                                            const remote_rtimv::CubeFrameRequest *request,
+                                            remote_rtimv::CubeFrameResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    if( !imageTh->connected() )
+    {
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    imageTh->cubeFrame( request->frame() );
 
     reactor->Finish( Status::OK );
     return reactor;
@@ -556,6 +608,37 @@ rtimvServer::GetPixel( CallbackServerContext *context, const remote_rtimv::Coord
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::GetImageNo( CallbackServerContext *context,
+                                             const remote_rtimv::ImageNoRequest *request,
+                                             remote_rtimv::ImageNoResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+
+    // Check if image has been found
+    if( !imageTh->connected() )
+    {
+        reply->set_valid( false );
+        reply->set_no( 0 );
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    uint32_t n = request->image();
+    if( n >= imageTh->nz() )
+    {
+        reply->set_valid( false );
+        reply->set_no( 0 );
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    reply->set_valid( true );
+    reply->set_no( imageTh->imageNo( n ) );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::ColorBox( CallbackServerContext *context,
                                            const remote_rtimv::Box *request,
                                            remote_rtimv::MinvalMaxval *reply )
@@ -593,6 +676,8 @@ ServerUnaryReactor *rtimvServer::Recolor( CallbackServerContext *context,
                                           remote_rtimv::RecolorResponse *reply )
 {
     PREPARE_RPC_REACTOR
+    static_cast<void>( request );
+    static_cast<void>( reply );
 
     imageTh->mtxUL_recolor();
 

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -315,6 +315,18 @@ ServerUnaryReactor *rtimvServer::SetMaxScale( CallbackServerContext *context,
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::SetImageTimeout( CallbackServerContext *context,
+                                                  const remote_rtimv::ImageTimeoutRequest *request,
+                                                  remote_rtimv::ImageTimeoutResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+
+    imageTh->imageTimeout( request->timeout() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::Restretch( CallbackServerContext *context,
                                             const remote_rtimv::RestretchRequest *request,
                                             remote_rtimv::RestretchResponse *reply )
@@ -410,9 +422,41 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         ++nwaits;
     }
 
+    auto populateImageState = [imageTh, reply]() {
+        reply->set_nx( imageTh->nx() );
+        reply->set_ny( imageTh->ny() );
+        reply->set_nz( imageTh->nz() );
+        reply->set_no( imageTh->imageNo( 0 ) );
+
+        reply->set_atime( imageTh->imageTime() );
+        reply->set_fps( imageTh->fpsEst() );
+
+        reply->set_saturated( imageTh->saturated() );
+
+        reply->set_min_image_data( imageTh->minImageData() );
+        reply->set_max_image_data( imageTh->maxImageData() );
+        reply->set_min_scale_data( imageTh->minScaleData() );
+        reply->set_max_scale_data( imageTh->maxScaleData() );
+
+        reply->set_colorbar( rtimv::colorbar2grpc( imageTh->colorbar() ) );
+
+        reply->set_colormode( rtimv::colormode2grpc( imageTh->colormode() ) );
+
+        reply->set_colorstretch( rtimv::stretch2grpc( imageTh->stretch() ) );
+
+        reply->set_autoscale( imageTh->autoScale() );
+
+        reply->set_subtract_dark( imageTh->subtractDark() );
+        reply->set_apply_mask( imageTh->applyMask() );
+        reply->set_apply_sat_mask( imageTh->applySatMask() );
+
+        reply->set_image_timeout( imageTh->imageTimeout() );
+    };
+
     if( imageTh->newImage() == false )
     {
         reply->set_status( remote_rtimv::IMAGE_STATUS_TIMEOUT );
+        populateImageState();
         std::string *im = new std::string;
         reply->set_allocated_image( im );
 
@@ -430,37 +474,51 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
     imageTh->lastRequest( -1 ); // sets to now, again b/c of wait
 
     reply->set_status( remote_rtimv::IMAGE_STATUS_VALID );
-    reply->set_nx( imageTh->nx() );
-    reply->set_ny( imageTh->ny() );
-    reply->set_nz( imageTh->nz() );
-    reply->set_no( imageTh->imageNo( 0 ) );
-
-    reply->set_atime( imageTh->imageTime() );
-    reply->set_fps( imageTh->fpsEst() );
+    populateImageState();
 
     reply->set_allocated_image( im );
 
-    reply->set_saturated( imageTh->saturated() );
-
-    reply->set_min_image_data( imageTh->minImageData() );
-    reply->set_max_image_data( imageTh->maxImageData() );
-    reply->set_min_scale_data( imageTh->minScaleData() );
-    reply->set_max_scale_data( imageTh->maxScaleData() );
-
-    reply->set_colorbar( rtimv::colorbar2grpc( imageTh->colorbar() ) );
-
-    reply->set_colormode( rtimv::colormode2grpc( imageTh->colormode() ) );
-
-    reply->set_colorstretch( rtimv::stretch2grpc( imageTh->stretch() ) );
-
-    reply->set_autoscale( imageTh->autoScale());
-
-    reply->set_subtract_dark( imageTh->subtractDark() );
-    reply->set_apply_mask( imageTh->applyMask() );
-    reply->set_apply_sat_mask( imageTh->applySatMask() );
-
     reactor->Finish( Status::OK );
 
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::UpdateCube( CallbackServerContext *context,
+                                             const remote_rtimv::UpdateCubeRequest *request,
+                                             remote_rtimv::UpdateCubeResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( request );
+    static_cast<void>( reply );
+
+    if( !imageTh->connected() )
+    {
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    imageTh->updateCube();
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::CubeFrameDelta( CallbackServerContext *context,
+                                                 const remote_rtimv::CubeFrameDeltaRequest *request,
+                                                 remote_rtimv::CubeFrameDeltaResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    if( !imageTh->connected() )
+    {
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    imageTh->cubeFrameDelta( request->delta() );
+
+    reactor->Finish( Status::OK );
     return reactor;
 }
 

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -1,3 +1,10 @@
+/** \file rtimvServer.cpp
+ * \brief Definitions for the rtimvServer class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include "rtimvServer.hpp"
 
 // The boilerplate preparation for responding to an rpc
@@ -27,7 +34,6 @@
     {                                                                                                                  \
         imageTh->emit_awaken();                                                                                        \
     }
-
 
 rtimvServer::rtimvServer( int argc, char **argv, QObject *Parent ) : QObject( Parent )
 {
@@ -348,8 +354,8 @@ ServerUnaryReactor *rtimvServer::Restretch( CallbackServerContext *context,
 }
 
 ServerUnaryReactor *rtimvServer::SetAutoscale( CallbackServerContext *context,
-                                             const remote_rtimv::AutoscaleRequest *request,
-                                             remote_rtimv::AutoscaleResponse *reply )
+                                               const remote_rtimv::AutoscaleRequest *request,
+                                               remote_rtimv::AutoscaleResponse *reply )
 {
     PREPARE_RPC_REACTOR
     static_cast<void>( reply );
@@ -435,7 +441,8 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         ++nwaits;
     }
 
-    auto populateImageState = [imageTh, reply]() {
+    auto populateImageState = [imageTh, reply]()
+    {
         reply->set_nx( imageTh->nx() );
         reply->set_ny( imageTh->ny() );
         reply->set_nz( imageTh->nz() );

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -1,4 +1,11 @@
 
+/** \file rtimvServer.hpp
+ * \brief Declarations for the rtimvServer class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #ifndef rtimvServer_hpp
 #define rtimvServer_hpp
 
@@ -171,10 +178,12 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                      const remote_rtimv::ImageRequest *request,
                                      remote_rtimv::Image *reply ) override;
 
+    /// Set the cube playback direction on the server.
     ServerUnaryReactor *CubeDir( CallbackServerContext *context,
                                  const remote_rtimv::CubeDirRequest *request,
                                  remote_rtimv::CubeDirResponse *reply ) override;
 
+    /// Set the cube frame on the server.
     ServerUnaryReactor *CubeFrame( CallbackServerContext *context,
                                    const remote_rtimv::CubeFrameRequest *request,
                                    remote_rtimv::CubeFrameResponse *reply ) override;
@@ -190,6 +199,7 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
     ServerUnaryReactor *
     GetPixel( CallbackServerContext *context, const remote_rtimv::Coord *request, remote_rtimv::Pixel *reply ) override;
 
+    /// Get the image number for a requested image index.
     ServerUnaryReactor *GetImageNo( CallbackServerContext *context,
                                     const remote_rtimv::ImageNoRequest *request,
                                     remote_rtimv::ImageNoResponse *reply ) override;

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -171,6 +171,14 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                      const remote_rtimv::ImageRequest *request,
                                      remote_rtimv::Image *reply ) override;
 
+    ServerUnaryReactor *CubeDir( CallbackServerContext *context,
+                                 const remote_rtimv::CubeDirRequest *request,
+                                 remote_rtimv::CubeDirResponse *reply ) override;
+
+    ServerUnaryReactor *CubeFrame( CallbackServerContext *context,
+                                   const remote_rtimv::CubeFrameRequest *request,
+                                   remote_rtimv::CubeFrameResponse *reply ) override;
+
     ServerUnaryReactor *UpdateCube( CallbackServerContext *context,
                                     const remote_rtimv::UpdateCubeRequest *request,
                                     remote_rtimv::UpdateCubeResponse *reply ) override;
@@ -181,6 +189,10 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
 
     ServerUnaryReactor *
     GetPixel( CallbackServerContext *context, const remote_rtimv::Coord *request, remote_rtimv::Pixel *reply ) override;
+
+    ServerUnaryReactor *GetImageNo( CallbackServerContext *context,
+                                    const remote_rtimv::ImageNoRequest *request,
+                                    remote_rtimv::ImageNoResponse *reply ) override;
 
     ServerUnaryReactor *ColorBox( CallbackServerContext *context,
                                   const remote_rtimv::Box *request,

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -143,6 +143,10 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                      const remote_rtimv::ScaleRequest *request,
                                      remote_rtimv::ScaleResponse *reply ) override;
 
+    ServerUnaryReactor *SetImageTimeout( CallbackServerContext *context,
+                                         const remote_rtimv::ImageTimeoutRequest *request,
+                                         remote_rtimv::ImageTimeoutResponse *reply ) override;
+
     ServerUnaryReactor *Restretch( CallbackServerContext *context,
                                    const remote_rtimv::RestretchRequest *request,
                                    remote_rtimv::RestretchResponse *reply ) override;
@@ -166,6 +170,14 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
     ServerUnaryReactor *ImagePlease( CallbackServerContext *context,
                                      const remote_rtimv::ImageRequest *request,
                                      remote_rtimv::Image *reply ) override;
+
+    ServerUnaryReactor *UpdateCube( CallbackServerContext *context,
+                                    const remote_rtimv::UpdateCubeRequest *request,
+                                    remote_rtimv::UpdateCubeResponse *reply ) override;
+
+    ServerUnaryReactor *CubeFrameDelta( CallbackServerContext *context,
+                                        const remote_rtimv::CubeFrameDeltaRequest *request,
+                                        remote_rtimv::CubeFrameDeltaResponse *reply ) override;
 
     ServerUnaryReactor *
     GetPixel( CallbackServerContext *context, const remote_rtimv::Coord *request, remote_rtimv::Pixel *reply ) override;


### PR DESCRIPTION
Almost all work done by GPT-5.3-codex.

This PR extends the gRPC client/server control surface for cube/image operations and aligns state synchronization so the client updates from `Image` payload state.

### Summary of changes
- Added/implemented RPCs:
  - `CubeDir`
  - `CubeFrame`
  - `UpdateCube`
  - `CubeFrameDelta`
  - `GetImageNo`
- Extended `Image` payload state synchronization:
  - includes backend config/state fields (including `cube_dir`, `image_timeout`, and image number usage for client-side updates).
- Updated client behavior:
  - `rtimvClientBase::imageNo(size_t)` now returns local cached image number for `n==0`, and uses RPC for `n>0`.
  - cube direction is set via RPC and locally refreshed from incoming `Image`.
- Updated server behavior:
  - added corresponding unary reactors.
  - for image-dependent modification RPCs, returns early when image is not connected.
  - ensured unused reactor params use `static_cast<void>(...)`.
- Added `rtimvBase::cubeDir()` getter to support server-side image-state population.
- Documentation/style pass on modified files and `agent_context.md` updates with new task-established conventions.

### Files changed
- `src/proto/rtimv.proto`
- `src/server/rtimvServer.hpp`
- `src/server/rtimvServer.cpp`
- `src/server/rtimvClientBase.hpp`
- `src/server/rtimvClientBase.cpp`
- `src/common/rtimvBase.hpp`
- `src/common/rtimvBase.cpp`
- `src/common/rtimvBaseObject.cpp`
- `agent_context.md`

### Verification
- Built successfully:
  - `cmake --build _build -j4 --target rtimvServer rtimvClient`

### Commits
- `986f086` Add CubeDir RPC and sync cube/image state over Image payload
- `0aa4a11` Apply doc/style pass for branch changes and extend agent context
