### PR TITLE
Add image filtering pipeline, gRPC controls, Filters UI tab, and update-path optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ install( EXPORT rtimv-sharedTargets
 
 set( commonsrcs src/common/rtimvBaseObject.cpp
                              src/common/rtimvBase.cpp
+                             src/common/rtimvFilters.cpp
                              src/common/images/shmimImage.cpp
                              src/common/images/mzmqImage.cpp
                              src/common/images/fitsImage.cpp

--- a/agent_context.md
+++ b/agent_context.md
@@ -60,6 +60,19 @@ Follow these code style and documentation rules exactly.
 - When practical, include configuration/state fields in `Image` so clients can refresh passively on each `ImagePlease` response.
 - Prefer updating local cached client state from received `Image` fields instead of immediately mirroring local writes after set-RPC calls.
 
+12) Doxygen Named Section Ordering
+- For classes that expose configuration via member data + accessors, keep named sections split into:
+  - `... - Data` for protected/private member state
+  - `...` (without `- Data`) for public access functions
+- Place the `... - Data` section before the corresponding public accessor section.
+
+13) Base/Client Interface Parity
+- Keep `rtimvBase` and `rtimvClientBase` documentation and section structure highly aligned when they implement the same conceptual interface.
+- If one side intentionally lacks working-memory members (e.g., server-only processing buffers), add an explicit note documenting why.
+
+14) Header Declaration Parameter Docs
+- In headers, prefer inline parameter documentation on declarations (`type name /**< ... */`) rather than separate `\param` lists, unless there is a specific reason to deviate.
+
 When you finish:
 - Summarize what changed.
 - List affected files.

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -28,6 +28,25 @@ rtimvBase::rtimvBase()
 
 rtimvBase::~rtimvBase()
 {
+    if( m_calDataRaw != nullptr )
+    {
+        delete[] m_calDataRaw;
+        m_calDataRaw = nullptr;
+        m_calData = nullptr;
+    }
+
+    if( m_satData != nullptr )
+    {
+        delete[] m_satData;
+        m_satData = nullptr;
+    }
+
+    if( m_qim != nullptr )
+    {
+        delete m_qim;
+        m_qim = nullptr;
+    }
+
     for( size_t n = 0; n < m_images.size(); ++n )
     {
         if( m_images[n] )
@@ -511,15 +530,15 @@ void rtimvBase::mtxL_setImsize( uint32_t x, uint32_t y, uint32_t z, const unique
     m_nz = z;
     m_foundation->emit_nzUpdated( m_nz );
 
-    if( m_nx != x || m_ny != y || m_calData == 0 || m_qim == 0 )
+    if( m_nx != x || m_ny != y || m_calDataRaw == nullptr || m_qim == nullptr )
     {
         m_nx = x;
         m_ny = y;
 
-        if( m_calData != nullptr )
+        if( m_calDataRaw != nullptr )
         {
-            delete[] m_calData;
-            m_calData = nullptr;
+            delete[] m_calDataRaw;
+            m_calDataRaw = nullptr;
         }
 
         if( m_satData != nullptr )
@@ -528,7 +547,8 @@ void rtimvBase::mtxL_setImsize( uint32_t x, uint32_t y, uint32_t z, const unique
             m_satData = nullptr;
         }
 
-        m_calData = new float[m_nx * m_ny];
+        m_calDataRaw = new float[m_nx * m_ny];
+        m_calData = m_calDataRaw;
         m_satData = new uint8_t[m_nx * m_ny];
 
         if( m_qim != nullptr )
@@ -803,36 +823,136 @@ void rtimvBase::subtractDark( bool sd )
     if( sd != m_subtractDark )
     {
         m_subtractDark = sd;
-        mtxUL_changeImdata(); // have to trigger refresh of cal data
+        mtxUL_changeImdata(); // Recompute calibrated/filtered data after calibration changes.
     }
 }
+
 bool rtimvBase::subtractDark()
 {
     return m_subtractDark;
 }
+
 void rtimvBase::applyMask( bool amsk )
 {
     if( amsk != m_applyMask )
     {
         m_applyMask = amsk;
-        mtxUL_changeImdata(); // have to trigger refresh of cal data
+        mtxUL_changeImdata(); // Recompute calibrated/filtered data after calibration changes.
     }
 }
+
 bool rtimvBase::applyMask()
 {
     return m_applyMask;
 }
+
 void rtimvBase::applySatMask( bool asmsk )
 {
     if( asmsk != m_applySatMask )
     {
         m_applySatMask = asmsk;
-        mtxUL_changeImdata(); // have to trigger refresh of cal data
+        mtxUL_changeImdata(); // Recompute calibrated/filtered data after calibration changes.
     }
 }
+
 bool rtimvBase::applySatMask()
 {
     return m_applySatMask;
+}
+
+// Filter setting changes are applied immediately to the current frame.
+void rtimvBase::hpFilter( rtimv::hpFilter filter )
+{
+    if( filter != m_hpFilter )
+    {
+        m_hpFilter = filter;
+        mtxUL_changeImdata();
+    }
+}
+
+rtimv::hpFilter rtimvBase::hpFilter()
+{
+    return m_hpFilter;
+}
+
+void rtimvBase::hpfFW( float fw )
+{
+    if( fw < 0 )
+    {
+        fw = 0;
+    }
+
+    if( fw != m_hpfFW )
+    {
+        m_hpfFW = fw;
+        mtxUL_changeImdata();
+    }
+}
+
+float rtimvBase::hpfFW()
+{
+    return m_hpfFW;
+}
+
+void rtimvBase::applyHPFilter( bool apply )
+{
+    if( apply != m_applyHPFilter )
+    {
+        m_applyHPFilter = apply;
+        mtxUL_changeImdata();
+    }
+}
+
+bool rtimvBase::applyHPFilter()
+{
+    return m_applyHPFilter;
+}
+
+void rtimvBase::lpFilter( rtimv::lpFilter filter )
+{
+    if( filter != m_lpFilter )
+    {
+        m_lpFilter = filter;
+        mtxUL_changeImdata();
+    }
+}
+
+rtimv::lpFilter rtimvBase::lpFilter()
+{
+    return m_lpFilter;
+}
+
+void rtimvBase::lpfFW( float fw )
+{
+    if( fw < 0 )
+    {
+        fw = 0;
+    }
+
+    if( fw != m_lpfFW )
+    {
+        m_lpfFW = fw;
+        mtxUL_changeImdata();
+    }
+}
+
+float rtimvBase::lpfFW()
+{
+    return m_lpfFW;
+}
+
+void rtimvBase::applyLPFilter( bool apply )
+{
+    if( apply != m_applyLPFilter )
+    {
+        m_applyLPFilter = apply;
+        mtxUL_changeImdata();
+    }
+}
+
+bool rtimvBase::applyLPFilter()
+{
+    return m_applyLPFilter;
 }
 
 rtimvBase::pixelF rtimvBase::rawPixel()
@@ -887,29 +1007,47 @@ rtimvBase::pixelF rtimvBase::rawPixel()
     {
 
         if( m_images[1] == nullptr && m_images[2] == nullptr )
+        {
             return _pixel;
+        }
         else if( m_images[2] == nullptr )
         {
             if( m_images[1]->nx() != m_images[0]->nx() || m_images[1]->ny() != m_images[0]->ny() )
+            {
                 return _pixel;
+            }
+
             if( m_images[1]->valid() )
+            {
                 _pixel = &pixel_subDark;
+            }
         }
         else if( m_images[1] == nullptr )
         {
             if( m_images[2]->nx() != m_images[0]->nx() || m_images[2]->ny() != m_images[0]->ny() )
+            {
                 return _pixel;
+            }
+
             if( m_images[2]->valid() )
+            {
                 _pixel = &pixel_applyMask;
+            }
         }
         else
         {
             if( m_images[1]->nx() != m_images[0]->nx() || m_images[1]->ny() != m_images[0]->ny() )
+            {
                 return _pixel;
+            }
             if( m_images[2]->nx() != m_images[0]->nx() || m_images[2]->ny() != m_images[0]->ny() )
+            {
                 return _pixel;
+            }
             if( m_images[1]->valid() && m_images[2]->valid() )
+            {
                 _pixel = &pixel_subDarkApplyMask;
+            }
         }
     }
 
@@ -1514,7 +1652,7 @@ void rtimvBase::mtxUL_changeImdata()
             }
 
             // Fill in calibrated value
-            m_calData[n] = _pixel( this, n );
+            m_calDataRaw[n] = _pixel( this, n );
         }
 
         RTIMV_DEBUG_BREADCRUMB
@@ -1551,12 +1689,24 @@ void rtimvBase::mtxUL_changeImdata()
             return;
         }
 
-        RTIMV_DEBUG_BREADCRUMB
-
-        // At this point the raw data has been copied out to calData.
+        // At this point the raw data has been copied into m_calDataRaw.
         // We have released the raw data mutex (rawlock).
         // We shared_lock the caldata mutex to make sure a subsequent call
-        // from a different thread doesn't delete m_calData.
+        // from a different thread doesn't delete the raw allocation.
+
+        RTIMV_DEBUG_BREADCRUMB
+
+        // Filter if desired
+
+        if( m_applyHPFilter || m_applyLPFilter )
+        {
+            mtxL_applyFilter();
+            //m_calData is assigned in applyFilter
+        }
+        else
+        {
+            m_calData = m_calDataRaw;
+        }
 
         RTIMV_DEBUG_BREADCRUMB
 
@@ -1684,6 +1834,36 @@ void rtimvBase::mtxUL_changeImdata()
     RTIMV_DEBUG_BREADCRUMB
 
 } // void rtimvBase::mtxUL_changeImdata()
+
+void rtimvBase::mtxL_applyFilter()
+{
+    if( !( m_applyHPFilter || m_applyLPFilter ) )
+    {
+        m_calData = m_calDataRaw;
+        return;
+    }
+
+    mx::improc::eigenMap<float> imin( m_calDataRaw, m_nx, m_ny );
+
+    if( m_applyHPFilter )
+    {
+        rtimv::applyHPFilter( m_hpFiltered, imin, m_hpFilter, m_hpfFW, m_filterWork );
+        if( m_applyLPFilter )
+        {
+            rtimv::applyLPFilter( m_lpFiltered, m_hpFiltered, m_lpFilter, m_lpfFW );
+            m_calData = m_lpFiltered.data();
+        }
+        else
+        {
+            m_calData = m_hpFiltered.data();
+        }
+    }
+    else
+    {
+        rtimv::applyLPFilter( m_lpFiltered, imin, m_lpFilter, m_lpfFW );
+        m_calData = m_lpFiltered.data();
+    }
+}
 
 void rtimvBase::mtxL_recolorImpl()
 {

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -851,7 +851,7 @@ void rtimvBase::applySatMask( bool asmsk )
     if( asmsk != m_applySatMask )
     {
         m_applySatMask = asmsk;
-        mtxUL_changeImdata(); // Recompute calibrated/filtered data after calibration changes.
+        mtxUL_recolor(); // Saturation-mask display is a recolor-only change.
     }
 }
 
@@ -866,7 +866,7 @@ void rtimvBase::hpFilter( rtimv::hpFilter filter )
     if( filter != m_hpFilter )
     {
         m_hpFilter = filter;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -885,7 +885,7 @@ void rtimvBase::hpfFW( float fw )
     if( fw != m_hpfFW )
     {
         m_hpfFW = fw;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -899,7 +899,7 @@ void rtimvBase::applyHPFilter( bool apply )
     if( apply != m_applyHPFilter )
     {
         m_applyHPFilter = apply;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -913,7 +913,7 @@ void rtimvBase::lpFilter( rtimv::lpFilter filter )
     if( filter != m_lpFilter )
     {
         m_lpFilter = filter;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -932,7 +932,7 @@ void rtimvBase::lpfFW( float fw )
     if( fw != m_lpfFW )
     {
         m_lpfFW = fw;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -946,7 +946,7 @@ void rtimvBase::applyLPFilter( bool apply )
     if( apply != m_applyLPFilter )
     {
         m_applyLPFilter = apply;
-        mtxUL_changeImdata();
+        mtxUL_changeImdata( false );
     }
 }
 
@@ -1577,7 +1577,7 @@ uint8_t rtimvBase::lightness( int x, int y )
     return lightness( n );
 }
 
-void rtimvBase::mtxUL_changeImdata()
+void rtimvBase::mtxUL_changeImdata( bool newdata )
 {
     RTIMV_DEBUG_BREADCRUMB
 
@@ -1592,6 +1592,7 @@ void rtimvBase::mtxUL_changeImdata()
 
     bool resized = false;
 
+    if( newdata )
     { // mutex scope
 
         // Get a unique lock on the cal data to allow us to delete it and overwrite it

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -892,8 +892,10 @@ class rtimvBase : public mx::app::application
                        int y  /**< [in] the y location of the pixel */
     );
 
-    /// Updates the QImage and basic statistics after a new image.
-    void mtxUL_changeImdata();
+    /// Updates filtered data, the QImage, and basic statistics.
+    /** When \p newdata is false, raw calibrated pixels in \ref m_calDataRaw are reused.
+     */
+    void mtxUL_changeImdata( bool newdata = true /**< [in] true to repopulate \ref m_calDataRaw */ );
 
     /// Apply configured high-pass/low-pass filters and update \ref m_calData.
     /** Called with \ref m_calMutex in shared-lock context from \ref mtxUL_changeImdata.

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -19,6 +19,7 @@
 #include "rtimvImage.hpp"
 #include "colorMaps.hpp"
 #include "rtimvColor.hpp"
+#include "rtimvFilters.hpp"
 
 #include "rtimvBaseObject.hpp"
 
@@ -238,7 +239,7 @@ class rtimvBase : public mx::app::application
      */
 
     /// Changes the image size, but only if necessary.
-    /** This reallocates m_calData and m_qim
+    /** This reallocates \ref m_calDataRaw, updates \ref m_calData, and reallocates \ref m_qim.
      *
      */
     void mtxL_setImsize( uint32_t x, ///< [in] the new x size
@@ -401,7 +402,13 @@ class rtimvBase : public mx::app::application
      */
     bool m_applySatMask{ false };
 
-    /// Buffer to hold the calibrated image data
+    /// Owned buffer that stores unfiltered calibrated pixel data.
+    float *m_calDataRaw{ nullptr };
+
+    /// Pointer to the currently active calibrated data buffer.
+    /** Normally this points at \ref m_calDataRaw. When filtering is enabled it points at
+     * filter output buffers managed elsewhere.
+     */
     float *m_calData{ nullptr };
 
     /// Buffer to hold the the saturated pixel map
@@ -782,18 +789,83 @@ class rtimvBase : public mx::app::application
 
     ///@}
 
+    /** @name Image Filtering - Data
+     *
+     * Controls for optional high-pass/low-pass image filtering.
+     * @{
+     */
+  protected:
+    rtimv::hpFilter m_hpFilter{ rtimv::hpFilter::gaussian }; ///< Selected high-pass filter type.
+
+    float m_hpfFW{ 10 }; ///< Full width for the high-pass filter in pixels.
+
+    bool m_applyHPFilter{ false }; ///< Whether the high-pass filter is currently enabled.
+
+    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::gaussian }; ///< Selected low-pass filter type.
+
+    float m_lpfFW{ 3 }; ///< Full width for the low-pass filter in pixels.
+
+    bool m_applyLPFilter{ false }; ///< Whether the low-pass filter is currently enabled.
+
+    ///@}
+
     /** @name Image Filtering
+     *
+     * Public access to image filtering configuration.
+     * @{
+     */
+  public:
+    /// Set the high-pass filter type.
+    void hpFilter( rtimv::hpFilter filter /**< [in] selected high-pass filter type */ );
+
+    /// Get the high-pass filter type.
+    rtimv::hpFilter hpFilter();
+
+    /// Set the high-pass filter full width.
+    void hpfFW( float fw /**< [in] high-pass filter width in pixels */ );
+
+    /// Get the high-pass filter full width.
+    float hpfFW();
+
+    /// Set whether high-pass filtering is applied.
+    void applyHPFilter( bool apply /**< [in] true enables high-pass filtering */ );
+
+    /// Get whether high-pass filtering is enabled.
+    bool applyHPFilter();
+
+    /// Set the low-pass filter type.
+    void lpFilter( rtimv::lpFilter filter /**< [in] selected low-pass filter type */ );
+
+    /// Get the low-pass filter type.
+    rtimv::lpFilter lpFilter();
+
+    /// Set the low-pass filter full width.
+    void lpfFW( float fw /**< [in] low-pass filter width in pixels */ );
+
+    /// Get the low-pass filter full width.
+    float lpfFW();
+
+    /// Set whether low-pass filtering is applied.
+    void applyLPFilter( bool apply /**< [in] true enables low-pass filtering */ );
+
+    /// Get whether low-pass filtering is enabled.
+    bool applyLPFilter();
+
+    ///@}
+
+    /** @name Image Filtering - Working Memory
      *
      * @{
      */
+    /// Scratch image used for intermediate smoothing during filtering.
+    mx::improc::eigenImage<float> m_filterWork;
 
-    float *m_lowPassFiltered{ nullptr };
+    /// Buffer holding the current high-pass filtered image.
+    mx::improc::eigenImage<float> m_hpFiltered;
 
-    bool m_applyLPFilter;
-
-    int m_lpFilterType;
-
-    ///@} -- filtering
+    /// Buffer holding the current low-pass filtered image.
+    mx::improc::eigenImage<float> m_lpFiltered;
+    /// @}
 
     //****** The display *************
   protected:
@@ -822,6 +894,11 @@ class rtimvBase : public mx::app::application
 
     /// Updates the QImage and basic statistics after a new image.
     void mtxUL_changeImdata();
+
+    /// Apply configured high-pass/low-pass filters and update \ref m_calData.
+    /** Called with \ref m_calMutex in shared-lock context from \ref mtxUL_changeImdata.
+     */
+    void mtxL_applyFilter();
 
   private:
     /// Color the image based on the current colormap configuration and stretch

--- a/src/common/rtimvFilters.cpp
+++ b/src/common/rtimvFilters.cpp
@@ -1,0 +1,100 @@
+/** \file rtimvFilters.cpp
+ * \brief Image filtering definitions for rtimv.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
+
+#include "rtimvFilters.hpp"
+
+#include <cmath>
+
+#include <mx/improc/imageFilters.hpp>
+
+namespace
+{
+
+/// Round to the nearest odd integer and enforce a minimum of 1.
+int nearestOdd( float x )
+{
+    int n = static_cast<int>( std::lround( x ) );
+
+    if( n < 1 )
+    {
+        n = 1;
+    }
+
+    if( ( n % 2 ) == 0 )
+    {
+        ++n;
+    }
+
+    return n;
+}
+
+} // namespace
+
+namespace rtimv
+{
+
+void applyHPFilter( mx::improc::eigenImage<float> &outim,
+                    constImageRef inim,
+                    hpFilter filter,
+                    float fw,
+                    mx::improc::eigenImage<float> &work )
+{
+    outim.resize( inim.rows(), inim.cols() );
+    work.resize( inim.rows(), inim.cols() );
+
+    if( filter == hpFilter::gaussian )
+    {
+        mx::improc::filterImage( work, inim, mx::improc::gaussKernel<mx::improc::eigenImage<float>, 2>( fw ) );
+        outim = inim - work;
+        return;
+    }
+
+    work = inim;
+
+    if( filter == hpFilter::median )
+    {
+        mx::improc::medianSmooth( work, inim, nearestOdd( fw ) );
+        outim = inim - work;
+        return;
+    }
+
+    if( filter == hpFilter::mean )
+    {
+        mx::improc::meanSmooth( work, inim, nearestOdd( fw ) );
+        outim = inim - work;
+        return;
+    }
+
+    // Placeholder implementations currently pass input through unchanged.
+    outim = inim;
+}
+
+void applyLPFilter( mx::improc::eigenImage<float> &outim, constImageRef inim, lpFilter filter, float fw )
+{
+    outim.resize( inim.rows(), inim.cols() );
+
+    if( filter == lpFilter::gaussian )
+    {
+        mx::improc::filterImage( outim, inim, mx::improc::gaussKernel<mx::improc::eigenImage<float>, 2>( fw ) );
+        return;
+    }
+
+    outim = inim;
+
+    if( filter == lpFilter::median )
+    {
+        mx::improc::medianSmooth( outim, inim, nearestOdd( fw ) );
+        return;
+    }
+
+    if( filter == lpFilter::mean )
+    {
+        mx::improc::meanSmooth( outim, inim, nearestOdd( fw ) );
+        return;
+    }
+}
+
+} // namespace rtimv

--- a/src/common/rtimvFilters.hpp
+++ b/src/common/rtimvFilters.hpp
@@ -1,0 +1,61 @@
+/** \file rtimvFilters.hpp
+ * \brief Image filtering declarations for rtimv.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
+
+#ifndef rtimv_rtimvFilters_hpp
+#define rtimv_rtimvFilters_hpp
+
+#include <Eigen/Dense>
+
+#include <mx/improc/eigenImage.hpp>
+
+namespace rtimv
+{
+
+/// Available high-pass filter implementations.
+enum class hpFilter
+{
+    gaussian, ///< Subtract a Gaussian-smoothed image (fw is FWHM in pixels).
+    median,   ///< Subtract a median-smoothed image (fw is full width in pixels).
+    mean,     ///< Subtract a mean-smoothed image (fw is full width in pixels).
+    fourier,  ///< Fourier high-pass filter placeholder (currently pass-through).
+    radprof   ///< Radial-profile subtraction placeholder (currently pass-through).
+};
+
+/// Available low-pass filter implementations.
+enum class lpFilter
+{
+    gaussian, ///< Gaussian smoothing (fw is FWHM in pixels).
+    median,   ///< Median smoothing (fw is full width in pixels).
+    mean      ///< Mean smoothing (fw is full width in pixels).
+};
+
+/// Shared read-only reference type for 2-D floating-point images.
+using constImageRef = Eigen::Ref<const mx::improc::eigenImage<float>>;
+
+/// Apply a high-pass filter.
+/**
+ * The input image is not modified. Output image dimensions follow \p inim.
+ */
+void applyHPFilter( mx::improc::eigenImage<float> &outim, ///< [out] Filtered image result.
+                    constImageRef inim,                   ///< [in] Input image.
+                    hpFilter filter,                      ///< [in] Selected high-pass filter.
+                    float fw,                             ///< [in] Filter width parameter in pixels.
+                    mx::improc::eigenImage<float> &work   ///< [in,out] Temporary smoothing work buffer.
+);
+
+/// Apply a low-pass filter.
+/**
+ * The input image is not modified. Output image dimensions follow \p inim.
+ */
+void applyLPFilter( mx::improc::eigenImage<float> &outim, ///< [out] Filtered image result.
+                    constImageRef inim,                   ///< [in] Input image.
+                    lpFilter filter,                      ///< [in] Selected low-pass filter.
+                    float fw                              ///< [in] Filter width parameter in pixels.
+);
+
+} // namespace rtimv
+
+#endif // rtimv_rtimvFilters_hpp

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -1,5 +1,7 @@
 #include "rtimvControlPanel.hpp"
 
+#include <algorithm>
+
 rtimvControlPanel::rtimvControlPanel()
 {
 }
@@ -100,6 +102,16 @@ void rtimvControlPanel::setupCombos()
     m_ui.pointerViewModecomboBox->insertItem( PointerViewOnPress, "On mouse press" );
     m_ui.pointerViewModecomboBox->insertItem( PointerViewDisabled, "Disabled" );
     m_ui.pointerViewModecomboBox->setCurrentIndex( PointerViewOnPress );
+
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::gaussian ), "Gaussian" );
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::median ), "Median" );
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::mean ), "Mean" );
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::fourier ), "Fourier (TBD)" );
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::radprof ), "Radial Profile (TBD)" );
+
+    m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::gaussian ), "Gaussian" );
+    m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::median ), "Median" );
+    m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::mean ), "Mean" );
 }
 
 void rtimvControlPanel::init_panel()
@@ -121,6 +133,8 @@ void rtimvControlPanel::init_panel()
     update_qualitySlider();
     update_qualityEntry();
 #endif
+    update_hpFilter();
+    update_lpFilter();
 }
 
 void rtimvControlPanel::update_panel()
@@ -160,6 +174,9 @@ void rtimvControlPanel::update_panel()
     update_qualitySlider();
     update_qualityEntry();
 #endif
+
+    update_hpFilter();
+    update_lpFilter();
 }
 
 void rtimvControlPanel::update_ZoomSlider()
@@ -749,6 +766,64 @@ void rtimvControlPanel::update_qualityEntry()
 #endif
 }
 
+void rtimvControlPanel::update_hpFilter()
+{
+    constexpr int minSlider = 1;
+    constexpr int maxSlider = 1000;
+    constexpr float fwScale = 10.0f;
+
+    m_ui.hpFilterCombo->blockSignals( true );
+    m_ui.hpFilterCombo->setCurrentIndex( static_cast<int>( m_imv->hpFilter() ) );
+    m_ui.hpFilterCombo->blockSignals( false );
+
+    m_ui.hpApplyCheck->blockSignals( true );
+    m_ui.hpApplyCheck->setChecked( m_imv->applyHPFilter() );
+    m_ui.hpApplyCheck->blockSignals( false );
+
+    const float fw = std::max( 0.0f, m_imv->hpfFW() );
+    const int slider = std::clamp( static_cast<int>( fw * fwScale + 0.5f ), minSlider, maxSlider );
+
+    m_ui.hpFWSlider->blockSignals( true );
+    m_ui.hpFWSlider->setValue( slider );
+    m_ui.hpFWSlider->blockSignals( false );
+
+    if( !m_ui.hpFWEntry->hasFocus() )
+    {
+        m_ui.hpFWEntry->blockSignals( true );
+        m_ui.hpFWEntry->setText( QString::number( fw, 'f', 1 ) );
+        m_ui.hpFWEntry->blockSignals( false );
+    }
+}
+
+void rtimvControlPanel::update_lpFilter()
+{
+    constexpr int minSlider = 1;
+    constexpr int maxSlider = 1000;
+    constexpr float fwScale = 10.0f;
+
+    m_ui.lpFilterCombo->blockSignals( true );
+    m_ui.lpFilterCombo->setCurrentIndex( static_cast<int>( m_imv->lpFilter() ) );
+    m_ui.lpFilterCombo->blockSignals( false );
+
+    m_ui.lpApplyCheck->blockSignals( true );
+    m_ui.lpApplyCheck->setChecked( m_imv->applyLPFilter() );
+    m_ui.lpApplyCheck->blockSignals( false );
+
+    const float fw = std::max( 0.0f, m_imv->lpfFW() );
+    const int slider = std::clamp( static_cast<int>( fw * fwScale + 0.5f ), minSlider, maxSlider );
+
+    m_ui.lpFWSlider->blockSignals( true );
+    m_ui.lpFWSlider->setValue( slider );
+    m_ui.lpFWSlider->blockSignals( false );
+
+    if( !m_ui.lpFWEntry->hasFocus() )
+    {
+        m_ui.lpFWEntry->blockSignals( true );
+        m_ui.lpFWEntry->setText( QString::number( fw, 'f', 1 ) );
+        m_ui.lpFWEntry->blockSignals( false );
+    }
+}
+
 void rtimvControlPanel::on_scaleModeCombo_activated( int index )
 {
     if( static_cast<rtimv::colormode>( index ) == rtimv::colormode::minmaxglobal )
@@ -837,6 +912,70 @@ void rtimvControlPanel::on_contrastEntry_editingFinished()
     m_imv->contrast( m_ui.contrastEntry->text().toDouble() );
 
     m_imv->mtxUL_colormode( rtimv::colormode::user );
+}
+
+void rtimvControlPanel::on_hpFilterCombo_activated( int index )
+{
+    m_imv->hpFilter( static_cast<rtimv::hpFilter>( index ) );
+}
+
+void rtimvControlPanel::on_hpApplyCheck_stateChanged( int state )
+{
+    m_imv->applyHPFilter( state != 0 );
+}
+
+void rtimvControlPanel::on_hpFWSlider_valueChanged( int value )
+{
+    constexpr float fwScale = 10.0f;
+    m_imv->hpfFW( value / fwScale );
+    update_hpFilter();
+}
+
+void rtimvControlPanel::on_hpFWEntry_editingFinished()
+{
+    bool ok = false;
+    const float fw = m_ui.hpFWEntry->text().toFloat( &ok );
+
+    if( !ok )
+    {
+        update_hpFilter();
+        return;
+    }
+
+    m_imv->hpfFW( fw );
+    update_hpFilter();
+}
+
+void rtimvControlPanel::on_lpFilterCombo_activated( int index )
+{
+    m_imv->lpFilter( static_cast<rtimv::lpFilter>( index ) );
+}
+
+void rtimvControlPanel::on_lpApplyCheck_stateChanged( int state )
+{
+    m_imv->applyLPFilter( state != 0 );
+}
+
+void rtimvControlPanel::on_lpFWSlider_valueChanged( int value )
+{
+    constexpr float fwScale = 10.0f;
+    m_imv->lpfFW( value / fwScale );
+    update_lpFilter();
+}
+
+void rtimvControlPanel::on_lpFWEntry_editingFinished()
+{
+    bool ok = false;
+    const float fw = m_ui.lpFWEntry->text().toFloat( &ok );
+
+    if( !ok )
+    {
+        update_lpFilter();
+        return;
+    }
+
+    m_imv->lpfFW( fw );
+    update_lpFilter();
 }
 
 void rtimvControlPanel::on_imtimerspinBox_valueChanged( int to )

--- a/src/gui/rtimvControlPanel.hpp
+++ b/src/gui/rtimvControlPanel.hpp
@@ -263,6 +263,12 @@ class rtimvControlPanel : public QWidget
     /// Synchronize JPEG quality entry from model state.
     void update_qualityEntry();
 
+    /// Synchronize high-pass filter controls from model state.
+    void update_hpFilter();
+
+    /// Synchronize low-pass filter controls from model state.
+    void update_lpFilter();
+
   public slots:
     /// Handle color mode combo selection.
     void on_scaleModeCombo_activated( int index /**< [in] selected color mode index*/ );
@@ -290,6 +296,30 @@ class rtimvControlPanel : public QWidget
 
     /// Handle contrast entry edits.
     void on_contrastEntry_editingFinished();
+
+    /// Handle high-pass filter type changes.
+    void on_hpFilterCombo_activated( int index /**< [in] selected high-pass filter type*/ );
+
+    /// Handle high-pass filter enable state changes.
+    void on_hpApplyCheck_stateChanged( int state /**< [in] checked state*/ );
+
+    /// Handle high-pass width slider changes.
+    void on_hpFWSlider_valueChanged( int value /**< [in] slider position*/ );
+
+    /// Handle high-pass width entry edits.
+    void on_hpFWEntry_editingFinished();
+
+    /// Handle low-pass filter type changes.
+    void on_lpFilterCombo_activated( int index /**< [in] selected low-pass filter type*/ );
+
+    /// Handle low-pass filter enable state changes.
+    void on_lpApplyCheck_stateChanged( int state /**< [in] checked state*/ );
+
+    /// Handle low-pass width slider changes.
+    void on_lpFWSlider_valueChanged( int value /**< [in] slider position*/ );
+
+    /// Handle low-pass width entry edits.
+    void on_lpFWEntry_editingFinished();
 
   public:
     /*** Real Time Controls ***/

--- a/src/gui/rtimvControlPanel.ui
+++ b/src/gui/rtimvControlPanel.ui
@@ -1800,6 +1800,195 @@
      </property>
     </widget>
    </widget>
+   <widget class="QWidget" name="tabFilters">
+    <attribute name="title">
+     <string>Filters</string>
+    </attribute>
+    <widget class="QLabel" name="hpFilterLabel">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>18</y>
+       <width>151</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>High-Pass Filter</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="hpFilterCombo">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>40</y>
+       <width>211</width>
+       <height>28</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="hpApplyCheck">
+     <property name="geometry">
+      <rect>
+       <x>250</x>
+       <y>44</y>
+       <width>91</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="hpFWLabel">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>78</y>
+       <width>111</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Width (pixels)</string>
+     </property>
+    </widget>
+    <widget class="QSlider" name="hpFWSlider">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>100</y>
+       <width>231</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>1000</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="hpFWEntry">
+     <property name="geometry">
+      <rect>
+       <x>260</x>
+       <y>98</y>
+       <width>81</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QFrame" name="filterDivider">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>145</y>
+       <width>680</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+    </widget>
+    <widget class="QLabel" name="lpFilterLabel">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>170</y>
+       <width>151</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Low-Pass Filter</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="lpFilterCombo">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>192</y>
+       <width>211</width>
+       <height>28</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="lpApplyCheck">
+     <property name="geometry">
+      <rect>
+       <x>250</x>
+       <y>196</y>
+       <width>91</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="lpFWLabel">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>230</y>
+       <width>111</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Width (pixels)</string>
+     </property>
+    </widget>
+    <widget class="QSlider" name="lpFWSlider">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>252</y>
+       <width>231</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>1000</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lpFWEntry">
+     <property name="geometry">
+      <rect>
+       <x>260</x>
+       <y>250</y>
+       <width>81</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </widget>
    <widget class="QWidget" name="tabSetup">
     <attribute name="title">
      <string>Setup</string>
@@ -2066,6 +2255,14 @@
   <tabstop>view_down</tabstop>
   <tabstop>absfixedButton</tabstop>
   <tabstop>relfixedButton</tabstop>
+  <tabstop>hpFilterCombo</tabstop>
+  <tabstop>hpApplyCheck</tabstop>
+  <tabstop>hpFWSlider</tabstop>
+  <tabstop>hpFWEntry</tabstop>
+  <tabstop>lpFilterCombo</tabstop>
+  <tabstop>lpApplyCheck</tabstop>
+  <tabstop>lpFWSlider</tabstop>
+  <tabstop>lpFWEntry</tabstop>
   <tabstop>ViewViewModecheckBox</tabstop>
   <tabstop>pointerViewModecomboBox</tabstop>
   <tabstop>imtimerspinBox</tabstop>

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -30,6 +30,18 @@ service rtimv
 
     rpc SetApplySatMask(ApplySatMaskRequest) returns (ApplySatMaskResponse);
 
+    rpc SetHPFilter(HPFilterRequest) returns (HPFilterResponse);
+
+    rpc SetHPFW(FilterWidthRequest) returns (FilterWidthResponse);
+
+    rpc SetApplyHPFilter(ApplyFilterRequest) returns (ApplyFilterResponse);
+
+    rpc SetLPFilter(LPFilterRequest) returns (LPFilterResponse);
+
+    rpc SetLPFW(FilterWidthRequest) returns (FilterWidthResponse);
+
+    rpc SetApplyLPFilter(ApplyFilterRequest) returns (ApplyFilterResponse);
+
     rpc ImagePlease(ImageRequest) returns (Image);
 
     rpc CubeDir(CubeDirRequest) returns (CubeDirResponse);
@@ -227,6 +239,60 @@ message ApplySatMaskResponse
 {
 }
 
+enum HPFilter
+{
+    HPFILTER_UNKNOWN = 0;
+    HPFILTER_GAUSSIAN = 1;
+    HPFILTER_MEDIAN = 2;
+    HPFILTER_MEAN = 3;
+    HPFILTER_FOURIER = 4;
+    HPFILTER_RADPROF = 5;
+}
+
+message HPFilterRequest
+{
+    HPFilter hp_filter = 1;
+}
+
+message HPFilterResponse
+{
+}
+
+enum LPFilter
+{
+    LPFILTER_UNKNOWN = 0;
+    LPFILTER_GAUSSIAN = 1;
+    LPFILTER_MEDIAN = 2;
+    LPFILTER_MEAN = 3;
+}
+
+message LPFilterRequest
+{
+    LPFilter lp_filter = 1;
+}
+
+message LPFilterResponse
+{
+}
+
+message FilterWidthRequest
+{
+    float width = 1;
+}
+
+message FilterWidthResponse
+{
+}
+
+message ApplyFilterRequest
+{
+    bool apply_filter = 1;
+}
+
+message ApplyFilterResponse
+{
+}
+
 message UpdateCubeRequest
 {
 }
@@ -311,6 +377,14 @@ message Image
     int32 image_timeout = 170;
     int32 cube_dir = 175;
     int32 quality = 180;
+
+    HPFilter hp_filter = 185;
+    float hpf_fw = 186;
+    bool apply_hp_filter = 187;
+
+    LPFilter lp_filter = 188;
+    float lpf_fw = 189;
+    bool apply_lp_filter = 190;
 }
 
 message Coord

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -7,6 +7,7 @@
 
 #include "rtimvClientBase.hpp"
 #include "rtimvColorGRPC.hpp"
+#include "rtimvFilterGRPC.hpp"
 
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
 #define RTIMV_DEBUG_BREADCRUMB
@@ -579,6 +580,12 @@ void rtimvClientBase::ImageReceived()
     bool subtractDark;
     bool applyMask;
     bool applySatMask;
+    remote_rtimv::HPFilter hpFilter;
+    float hpfFW;
+    bool applyHPFilter;
+    remote_rtimv::LPFilter lpFilter;
+    float lpfFW;
+    bool applyLPFilter;
     int cubeDir;
     bool hasImagePayload{ false };
 
@@ -643,6 +650,12 @@ void rtimvClientBase::ImageReceived()
         subtractDark = m_grpcImage.subtract_dark();
         applyMask = m_grpcImage.apply_mask();
         applySatMask = m_grpcImage.apply_sat_mask();
+        hpFilter = m_grpcImage.hp_filter();
+        hpfFW = m_grpcImage.hpf_fw();
+        applyHPFilter = m_grpcImage.apply_hp_filter();
+        lpFilter = m_grpcImage.lp_filter();
+        lpfFW = m_grpcImage.lpf_fw();
+        applyLPFilter = m_grpcImage.apply_lp_filter();
 
         imageTimeout = m_grpcImage.image_timeout();
         cubeDir = m_grpcImage.cube_dir();
@@ -688,6 +701,20 @@ void rtimvClientBase::ImageReceived()
     m_subtractDark = subtractDark;
     m_applyMask = applyMask;
     m_applySatMask = applySatMask;
+    rtimv::hpFilter hp = rtimv::grpc2hpFilter( hpFilter );
+    if( hp != static_cast<rtimv::hpFilter>( -1 ) )
+    {
+        m_hpFilter = hp;
+    }
+    m_hpfFW = hpfFW;
+    m_applyHPFilter = applyHPFilter;
+    rtimv::lpFilter lp = rtimv::grpc2lpFilter( lpFilter );
+    if( lp != static_cast<rtimv::lpFilter>( -1 ) )
+    {
+        m_lpFilter = lp;
+    }
+    m_lpfFW = lpfFW;
+    m_applyLPFilter = applyLPFilter;
     m_imageTimeout = imageTimeout;
     m_quality = quality;
     if( m_cubeDir != cubeDir )
@@ -1079,6 +1106,7 @@ void rtimvClientBase::imageTimeout( int to )
 {
     SHARED_CONN_LOCK
 
+    // Server applies the change; local state is synchronized via Image responses.
     remote_rtimv::ImageTimeoutRequest request;
     remote_rtimv::ImageTimeoutResponse response;
     grpc::ClientContext context;
@@ -1102,6 +1130,7 @@ void rtimvClientBase::quality( int q )
 {
     SHARED_CONN_LOCK
 
+    // Server applies the change; local state is synchronized via Image responses.
     remote_rtimv::QualityRequest request;
     remote_rtimv::QualityResponse response;
     grpc::ClientContext context;
@@ -1125,6 +1154,7 @@ void rtimvClientBase::subtractDark( bool sd )
 {
     SHARED_CONN_LOCK
 
+    // Server applies the change; local state is synchronized via Image responses.
     remote_rtimv::SubDarkRequest request;
     remote_rtimv::SubDarkResponse response;
     grpc::ClientContext context;
@@ -1148,6 +1178,7 @@ void rtimvClientBase::applyMask( bool amsk )
 {
     SHARED_CONN_LOCK
 
+    // Server applies the change; local state is synchronized via Image responses.
     remote_rtimv::ApplyMaskRequest request;
     remote_rtimv::ApplyMaskResponse response;
     grpc::ClientContext context;
@@ -1171,6 +1202,7 @@ void rtimvClientBase::applySatMask( bool asmsk )
 {
     SHARED_CONN_LOCK
 
+    // Server applies the change; local state is synchronized via Image responses.
     remote_rtimv::ApplySatMaskRequest request;
     remote_rtimv::ApplySatMaskResponse response;
     grpc::ClientContext context;
@@ -1188,6 +1220,150 @@ void rtimvClientBase::applySatMask( bool asmsk )
 bool rtimvClientBase::applySatMask()
 {
     return m_applySatMask;
+}
+
+void rtimvClientBase::hpFilter( rtimv::hpFilter filter )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::HPFilterRequest request;
+    remote_rtimv::HPFilterResponse response;
+    grpc::ClientContext context;
+
+    request.set_hp_filter( rtimv::hpFilter2grpc( filter ) );
+
+    grpc::Status status = stub_->SetHPFilter( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+rtimv::hpFilter rtimvClientBase::hpFilter()
+{
+    return m_hpFilter;
+}
+
+void rtimvClientBase::hpfFW( float fw )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::FilterWidthRequest request;
+    remote_rtimv::FilterWidthResponse response;
+    grpc::ClientContext context;
+
+    request.set_width( fw );
+
+    grpc::Status status = stub_->SetHPFW( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+float rtimvClientBase::hpfFW()
+{
+    return m_hpfFW;
+}
+
+void rtimvClientBase::applyHPFilter( bool apply )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::ApplyFilterRequest request;
+    remote_rtimv::ApplyFilterResponse response;
+    grpc::ClientContext context;
+
+    request.set_apply_filter( apply );
+
+    grpc::Status status = stub_->SetApplyHPFilter( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+bool rtimvClientBase::applyHPFilter()
+{
+    return m_applyHPFilter;
+}
+
+void rtimvClientBase::lpFilter( rtimv::lpFilter filter )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::LPFilterRequest request;
+    remote_rtimv::LPFilterResponse response;
+    grpc::ClientContext context;
+
+    request.set_lp_filter( rtimv::lpFilter2grpc( filter ) );
+
+    grpc::Status status = stub_->SetLPFilter( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+rtimv::lpFilter rtimvClientBase::lpFilter()
+{
+    return m_lpFilter;
+}
+
+void rtimvClientBase::lpfFW( float fw )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::FilterWidthRequest request;
+    remote_rtimv::FilterWidthResponse response;
+    grpc::ClientContext context;
+
+    request.set_width( fw );
+
+    grpc::Status status = stub_->SetLPFW( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+float rtimvClientBase::lpfFW()
+{
+    return m_lpfFW;
+}
+
+void rtimvClientBase::applyLPFilter( bool apply )
+{
+    SHARED_CONN_LOCK
+
+    // Server applies the change; local state is synchronized via Image responses.
+    remote_rtimv::ApplyFilterRequest request;
+    remote_rtimv::ApplyFilterResponse response;
+    grpc::ClientContext context;
+
+    request.set_apply_filter( apply );
+
+    grpc::Status status = stub_->SetApplyLPFilter( &context, request, &response );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+    }
+}
+
+bool rtimvClientBase::applyLPFilter()
+{
+    return m_applyLPFilter;
 }
 
 float rtimvClientBase::calPixel( uint32_t x, uint32_t y )
@@ -1527,16 +1703,12 @@ void rtimvClientBase::mtxUL_autoScale( bool as )
 
     grpc::Status status = stub_->SetAutoscale( &context, request, &response );
 
-    // Act upon its status.
     if( status.ok() )
     {
         return;
     }
-    else
-    {
-        REPORT_SERVER_DISCONNECTED
-        return;
-    }
+
+    REPORT_SERVER_DISCONNECTED
 }
 
 bool rtimvClientBase::autoScale()
@@ -1558,11 +1730,8 @@ void rtimvClientBase::mtxUL_reStretch()
     {
         return;
     }
-    else
-    {
-        REPORT_SERVER_DISCONNECTED
-        return;
-    }
+
+    REPORT_SERVER_DISCONNECTED
 }
 
 uint8_t rtimvClientBase::lightness( int x, int y )

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -21,6 +21,7 @@
 
 #include "rtimvBaseObject.hpp"
 #include "rtimvColor.hpp"
+#include "rtimvFilters.hpp"
 
 #include <grpcpp/grpcpp.h>
 
@@ -380,10 +381,10 @@ class rtimvClientBase : public mx::app::application
      */
     int imageTimeout();
 
-    /// Set the JPEG quality used by the server.
+    /// Set the JPEG quality.
     void quality( int q /**< [in] the new JPEG quality [0,100] */ );
 
-    /// Get the JPEG quality.
+    /// Get the JPEG quality
     int quality();
 
     /// Get the current image display timeout.
@@ -437,7 +438,10 @@ class rtimvClientBase : public mx::app::application
 
     /** \name Calibrated Pixel Data
      *
-     * Settings to control which calibrations are applied, and manage access to memory.
+     * Settings to control which calibrations are applied.
+     *
+     * In the gRPC client, these values are synchronized from the server via
+     * the Image message and are also writable through corresponding RPCs.
      *
      * @{
      */
@@ -721,22 +725,75 @@ class rtimvClientBase : public mx::app::application
      */
     bool autoScale();
 
+    /// Restretch the image based on the current colormode.
     void mtxUL_reStretch();
+
+    ///@}
+
+    /** @name Image Filtering - Data
+     *
+     * Controls for optional high-pass/low-pass image filtering.
+     * @{
+     */
+  protected:
+    rtimv::hpFilter m_hpFilter{ rtimv::hpFilter::gaussian }; ///< Selected high-pass filter type.
+    float m_hpfFW{ 10 };                                     ///< Full width for the high-pass filter in pixels.
+    bool m_applyHPFilter{ false };                           ///< Whether the high-pass filter is currently enabled.
+
+    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::gaussian }; ///< Selected low-pass filter type.
+    float m_lpfFW{ 3 };                                      ///< Full width for the low-pass filter in pixels.
+    bool m_applyLPFilter{ false };                           ///< Whether the low-pass filter is currently enabled.
+
+    /// Filtering working buffers are not stored on the client.
+    /** The client receives post-filter state through the Image message; filtering work
+     * is performed on the server side.
+     */
 
     ///@}
 
     /** @name Image Filtering
      *
+     * Public access to image filtering configuration.
      * @{
      */
+  public:
+    /// Set the high-pass filter type.
+    void hpFilter( rtimv::hpFilter filter /**< [in] selected high-pass filter type */ );
 
-    // float *m_lowPassFiltered{ nullptr };
+    /// Get the high-pass filter type.
+    rtimv::hpFilter hpFilter();
 
-    // bool m_applyLPFilter;
+    /// Set the high-pass filter full width.
+    void hpfFW( float fw /**< [in] high-pass filter width in pixels */ );
 
-    // int m_lpFilterType;
+    /// Get the high-pass filter full width.
+    float hpfFW();
 
-    ///@} -- filtering
+    /// Set whether high-pass filtering is applied.
+    void applyHPFilter( bool apply /**< [in] true enables high-pass filtering */ );
+
+    /// Get whether high-pass filtering is enabled.
+    bool applyHPFilter();
+
+    /// Set the low-pass filter type.
+    void lpFilter( rtimv::lpFilter filter /**< [in] selected low-pass filter type */ );
+
+    /// Get the low-pass filter type.
+    rtimv::lpFilter lpFilter();
+
+    /// Set the low-pass filter full width.
+    void lpfFW( float fw /**< [in] low-pass filter width in pixels */ );
+
+    /// Get the low-pass filter full width.
+    float lpfFW();
+
+    /// Set whether low-pass filtering is applied.
+    void applyLPFilter( bool apply /**< [in] true enables low-pass filtering */ );
+
+    /// Get whether low-pass filtering is enabled.
+    bool applyLPFilter();
+
+    ///@}
 
     //****** The display *************
   protected:

--- a/src/server/rtimvFilterGRPC.hpp
+++ b/src/server/rtimvFilterGRPC.hpp
@@ -1,0 +1,86 @@
+/** \file rtimvFilterGRPC.hpp
+ * \brief Conversion of filter enums for gRPC in rtimv.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
+
+#ifndef rtimv_rtimvFilterGRPC_hpp
+#define rtimv_rtimvFilterGRPC_hpp
+
+#include "rtimv.grpc.pb.h"
+#include "rtimvFilters.hpp"
+
+namespace rtimv
+{
+
+inline remote_rtimv::HPFilter hpFilter2grpc( rtimv::hpFilter filter )
+{
+    switch( filter )
+    {
+    case rtimv::hpFilter::gaussian:
+        return remote_rtimv::HPFILTER_GAUSSIAN;
+    case rtimv::hpFilter::median:
+        return remote_rtimv::HPFILTER_MEDIAN;
+    case rtimv::hpFilter::mean:
+        return remote_rtimv::HPFILTER_MEAN;
+    case rtimv::hpFilter::fourier:
+        return remote_rtimv::HPFILTER_FOURIER;
+    case rtimv::hpFilter::radprof:
+        return remote_rtimv::HPFILTER_RADPROF;
+    default:
+        return remote_rtimv::HPFILTER_UNKNOWN;
+    }
+}
+
+inline rtimv::hpFilter grpc2hpFilter( remote_rtimv::HPFilter filter )
+{
+    switch( filter )
+    {
+    case remote_rtimv::HPFILTER_GAUSSIAN:
+        return rtimv::hpFilter::gaussian;
+    case remote_rtimv::HPFILTER_MEDIAN:
+        return rtimv::hpFilter::median;
+    case remote_rtimv::HPFILTER_MEAN:
+        return rtimv::hpFilter::mean;
+    case remote_rtimv::HPFILTER_FOURIER:
+        return rtimv::hpFilter::fourier;
+    case remote_rtimv::HPFILTER_RADPROF:
+        return rtimv::hpFilter::radprof;
+    default:
+        return static_cast<rtimv::hpFilter>( -1 );
+    }
+}
+
+inline remote_rtimv::LPFilter lpFilter2grpc( rtimv::lpFilter filter )
+{
+    switch( filter )
+    {
+    case rtimv::lpFilter::gaussian:
+        return remote_rtimv::LPFILTER_GAUSSIAN;
+    case rtimv::lpFilter::median:
+        return remote_rtimv::LPFILTER_MEDIAN;
+    case rtimv::lpFilter::mean:
+        return remote_rtimv::LPFILTER_MEAN;
+    default:
+        return remote_rtimv::LPFILTER_UNKNOWN;
+    }
+}
+
+inline rtimv::lpFilter grpc2lpFilter( remote_rtimv::LPFilter filter )
+{
+    switch( filter )
+    {
+    case remote_rtimv::LPFILTER_GAUSSIAN:
+        return rtimv::lpFilter::gaussian;
+    case remote_rtimv::LPFILTER_MEDIAN:
+        return rtimv::lpFilter::median;
+    case remote_rtimv::LPFILTER_MEAN:
+        return rtimv::lpFilter::mean;
+    default:
+        return static_cast<rtimv::lpFilter>( -1 );
+    }
+}
+
+} // namespace rtimv
+
+#endif // rtimv_rtimvFilterGRPC_hpp

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -418,6 +418,102 @@ ServerUnaryReactor *rtimvServer::SetApplySatMask( CallbackServerContext *context
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::SetHPFilter( CallbackServerContext *context,
+                                              const remote_rtimv::HPFilterRequest *request,
+                                              remote_rtimv::HPFilterResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    rtimv::hpFilter filter = rtimv::grpc2hpFilter( request->hp_filter() );
+
+    if( filter != static_cast<rtimv::hpFilter>( -1 ) )
+    {
+        imageTh->hpFilter( filter );
+        reactor->Finish( Status::OK );
+    }
+    else
+    {
+        reactor->Finish( grpc::Status( grpc::INVALID_ARGUMENT, "invalid HP filter" ) );
+    }
+
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::SetHPFW( CallbackServerContext *context,
+                                          const remote_rtimv::FilterWidthRequest *request,
+                                          remote_rtimv::FilterWidthResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    imageTh->hpfFW( request->width() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::SetApplyHPFilter( CallbackServerContext *context,
+                                                   const remote_rtimv::ApplyFilterRequest *request,
+                                                   remote_rtimv::ApplyFilterResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    imageTh->applyHPFilter( request->apply_filter() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::SetLPFilter( CallbackServerContext *context,
+                                              const remote_rtimv::LPFilterRequest *request,
+                                              remote_rtimv::LPFilterResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    rtimv::lpFilter filter = rtimv::grpc2lpFilter( request->lp_filter() );
+
+    if( filter != static_cast<rtimv::lpFilter>( -1 ) )
+    {
+        imageTh->lpFilter( filter );
+        reactor->Finish( Status::OK );
+    }
+    else
+    {
+        reactor->Finish( grpc::Status( grpc::INVALID_ARGUMENT, "invalid LP filter" ) );
+    }
+
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::SetLPFW( CallbackServerContext *context,
+                                          const remote_rtimv::FilterWidthRequest *request,
+                                          remote_rtimv::FilterWidthResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    imageTh->lpfFW( request->width() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::SetApplyLPFilter( CallbackServerContext *context,
+                                                   const remote_rtimv::ApplyFilterRequest *request,
+                                                   remote_rtimv::ApplyFilterResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+    static_cast<void>( reply );
+
+    imageTh->applyLPFilter( request->apply_filter() );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
                                               const remote_rtimv::ImageRequest *request,
                                               remote_rtimv::Image *reply )
@@ -486,6 +582,14 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         reply->set_image_timeout( imageTh->imageTimeout() );
         reply->set_cube_dir( imageTh->cubeDir() );
         reply->set_quality( imageTh->quality() );
+
+        reply->set_hp_filter( rtimv::hpFilter2grpc( imageTh->hpFilter() ) );
+        reply->set_hpf_fw( imageTh->hpfFW() );
+        reply->set_apply_hp_filter( imageTh->applyHPFilter() );
+
+        reply->set_lp_filter( rtimv::lpFilter2grpc( imageTh->lpFilter() ) );
+        reply->set_lpf_fw( imageTh->lpfFW() );
+        reply->set_apply_lp_filter( imageTh->applyLPFilter() );
     };
 
     if( imageTh->newImage() == false )

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -32,6 +32,7 @@ using grpc::Status;
 
 #include "rtimvServerThread.hpp"
 #include "rtimvColorGRPC.hpp"
+#include "rtimvFilterGRPC.hpp"
 
 #define RTIMV_DEBUG_BREADCRUMB
 
@@ -177,6 +178,30 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
     ServerUnaryReactor *SetApplySatMask( CallbackServerContext *context,
                                          const remote_rtimv::ApplySatMaskRequest *request,
                                          remote_rtimv::ApplySatMaskResponse *reply ) override;
+
+    ServerUnaryReactor *SetHPFilter( CallbackServerContext *context,
+                                     const remote_rtimv::HPFilterRequest *request,
+                                     remote_rtimv::HPFilterResponse *reply ) override;
+
+    ServerUnaryReactor *SetHPFW( CallbackServerContext *context,
+                                 const remote_rtimv::FilterWidthRequest *request,
+                                 remote_rtimv::FilterWidthResponse *reply ) override;
+
+    ServerUnaryReactor *SetApplyHPFilter( CallbackServerContext *context,
+                                          const remote_rtimv::ApplyFilterRequest *request,
+                                          remote_rtimv::ApplyFilterResponse *reply ) override;
+
+    ServerUnaryReactor *SetLPFilter( CallbackServerContext *context,
+                                     const remote_rtimv::LPFilterRequest *request,
+                                     remote_rtimv::LPFilterResponse *reply ) override;
+
+    ServerUnaryReactor *SetLPFW( CallbackServerContext *context,
+                                 const remote_rtimv::FilterWidthRequest *request,
+                                 remote_rtimv::FilterWidthResponse *reply ) override;
+
+    ServerUnaryReactor *SetApplyLPFilter( CallbackServerContext *context,
+                                          const remote_rtimv::ApplyFilterRequest *request,
+                                          remote_rtimv::ApplyFilterResponse *reply ) override;
 
     ServerUnaryReactor *ImagePlease( CallbackServerContext *context,
                                      const remote_rtimv::ImageRequest *request,


### PR DESCRIPTION
Work done by GPT-5.3-Codex

## Summary
This PR implements end-to-end image filtering support and UI control, including local/server-client parity and performance cleanup.

## What Changed
1. Added `rtimvFilters` implementation split:
- New `src/common/rtimvFilters.cpp`
- Updated `src/common/rtimvFilters.hpp` with declarations and inline parameter docs
- Added to build in `CMakeLists.txt`

2. Extended `rtimvBase` filtering model:
- Added high-pass/low-pass filter data and accessor APIs
- Introduced `m_calDataRaw` as owned calibrated buffer
- `m_calData` is now a view pointer to raw or filtered data
- Added filter working memory docs and filtering API docs
- Preserved doxygen section convention: `Image Filtering - Data` before public access section

3. gRPC protocol + server/client integration:
- Extended `src/proto/rtimv.proto` with HP/LP filter enums, requests, RPCs, and Image state fields
- Added `src/server/rtimvFilterGRPC.hpp` enum conversions
- Implemented server RPC handlers in `src/server/rtimvServer.cpp/.hpp`
- Implemented client RPC accessors and Image-state sync in `src/server/rtimvClientBase.cpp/.hpp`

4. Control panel UI:
- Added new `Filters` tab in `src/gui/rtimvControlPanel.ui`
- Added HP/LP type combo boxes, apply toggles, width sliders + entries
- Wired slots/update methods in `src/gui/rtimvControlPanel.cpp/.hpp`

5. Performance optimizations:
- `mtxUL_changeImdata(bool newdata=true)` added
- Filter parameter changes now call `mtxUL_changeImdata(false)` to reuse `m_calDataRaw`
- `applySatMask` now triggers `mtxUL_recolor()` instead of full image-data refresh

6. Documentation/style alignment:
- Aligned `rtimvBase` and `rtimvClientBase` section/doc style for shared interface
- Updated `agent_context.md` with new project-specific documentation conventions

## Verification
Built successfully:
- `cmake --build /tmp/rtimv-build -j4 --target rtimv`
- `cmake --build /tmp/rtimv-build -j4 --target rtimvClient`
- `cmake --build /tmp/rtimv-build -j4 --target rtimv rtimvClient`
