### PR TITLE
Add explicit none filter mode and improve toggle feedback

### DIFF
--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -1838,7 +1838,10 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
 
 void rtimvBase::mtxL_applyFilter()
 {
-    if( !( m_applyHPFilter || m_applyLPFilter ) )
+    const bool doHP = m_applyHPFilter && ( m_hpFilter != rtimv::hpFilter::none ) && ( m_hpfFW > 0 );
+    const bool doLP = m_applyLPFilter && ( m_lpFilter != rtimv::lpFilter::none ) && ( m_lpfFW > 0 );
+
+    if( !( doHP || doLP ) )
     {
         m_calData = m_calDataRaw;
         return;
@@ -1846,10 +1849,10 @@ void rtimvBase::mtxL_applyFilter()
 
     mx::improc::eigenMap<float> imin( m_calDataRaw, m_nx, m_ny );
 
-    if( m_applyHPFilter )
+    if( doHP )
     {
         rtimv::applyHPFilter( m_hpFiltered, imin, m_hpFilter, m_hpfFW, m_filterWork );
-        if( m_applyLPFilter )
+        if( doLP )
         {
             rtimv::applyLPFilter( m_lpFiltered, m_hpFiltered, m_lpFilter, m_lpfFW );
             m_calData = m_lpFiltered.data();

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -801,7 +801,7 @@ class rtimvBase : public mx::app::application
 
     bool m_applyHPFilter{ false }; ///< Whether the high-pass filter is currently enabled.
 
-    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::gaussian }; ///< Selected low-pass filter type.
+    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::none }; ///< Selected low-pass filter type.
 
     float m_lpfFW{ 3 }; ///< Full width for the low-pass filter in pixels.
 

--- a/src/common/rtimvFilters.cpp
+++ b/src/common/rtimvFilters.cpp
@@ -45,6 +45,12 @@ void applyHPFilter( mx::improc::eigenImage<float> &outim,
     outim.resize( inim.rows(), inim.cols() );
     work.resize( inim.rows(), inim.cols() );
 
+    if( filter == hpFilter::none || fw <= 0 )
+    {
+        outim = inim;
+        return;
+    }
+
     if( filter == hpFilter::gaussian )
     {
         mx::improc::filterImage( work, inim, mx::improc::gaussKernel<mx::improc::eigenImage<float>, 2>( fw ) );
@@ -75,6 +81,12 @@ void applyHPFilter( mx::improc::eigenImage<float> &outim,
 void applyLPFilter( mx::improc::eigenImage<float> &outim, constImageRef inim, lpFilter filter, float fw )
 {
     outim.resize( inim.rows(), inim.cols() );
+
+    if( filter == lpFilter::none || fw <= 0 )
+    {
+        outim = inim;
+        return;
+    }
 
     if( filter == lpFilter::gaussian )
     {

--- a/src/common/rtimvFilters.hpp
+++ b/src/common/rtimvFilters.hpp
@@ -17,6 +17,7 @@ namespace rtimv
 /// Available high-pass filter implementations.
 enum class hpFilter
 {
+    none,     ///< No high-pass filtering.
     gaussian, ///< Subtract a Gaussian-smoothed image (fw is FWHM in pixels).
     median,   ///< Subtract a median-smoothed image (fw is full width in pixels).
     mean,     ///< Subtract a mean-smoothed image (fw is full width in pixels).
@@ -27,6 +28,7 @@ enum class hpFilter
 /// Available low-pass filter implementations.
 enum class lpFilter
 {
+    none,     ///< No low-pass filtering.
     gaussian, ///< Gaussian smoothing (fw is FWHM in pixels).
     median,   ///< Median smoothing (fw is full width in pixels).
     mean      ///< Mean smoothing (fw is full width in pixels).

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -103,12 +103,14 @@ void rtimvControlPanel::setupCombos()
     m_ui.pointerViewModecomboBox->insertItem( PointerViewDisabled, "Disabled" );
     m_ui.pointerViewModecomboBox->setCurrentIndex( PointerViewOnPress );
 
+    m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::none ), "None" );
     m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::gaussian ), "Gaussian" );
     m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::median ), "Median" );
     m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::mean ), "Mean" );
     m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::fourier ), "Fourier (TBD)" );
     m_ui.hpFilterCombo->insertItem( static_cast<int>( rtimv::hpFilter::radprof ), "Radial Profile (TBD)" );
 
+    m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::none ), "None" );
     m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::gaussian ), "Gaussian" );
     m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::median ), "Median" );
     m_ui.lpFilterCombo->insertItem( static_cast<int>( rtimv::lpFilter::mean ), "Mean" );

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -2222,6 +2222,8 @@ void rtimvMainWindow::keyPressEvent( QKeyEvent *ke )
         case Qt::Key_F:
             if( key == 'f' )
                 return toggleFPSGage();
+            if( key == 'F' )
+                return toggleFilter();
             break;
         case Qt::Key_H:
             if( key == 'h' )
@@ -2654,6 +2656,54 @@ void rtimvMainWindow::toggleApplySatMask()
     }
 }
 
+void rtimvMainWindow::toggleFilter()
+{
+    if( applyHPFilter() || applyLPFilter() )
+    {
+        applyHPFilter( false );
+        applyLPFilter( false );
+        ui.graphicsView->zoomText( "filters off" );
+        mtxTry_fontLuminance( ui.graphicsView->zoomText() );
+        return;
+    }
+
+    const bool enableHP = ( hpFilter() != rtimv::hpFilter::none ) && ( hpfFW() > 0 );
+    const bool enableLP = ( lpFilter() != rtimv::lpFilter::none ) && ( lpfFW() > 0 );
+
+    applyHPFilter( enableHP );
+    applyLPFilter( enableLP );
+
+    if( enableHP && enableLP )
+    {
+        ui.graphicsView->zoomText( "HP & LP filter on" );
+    }
+    else if( enableHP )
+    {
+        ui.graphicsView->zoomText( "HP filter on" );
+    }
+    else if( enableLP )
+    {
+        ui.graphicsView->zoomText( "LP filter on" );
+    }
+    else
+    {
+        const bool hpNone = ( hpFilter() == rtimv::hpFilter::none );
+        const bool lpNone = ( lpFilter() == rtimv::lpFilter::none );
+        const bool offByNone = ( hpNone && !enableLP ) || ( lpNone && !enableHP );
+
+        if( offByNone )
+        {
+            ui.graphicsView->zoomText( "filters off (none)" );
+        }
+        else
+        {
+            ui.graphicsView->zoomText( "filters off (FW=0)" );
+        }
+    }
+
+    mtxTry_fontLuminance( ui.graphicsView->zoomText() );
+}
+
 void rtimvMainWindow::toggleLogLinear()
 {
     rtimv::stretch s = stretch();
@@ -2709,8 +2759,8 @@ std::string rtimvMainWindow::generateHelp()
 
     help += "\n";
     help += "C: toggle cube control        D: toggle dark subtraction     \n";
-    help += "L: toggle log scale           M: toggle mask                 \n";
-    help += "S: toggle saturation mask      \n";
+    help += "F: toggle filters             L: toggle log scale           \n";
+    help += "M: toggle mask                S: toggle saturation mask      \n";
 
     help += "\n";
     help += "1-9: change zoom level        ctrl +: zoom in\n";

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -700,6 +700,8 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
 
     void toggleApplySatMask();
 
+    void toggleFilter();
+
     void toggleLogLinear();
 
     void toggleTarget();

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -242,11 +242,12 @@ message ApplySatMaskResponse
 enum HPFilter
 {
     HPFILTER_UNKNOWN = 0;
-    HPFILTER_GAUSSIAN = 1;
-    HPFILTER_MEDIAN = 2;
-    HPFILTER_MEAN = 3;
-    HPFILTER_FOURIER = 4;
-    HPFILTER_RADPROF = 5;
+    HPFILTER_NONE = 1;
+    HPFILTER_GAUSSIAN = 2;
+    HPFILTER_MEDIAN = 3;
+    HPFILTER_MEAN = 4;
+    HPFILTER_FOURIER = 5;
+    HPFILTER_RADPROF = 6;
 }
 
 message HPFilterRequest
@@ -261,9 +262,10 @@ message HPFilterResponse
 enum LPFilter
 {
     LPFILTER_UNKNOWN = 0;
-    LPFILTER_GAUSSIAN = 1;
-    LPFILTER_MEDIAN = 2;
-    LPFILTER_MEAN = 3;
+    LPFILTER_NONE = 1;
+    LPFILTER_GAUSSIAN = 2;
+    LPFILTER_MEDIAN = 3;
+    LPFILTER_MEAN = 4;
 }
 
 message LPFilterRequest

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -740,7 +740,7 @@ class rtimvClientBase : public mx::app::application
     float m_hpfFW{ 10 };                                     ///< Full width for the high-pass filter in pixels.
     bool m_applyHPFilter{ false };                           ///< Whether the high-pass filter is currently enabled.
 
-    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::gaussian }; ///< Selected low-pass filter type.
+    rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::none }; ///< Selected low-pass filter type.
     float m_lpfFW{ 3 };                                      ///< Full width for the low-pass filter in pixels.
     bool m_applyLPFilter{ false };                           ///< Whether the low-pass filter is currently enabled.
 

--- a/src/server/rtimvFilterGRPC.hpp
+++ b/src/server/rtimvFilterGRPC.hpp
@@ -17,6 +17,8 @@ inline remote_rtimv::HPFilter hpFilter2grpc( rtimv::hpFilter filter )
 {
     switch( filter )
     {
+    case rtimv::hpFilter::none:
+        return remote_rtimv::HPFILTER_NONE;
     case rtimv::hpFilter::gaussian:
         return remote_rtimv::HPFILTER_GAUSSIAN;
     case rtimv::hpFilter::median:
@@ -36,6 +38,8 @@ inline rtimv::hpFilter grpc2hpFilter( remote_rtimv::HPFilter filter )
 {
     switch( filter )
     {
+    case remote_rtimv::HPFILTER_NONE:
+        return rtimv::hpFilter::none;
     case remote_rtimv::HPFILTER_GAUSSIAN:
         return rtimv::hpFilter::gaussian;
     case remote_rtimv::HPFILTER_MEDIAN:
@@ -55,6 +59,8 @@ inline remote_rtimv::LPFilter lpFilter2grpc( rtimv::lpFilter filter )
 {
     switch( filter )
     {
+    case rtimv::lpFilter::none:
+        return remote_rtimv::LPFILTER_NONE;
     case rtimv::lpFilter::gaussian:
         return remote_rtimv::LPFILTER_GAUSSIAN;
     case rtimv::lpFilter::median:
@@ -70,6 +76,8 @@ inline rtimv::lpFilter grpc2lpFilter( remote_rtimv::LPFilter filter )
 {
     switch( filter )
     {
+    case remote_rtimv::LPFILTER_NONE:
+        return rtimv::lpFilter::none;
     case remote_rtimv::LPFILTER_GAUSSIAN:
         return rtimv::lpFilter::gaussian;
     case remote_rtimv::LPFILTER_MEDIAN:


### PR DESCRIPTION
work done by GPT-5.3-codex

## Summary
- add \`none\` as an explicit HP/LP filter enum option and expose it in filter combo boxes
- treat \`none\` and \`FW <= 0\` as no-op filtering in filter application logic
- improve \`F\` toggle feedback text to distinguish \`filters off (none)\` vs \`filters off (FW=0)\`
- set LP filter default to \`none\` in both base and client state to keep behavior consistent

## Validation
- built successfully: \`rtimv\`, \`rtimvClient\`, \`rtimvServer\`"
