### PR TITLE
Move stats-box calculations into base and sync over gRPC

### DIFF
--- a/agent_context.md
+++ b/agent_context.md
@@ -73,6 +73,20 @@ Follow these code style and documentation rules exactly.
 14) Header Declaration Parameter Docs
 - In headers, prefer inline parameter documentation on declarations (`type name /**< ... */`) rather than separate `\param` lists, unless there is a specific reason to deviate.
 
+15) PR Prompt Attribution
+- At the top of PR descriptions, include an explicit attribution line when work was performed with Codex.
+- Preferred format:
+  - `This work was performed by GPT-5.3-Codex in response to the prompt: "...".`
+- Include the primary user prompt verbatim (or a faithful condensed version if it is extremely long).
+
+16) Stats Architecture Rule
+- Keep statistics calculations in `rtimvBase`/`rtimvClientBase` rather than GUI classes when the behavior should match between local and gRPC clients.
+- GUI classes should provide region coordinates and render values, but not own the calculation pipeline.
+
+17) Display-Only Widget Pattern
+- When backend state is authoritative, GUI dialogs/widgets should be display-only and poll/read backend values instead of running duplicate worker threads.
+- Prefer a single source of truth for computed values and synchronize via `Image` state where appropriate.
+
 When you finish:
 - Summarize what changed.
 - List affected files.

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -18,6 +18,8 @@
 #include "images/fitsDirectory.hpp"
 #include "images/mzmqImage.hpp"
 
+#include <mx/math/vectorUtils.hpp>
+
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
 #define RTIMV_DEBUG_BREADCRUMB
 
@@ -1363,6 +1365,159 @@ float rtimvBase::colorBox_max()
     return m_colorBox_max;
 }
 
+void rtimvBase::statsBox( bool sb )
+{
+    m_statsBox = sb;
+
+    if( !m_statsBox )
+    {
+        m_statsBox_min = 0;
+        m_statsBox_max = 0;
+        m_statsBox_mean = 0;
+        m_statsBox_median = 0;
+    }
+}
+
+bool rtimvBase::statsBox()
+{
+    return m_statsBox;
+}
+
+void rtimvBase::statsBox_i0( int64_t i0 )
+{
+    m_statsBox_i0 = i0;
+}
+
+int64_t rtimvBase::statsBox_i0()
+{
+    return m_statsBox_i0;
+}
+
+void rtimvBase::statsBox_j0( int64_t j0 )
+{
+    m_statsBox_j0 = j0;
+}
+
+int64_t rtimvBase::statsBox_j0()
+{
+    return m_statsBox_j0;
+}
+
+void rtimvBase::statsBox_i1( int64_t i1 )
+{
+    m_statsBox_i1 = i1;
+}
+
+int64_t rtimvBase::statsBox_i1()
+{
+    return m_statsBox_i1;
+}
+
+void rtimvBase::statsBox_j1( int64_t j1 )
+{
+    m_statsBox_j1 = j1;
+}
+
+int64_t rtimvBase::statsBox_j1()
+{
+    return m_statsBox_j1;
+}
+
+float rtimvBase::statsBox_min()
+{
+    return m_statsBox_min;
+}
+
+float rtimvBase::statsBox_max()
+{
+    return m_statsBox_max;
+}
+
+float rtimvBase::statsBox_mean()
+{
+    return m_statsBox_mean;
+}
+
+float rtimvBase::statsBox_median()
+{
+    return m_statsBox_median;
+}
+
+void rtimvBase::mtxUL_calcStatsBox()
+{
+    sharedLockT lock( m_calMutex );
+
+    mtxL_calcStatsBox( lock );
+}
+
+void rtimvBase::mtxL_calcStatsBox( const sharedLockT &lock )
+{
+    assert( lock.owns_lock() );
+
+    if( !m_statsBox )
+    {
+        return;
+    }
+
+    if( m_nx < 2 || m_ny < 2 || m_calData == nullptr )
+    {
+        m_statsBox_min = 0;
+        m_statsBox_max = 0;
+        m_statsBox_mean = 0;
+        m_statsBox_median = 0;
+        return;
+    }
+
+    normalizeStatsBox();
+
+    m_statsBox_min = std::numeric_limits<float>::max();
+    m_statsBox_max = -std::numeric_limits<float>::max();
+    double mean = 0;
+    size_t nn = 0;
+
+    m_statsBox_medWork.clear();
+    m_statsBox_medWork.reserve( ( m_statsBox_i1 - m_statsBox_i0 + 1 ) * ( m_statsBox_j1 - m_statsBox_j0 + 1 ) );
+
+    for( int64_t j = m_statsBox_j0; j <= m_statsBox_j1; ++j )
+    {
+        for( int64_t i = m_statsBox_i0; i <= m_statsBox_i1; ++i )
+        {
+            float imval = calPixel( i, j );
+
+            if( !std::isfinite( imval ) )
+            {
+                continue;
+            }
+
+            m_statsBox_medWork.push_back( imval );
+
+            mean += imval;
+            ++nn;
+
+            if( imval < m_statsBox_min )
+            {
+                m_statsBox_min = imval;
+            }
+            if( imval > m_statsBox_max )
+            {
+                m_statsBox_max = imval;
+            }
+        }
+    }
+
+    if( nn == 0 )
+    {
+        m_statsBox_min = 0;
+        m_statsBox_max = 0;
+        m_statsBox_mean = 0;
+        m_statsBox_median = 0;
+        return;
+    }
+
+    m_statsBox_mean = mean / nn;
+    m_statsBox_median = mx::math::vectorMedianInPlace( m_statsBox_medWork );
+}
+
 void rtimvBase::stretch( rtimv::stretch ct )
 {
     m_stretch = ct;
@@ -1808,6 +1963,11 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
             }
         }
 
+        if( m_statsBox )
+        {
+            mtxL_calcStatsBox( lock );
+        }
+
         RTIMV_DEBUG_BREADCRUMB
 
         mtxL_recolorImpl();
@@ -2024,6 +2184,15 @@ void rtimvBase::zoomLevel( float zl )
 
 void rtimvBase::normalizeColorBox()
 {
+    if( m_nx < 2 || m_ny < 2 )
+    {
+        m_colorBox_i0 = 0;
+        m_colorBox_i1 = 0;
+        m_colorBox_j0 = 0;
+        m_colorBox_j1 = 0;
+        return;
+    }
+
     if( m_colorBox_i0 < 0 )
     {
         m_colorBox_i0 = 0;
@@ -2068,6 +2237,64 @@ void rtimvBase::normalizeColorBox()
     if( m_colorBox_j0 > m_colorBox_j1 )
     {
         std::swap( m_colorBox_j0, m_colorBox_j1 );
+    }
+}
+
+void rtimvBase::normalizeStatsBox()
+{
+    if( m_nx < 2 || m_ny < 2 )
+    {
+        m_statsBox_i0 = 0;
+        m_statsBox_i1 = 0;
+        m_statsBox_j0 = 0;
+        m_statsBox_j1 = 0;
+        return;
+    }
+
+    if( m_statsBox_i0 < 0 )
+    {
+        m_statsBox_i0 = 0;
+    }
+    else if( m_statsBox_i0 >= (int64_t)m_nx - 1 )
+    {
+        m_statsBox_i0 = (int64_t)m_nx - 2;
+    }
+
+    if( m_statsBox_i1 < 0 )
+    {
+        m_statsBox_i1 = 0;
+    }
+    else if( m_statsBox_i1 >= (int64_t)m_nx - 1 )
+    {
+        m_statsBox_i1 = (int64_t)m_nx - 2;
+    }
+
+    if( m_statsBox_i0 > m_statsBox_i1 )
+    {
+        std::swap( m_statsBox_i0, m_statsBox_i1 );
+    }
+
+    if( m_statsBox_j0 < 0 )
+    {
+        m_statsBox_j0 = 0;
+    }
+    else if( m_statsBox_j0 >= (int64_t)m_ny - 1 )
+    {
+        m_statsBox_j0 = (int64_t)m_ny - 2;
+    }
+
+    if( m_statsBox_j1 <= 0 )
+    {
+        m_statsBox_j1 = 0;
+    }
+    else if( m_statsBox_j1 >= (int64_t)m_ny - 1 )
+    {
+        m_statsBox_j1 = (int64_t)m_ny - 2;
+    }
+
+    if( m_statsBox_j0 > m_statsBox_j1 )
+    {
+        std::swap( m_statsBox_j0, m_statsBox_j1 );
     }
 }
 

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -700,6 +700,125 @@ class rtimvBase : public mx::app::application
 
     ///@}
 
+    /** @name Stats Box - Data
+     *
+     * @{
+     */
+  private:
+    /// The stats box upper left corner x coordinate
+    int64_t m_statsBox_i0{ 0 };
+
+    /// The stats box lower right corner x coordinate
+    int64_t m_statsBox_i1{ 0 };
+
+    /// The stats box upper left corner y coordinate
+    int64_t m_statsBox_j0{ 0 };
+
+    /// The stats box lower right corner y coordinate
+    int64_t m_statsBox_j1{ 0 };
+
+    /// Adjusts the stats box coordinates to ensure they are valid
+    void normalizeStatsBox();
+
+  protected:
+    /// Whether stats-box calculations are enabled.
+    bool m_statsBox{ false };
+
+    /// The minimum calibrated value in the stats box.
+    float m_statsBox_min{ 0 };
+
+    /// The maximum calibrated value in the stats box.
+    float m_statsBox_max{ 0 };
+
+    /// The mean calibrated value in the stats box.
+    float m_statsBox_mean{ 0 };
+
+    /// The median calibrated value in the stats box.
+    float m_statsBox_median{ 0 };
+
+    /// Working storage used for median calculation.
+    std::vector<float> m_statsBox_medWork;
+    ///@}
+
+    /** @name Stats Box
+     *
+     * @{
+     */
+  public:
+    /// Set whether stats-box calculations are enabled.
+    void statsBox( bool sb /**< [in] true enables stats-box calculations */ );
+
+    /// Get whether stats-box calculations are enabled.
+    bool statsBox();
+
+    /// Set the stats box upper left corner x coordinate.
+    void statsBox_i0( int64_t i0 /**< [in] the new upper-left x coordinate */ );
+
+    /// Get the stats box upper left corner x coordinate.
+    /**
+     * \returns m_statsBox_i0
+     */
+    int64_t statsBox_i0();
+
+    /// Set the stats box upper left corner y coordinate.
+    void statsBox_j0( int64_t j0 /**< [in] the new upper-left y coordinate */ );
+
+    /// Get the stats box upper left corner y coordinate.
+    /**
+     * \returns m_statsBox_j0
+     */
+    int64_t statsBox_j0();
+
+    /// Set the stats box lower right corner x coordinate.
+    void statsBox_i1( int64_t i1 /**< [in] the new lower-right x coordinate */ );
+
+    /// Get the stats box lower right corner x coordinate.
+    /**
+     * \returns m_statsBox_i1
+     */
+    int64_t statsBox_i1();
+
+    /// Set the stats box lower right corner y coordinate.
+    void statsBox_j1( int64_t j1 /**< [in] the new lower-right y coordinate */ );
+
+    /// Get the stats box lower right corner y coordinate.
+    /**
+     * \returns m_statsBox_j1
+     */
+    int64_t statsBox_j1();
+
+    /// Get the minimum calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_min
+     */
+    float statsBox_min();
+
+    /// Get the maximum calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_max
+     */
+    float statsBox_max();
+
+    /// Get the mean calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_mean
+     */
+    float statsBox_mean();
+
+    /// Get the median calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_median
+     */
+    float statsBox_median();
+
+    /// Calculate stats-box values while not holding \ref m_calMutex.
+    void mtxUL_calcStatsBox();
+
+    /// Calculate stats-box values with \ref m_calMutex in shared lock.
+    void mtxL_calcStatsBox( const sharedLockT &lock /**<[in] a shared mutex lock which is locked on m_calMutex*/ );
+
+    ///@}
+
     /** @name Color Stretch - Data
      *
      * @{

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -613,13 +613,6 @@ void rtimvMainWindow::mtxL_postChangeImdata( const sharedLockT &lock )
 
     RTIMV_DEBUG_BREADCRUMB
 
-    if( imStats )
-    {
-        imStats->setImdata();
-    }
-
-    RTIMV_DEBUG_BREADCRUMB
-
     if( m_connected ) // first time through this won't be true
     {
         if( imageValid( 0 ) ) // really can't be false if connected
@@ -1434,11 +1427,12 @@ void rtimvMainWindow::doLaunchStatsBox()
 
     if( !imStats )
     {
-        imStats = new rtimvStats( this, &m_calMutex, this, Qt::WindowFlags() );
+        imStats = new rtimvStats( this, this, Qt::WindowFlags() );
         imStats->setAttribute( Qt::WA_DeleteOnClose ); // Qt will delete imstats when it closes.
         connect( imStats, SIGNAL( finished( int ) ), this, SLOT( imStatsClosed( int ) ) );
     }
 
+    statsBox( true );
     mtxTry_statsBoxMoved( m_statsBox );
 
     imStats->show();
@@ -1448,6 +1442,8 @@ void rtimvMainWindow::doLaunchStatsBox()
 
 void rtimvMainWindow::doHideStatsBox()
 {
+    statsBox( false );
+
     if( imStats )
     {
         delete imStats;
@@ -1486,8 +1482,6 @@ void rtimvMainWindow::imStatsClosed( int result )
 
 void rtimvMainWindow::mtxTry_statsBoxMoved( StretchBox *sb )
 {
-    sharedLockT lock( m_calMutex );
-
     if( !m_statsBox )
         return;
 
@@ -1499,10 +1493,11 @@ void rtimvMainWindow::mtxTry_statsBoxMoved( StretchBox *sb )
                                        QPointF( m_statsBox->rect().x() + m_statsBox->rect().width(),
                                                 m_statsBox->rect().y() + m_statsBox->rect().height() ) );
 
-    if( imStats )
-    {
-        imStats->mtxL_setImdata( m_nx, m_ny, np.x(), np2.x(), m_ny - np2.y(), m_ny - np.y(), lock );
-    }
+    statsBox_i0( np.x() );
+    statsBox_i1( np2.x() );
+    statsBox_j0( m_ny - np2.y() );
+    statsBox_j1( m_ny - np.y() );
+    mtxUL_calcStatsBox();
 
     mtxTry_userBoxMoved( sb );
 }

--- a/src/gui/rtimvStats.cpp
+++ b/src/gui/rtimvStats.cpp
@@ -1,33 +1,18 @@
-
+/** \file rtimvStats.cpp
+ * \brief Definitions for the rtimvStats display dialog.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
 #include "rtimvStats.hpp"
 
-double get_curr_time()
-{
-    struct timespec tsp;
-    clock_gettime( CLOCK_REALTIME, &tsp );
+#include <cmath>
 
-    return ( (double)tsp.tv_sec ) + ( (double)tsp.tv_nsec ) / 1e9;
-}
-
-void StatsThread::run()
-{
-    m_imvs->statsThread();
-}
-
-rtimvStats::rtimvStats( RTIMV_BASE *imv, std::shared_mutex *calMutex, QWidget *Parent, Qt::WindowFlags f )
-    : QDialog( Parent, f )
+rtimvStats::rtimvStats( RTIMV_BASE *imv, QWidget *Parent, Qt::WindowFlags f ) : QDialog( Parent, f )
 {
     ui.setupUi( this );
 
     m_imv = imv;
-    m_calMutex = calMutex;
-
-    m_statsPause = 20;
     m_updateTimerTimeout = 50;
-
-    // Start stats thread here.
-    m_statsThread.m_imvs = this;
-    m_statsThread.start();
 
     connect( &m_updateTimer, SIGNAL( timeout() ), this, SLOT( updateGUI() ) );
     m_updateTimer.start( m_updateTimerTimeout );
@@ -35,177 +20,59 @@ rtimvStats::rtimvStats( RTIMV_BASE *imv, std::shared_mutex *calMutex, QWidget *P
 
 rtimvStats::~rtimvStats()
 {
-    m_dieNow = 1;
-    m_statsThread.wait();
-}
-
-void rtimvStats::setImdata()
-{
-    m_regionChanged = 1;
-}
-
-void rtimvStats::mtxL_setImdata(
-    size_t nx, size_t ny, size_t x0, size_t x1, size_t y0, size_t y1, std::shared_lock<std::shared_mutex> &lock )
-{
-    assert( lock.owns_lock() );
-
-    if( x1 <= x0 || x0 > nx || x1 > nx || y1 <= y0 || y0 > ny || y1 > ny )
-    {
-        m_regionChanged = 0;
-        return; // Bad data.
-    }
-
-    std::unique_lock<std::mutex> lockData( m_dataMutex );
-
-    m_nx = nx;
-    m_ny = ny;
-    m_x0 = x0;
-    m_x1 = x1;
-    m_y0 = y0;
-    m_y1 = y1;
-
-    // avoid comparison warning.  we checked if these would be > 0 above.
-    int dx = x1 - x0;
-    int dy = y1 - y0;
-    if( dx != m_imdata.rows() || dy != m_imdata.cols() )
-    {
-        m_imdata.resize( dx, dy );
-    }
-
-    m_regionChanged = 1;
-}
-
-void rtimvStats::statsThread()
-{
-    while( !m_dieNow )
-    {
-        usleep( m_statsPause * 1000 );
-        mtxUL_calcStats();
-    }
-}
-
-void rtimvStats::mtxUL_calcStats()
-{
-
-    if( !m_regionChanged )
-    {
-        return;
-    }
-
-    if( m_imv == nullptr )
-    {
-        m_regionChanged = 0;
-        return; // no data.
-    }
-
-    if( m_calMutex == nullptr )
-    {
-        m_regionChanged = 0;
-        return; // no data.
-    }
-
-    // Get the cal data mutex
-    std::shared_lock<std::shared_mutex> lockCal( *m_calMutex );
-
-    // mutex lock here (trylock, exit and wait if can't get it)
-    std::unique_lock<std::mutex> lockData( m_dataMutex, std::try_to_lock );
-    if( !lockData.owns_lock() )
-        return;
-
-    // After locking, verify that this is still the same size.
-    if( m_imv->nx() != m_nx || m_imv->ny() != m_ny )
-    {
-        return;
-    }
-
-    // copy data so we can be safe from changes to image memory
-    for( size_t i = m_x0; i < m_x1; ++i )
-    {
-        for( size_t j = m_y0; j < m_y1; ++j )
-        {
-            m_imdata( i - m_x0, j - m_y0 ) = m_imv->calPixel( i, j );
-        }
-    }
-
-    lockCal.unlock();
-
-    float tmp_min = m_imdata( 0, 0 );
-    float tmp_max = tmp_min;
-    float tmp_mean = 0;
-
-    m_medWork.resize( m_imdata.cols() * m_imdata.rows() ); // Should be a no-op most of the time
-    size_t nn = 0;
-    for( int c = 0; c < m_imdata.cols(); ++c )
-    {
-        for( int r = 0; r < m_imdata.rows(); ++r )
-        {
-            float imval = m_imdata( r, c );
-
-            tmp_mean += imval;
-            if( imval < tmp_min )
-                tmp_min = imval;
-            if( imval > tmp_max )
-                tmp_max = imval;
-
-            m_medWork[nn] = imval;
-            ++nn;
-        }
-    }
-
-    m_dataMin = tmp_min;
-    m_dataMax = tmp_max;
-    m_dataMean = tmp_mean / ( m_imdata.rows() * m_imdata.cols() );
-    m_dataMedian = mx::math::vectorMedianInPlace( m_medWork );
-
-    m_statsChanged = 1;
-    m_regionChanged = 0;
 }
 
 void rtimvStats::updateGUI()
 {
-    char txt[50];
-    if( m_statsChanged )
+    if( m_imv == nullptr )
     {
-        if( fabs( m_dataMin ) < 1e-1 )
-        {
-            snprintf( txt, sizeof( txt ), "%0.04g", (float)m_dataMin );
-        }
-        else
-        {
-            snprintf( txt, sizeof( txt ), "%0.02f", (float)m_dataMin );
-        }
-        ui.dataMin->setText( txt );
-
-        if( fabs( m_dataMax ) < 1e-1 )
-        {
-            snprintf( txt, sizeof( txt ), "%0.04g", (float)m_dataMax );
-        }
-        else
-        {
-            snprintf( txt, sizeof( txt ), "%0.02f", (float)m_dataMax );
-        }
-        ui.dataMax->setText( txt );
-
-        if( fabs( m_dataMean ) < 1e-1 )
-        {
-            snprintf( txt, sizeof( txt ), "%0.04g", (float)m_dataMean );
-        }
-        else
-        {
-            snprintf( txt, sizeof( txt ), "%0.02f", (float)m_dataMean );
-        }
-        ui.dataMean->setText( txt );
-
-        if( fabs( m_dataMedian ) < 1e-1 )
-        {
-            snprintf( txt, sizeof( txt ), "%0.04g", (float)m_dataMedian );
-        }
-        else
-        {
-            snprintf( txt, sizeof( txt ), "%0.02f", (float)m_dataMedian );
-        }
-        ui.dataMedian->setText( txt );
-
-        m_statsChanged = 0;
+        return;
     }
+
+    char txt[50];
+
+    float dataMin = m_imv->statsBox_min();
+    float dataMax = m_imv->statsBox_max();
+    float dataMean = m_imv->statsBox_mean();
+    float dataMedian = m_imv->statsBox_median();
+
+    if( std::fabs( dataMin ) < 1e-1 )
+    {
+        snprintf( txt, sizeof( txt ), "%0.04g", dataMin );
+    }
+    else
+    {
+        snprintf( txt, sizeof( txt ), "%0.02f", dataMin );
+    }
+    ui.dataMin->setText( txt );
+
+    if( std::fabs( dataMax ) < 1e-1 )
+    {
+        snprintf( txt, sizeof( txt ), "%0.04g", dataMax );
+    }
+    else
+    {
+        snprintf( txt, sizeof( txt ), "%0.02f", dataMax );
+    }
+    ui.dataMax->setText( txt );
+
+    if( std::fabs( dataMean ) < 1e-1 )
+    {
+        snprintf( txt, sizeof( txt ), "%0.04g", dataMean );
+    }
+    else
+    {
+        snprintf( txt, sizeof( txt ), "%0.02f", dataMean );
+    }
+    ui.dataMean->setText( txt );
+
+    if( std::fabs( dataMedian ) < 1e-1 )
+    {
+        snprintf( txt, sizeof( txt ), "%0.04g", dataMedian );
+    }
+    else
+    {
+        snprintf( txt, sizeof( txt ), "%0.02f", dataMedian );
+    }
+    ui.dataMedian->setText( txt );
 }

--- a/src/gui/rtimvStats.hpp
+++ b/src/gui/rtimvStats.hpp
@@ -1,16 +1,15 @@
-
+/** \file rtimvStats.hpp
+ * \brief Declarations for the rtimvStats display dialog.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
 #ifndef rtimv_rtimvStats_hpp
 #define rtimv_rtimvStats_hpp
 
 #include <cstdio>
-#include <unistd.h>
-
-#include <mutex>
 
 #include <QDialog>
-#include <QThread>
-
-#include <mx/improc/eigenImage.hpp>
+#include <QTimer>
 
 #include "ui_rtimvStats.h"
 
@@ -18,33 +17,17 @@
 
 #include RTIMV_BASE_INCLUDE
 
-class rtimvStats;
-
-/// Thread class to start the stats thread.
-class StatsThread : public QThread
-{
-  public:
-    void run();
-    rtimvStats *m_imvs;
-};
-
-/// Class to manage calculating statistics in the designated image region
-/** Copies the data in the region to a local array.  While less efficient than not doing so,
- * this is done to avoid problems if the image goes away while the stats calculations are occurring.
+/// Class to display statistics for the configured stats box.
+/** This class is display-only. Statistical calculations and region state are
+ * maintained in RTIMV_BASE and queried here for presentation.
  */
 class rtimvStats : public QDialog
 {
     Q_OBJECT
 
-  private:
-    rtimvStats()
-    {
-    }
-
   public:
     /// Constructor
-    rtimvStats( RTIMV_BASE *imv, ///< [in] The rtimv instance this is connected to
-                std::shared_mutex *calMutex,
+    rtimvStats( RTIMV_BASE *imv,              ///< [in] The rtimv instance this is connected to
                 QWidget *Parent = nullptr,            ///< [in] [optional] Qt parent widget
                 Qt::WindowFlags f = Qt::WindowFlags() ///< [in] [optional] Qt flags for this widget
     );
@@ -55,71 +38,8 @@ class rtimvStats : public QDialog
   protected:
     RTIMV_BASE *m_imv{ nullptr }; ///< The rtimv instance this is connected to
 
-    std::shared_mutex *m_calMutex{ nullptr };
-
-    int m_statsPause{ 20 }; ///< Pause between checks if the stats thread needs to calculate, milliseconds.
-
     QTimer m_updateTimer;           ///< When this times out the GUI is updated if needed.
     int m_updateTimerTimeout{ 50 }; ///< The GUI update timeout, milliseconds.
-
-    size_t m_nx{ 0 }; ///< The x size of the image, stored internally for copying from image data to local array
-    size_t m_ny{ 0 }; ///< The y size of the image, stored internally for copying from image data to local array
-    size_t m_x0{ 0 }; ///< The x coordinate of the starting corner of the region, stored internally for copying from
-                      ///< image data to local array
-    size_t m_x1{ 0 }; ///< The x coordinate of the ending corner of the region, stored internally for copying from image
-                      ///< data to local array
-    size_t m_y0{ 0 }; ///< The y coordinate of the starting corner of the region, stored internally for copying from
-                      ///< image data to local array
-    size_t m_y1{ 0 }; ///< The y coordinate of the ending corner of the region, stored internally for copying from image
-                      ///< data to local array
-
-    mx::improc::eigenImage<float> m_imdata; ///< Local image storage.  The region is copied to this for robustness
-                                            ///< against segfaults from image changes.
-
-    float m_dataMin{ 0 };  ///< The minimum value in the data
-    float m_dataMax{ 0 };  ///< The maximum value in the data
-    float m_dataMean{ 0 }; ///< The mean value in the data
-
-    std::vector<float> m_medWork; ///< Working memory for median calculation
-
-    float m_dataMedian{ 0 }; ///< The median value in the data
-
-    int m_regionChanged{ 0 }; /**< Flag indicating that the region has changed,
-                                   either size, location, or the data itself*/
-    int m_statsChanged{ 0 };  ///< Flag indicating that the statistics have changed
-    int m_dieNow{ 0 };        ///< Flag indicating that the stats thread should exit
-
-    std::mutex m_dataMutex; ///< Mutex for updating the local image (m_imdata).
-
-    StatsThread m_statsThread; ///< Thread for calculating the stats.
-
-  public:
-    /// Called by rtimvMainWindow to indicate that the data has changed.
-    void setImdata();
-
-    /// Called by rtimvMainWindow to indicate that the region has changed.
-    /**
-     * The calibration data mutex must be locked when this is called.
-     */
-    void mtxL_setImdata( size_t nx, ///< [in] the new image x size
-                         size_t ny, ///< [in] the new image y size
-                         size_t x0, ///< The x coordinate of the starting corner of the region.
-                         size_t x1, ///< The x coordinate of the ending corner of the region.
-                         size_t y0, ///< The y coordinate of the starting corner of the region.
-                         size_t y1, ///< The y coordinate of the ending corner of the region.
-                         std::shared_lock<std::shared_mutex> &lock ///< The locked mutex.
-    );
-
-    /// Run funciton for the statistics thread.
-    /** Pauses for m_statsPause then calls calcStats, until m_dieNow is called.
-     */
-    void statsThread();
-
-    /// Calculate the statistics.
-    /**
-     * Both the rtimv cal mutex and the local data mutex will be try-locked.
-     */
-    void mtxUL_calcStats();
 
   protected slots:
 

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -60,7 +60,7 @@ service rtimv
 
     rpc Recolor(RecolorRequest) returns (RecolorResponse);
 
-    rpc StatsBox(Box) returns(Pixel);
+    rpc StatsBox(Box) returns(StatsValues);
 
 }
 
@@ -387,6 +387,16 @@ message Image
     LPFilter lp_filter = 188;
     float lpf_fw = 189;
     bool apply_lp_filter = 190;
+
+    bool stats_box = 191;
+    uint32 stats_box_i0 = 192;
+    uint32 stats_box_i1 = 193;
+    uint32 stats_box_j0 = 194;
+    uint32 stats_box_j1 = 195;
+    float stats_box_min = 196;
+    float stats_box_max = 197;
+    float stats_box_mean = 198;
+    float stats_box_median = 199;
 }
 
 message Coord
@@ -431,4 +441,17 @@ message RecolorRequest
 
 message RecolorResponse
 {
+}
+
+message StatsValues
+{
+    bool valid = 1;
+    uint32 i0 = 2;
+    uint32 i1 = 3;
+    uint32 j0 = 4;
+    uint32 j1 = 5;
+    float min = 6;
+    float max = 7;
+    float mean = 8;
+    float median = 9;
 }

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -586,6 +586,9 @@ void rtimvClientBase::ImageReceived()
     remote_rtimv::LPFilter lpFilter;
     float lpfFW;
     bool applyLPFilter;
+    bool statsBox;
+    uint32_t statsBox_i0, statsBox_i1, statsBox_j0, statsBox_j1;
+    float statsBox_min, statsBox_max, statsBox_mean, statsBox_median;
     int cubeDir;
     bool hasImagePayload{ false };
 
@@ -656,6 +659,15 @@ void rtimvClientBase::ImageReceived()
         lpFilter = m_grpcImage.lp_filter();
         lpfFW = m_grpcImage.lpf_fw();
         applyLPFilter = m_grpcImage.apply_lp_filter();
+        statsBox = m_grpcImage.stats_box();
+        statsBox_i0 = m_grpcImage.stats_box_i0();
+        statsBox_i1 = m_grpcImage.stats_box_i1();
+        statsBox_j0 = m_grpcImage.stats_box_j0();
+        statsBox_j1 = m_grpcImage.stats_box_j1();
+        statsBox_min = m_grpcImage.stats_box_min();
+        statsBox_max = m_grpcImage.stats_box_max();
+        statsBox_mean = m_grpcImage.stats_box_mean();
+        statsBox_median = m_grpcImage.stats_box_median();
 
         imageTimeout = m_grpcImage.image_timeout();
         cubeDir = m_grpcImage.cube_dir();
@@ -715,6 +727,15 @@ void rtimvClientBase::ImageReceived()
     }
     m_lpfFW = lpfFW;
     m_applyLPFilter = applyLPFilter;
+    m_statsBox = statsBox;
+    m_statsBox_i0 = statsBox_i0;
+    m_statsBox_i1 = statsBox_i1;
+    m_statsBox_j0 = statsBox_j0;
+    m_statsBox_j1 = statsBox_j1;
+    m_statsBox_min = statsBox_min;
+    m_statsBox_max = statsBox_max;
+    m_statsBox_mean = statsBox_mean;
+    m_statsBox_median = statsBox_median;
     m_imageTimeout = imageTimeout;
     m_quality = quality;
     if( m_cubeDir != cubeDir )
@@ -1559,6 +1580,152 @@ float rtimvClientBase::colorBox_min()
 float rtimvClientBase::colorBox_max()
 {
     return m_colorBox_max;
+}
+
+void rtimvClientBase::statsBox( bool sb )
+{
+    m_statsBox = sb;
+
+    if( sb )
+    {
+        return;
+    }
+
+    m_statsBox_min = 0;
+    m_statsBox_max = 0;
+    m_statsBox_mean = 0;
+    m_statsBox_median = 0;
+
+    SHARED_CONN_LOCK
+
+    remote_rtimv::Box request;
+    remote_rtimv::StatsValues vals;
+    grpc::ClientContext context;
+
+    remote_rtimv::Coord *ul = new remote_rtimv::Coord;
+    ul->set_x( 1 );
+    ul->set_y( 1 );
+    request.set_allocated_upper_left( ul );
+
+    remote_rtimv::Coord *lr = new remote_rtimv::Coord;
+    lr->set_x( 0 );
+    lr->set_y( 0 );
+    request.set_allocated_lower_right( lr );
+
+    grpc::Status status = stub_->StatsBox( &context, request, &vals );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+        return;
+    }
+}
+
+bool rtimvClientBase::statsBox()
+{
+    return m_statsBox;
+}
+
+void rtimvClientBase::statsBox_i0( int64_t i0 )
+{
+    m_statsBox_i0 = i0;
+}
+
+int64_t rtimvClientBase::statsBox_i0()
+{
+    return m_statsBox_i0;
+}
+
+void rtimvClientBase::statsBox_i1( int64_t i1 )
+{
+    m_statsBox_i1 = i1;
+}
+
+int64_t rtimvClientBase::statsBox_i1()
+{
+    return m_statsBox_i1;
+}
+
+void rtimvClientBase::statsBox_j0( int64_t j0 )
+{
+    m_statsBox_j0 = j0;
+}
+
+int64_t rtimvClientBase::statsBox_j0()
+{
+    return m_statsBox_j0;
+}
+
+void rtimvClientBase::statsBox_j1( int64_t j1 )
+{
+    m_statsBox_j1 = j1;
+}
+
+int64_t rtimvClientBase::statsBox_j1()
+{
+    return m_statsBox_j1;
+}
+
+float rtimvClientBase::statsBox_min()
+{
+    return m_statsBox_min;
+}
+
+float rtimvClientBase::statsBox_max()
+{
+    return m_statsBox_max;
+}
+
+float rtimvClientBase::statsBox_mean()
+{
+    return m_statsBox_mean;
+}
+
+float rtimvClientBase::statsBox_median()
+{
+    return m_statsBox_median;
+}
+
+void rtimvClientBase::mtxUL_calcStatsBox()
+{
+    SHARED_CONN_LOCK
+
+    remote_rtimv::Box request;
+    remote_rtimv::StatsValues vals;
+    grpc::ClientContext context;
+
+    remote_rtimv::Coord *ul = new remote_rtimv::Coord;
+    ul->set_x( m_statsBox_i0 );
+    ul->set_y( m_statsBox_j0 );
+    request.set_allocated_upper_left( ul );
+
+    remote_rtimv::Coord *lr = new remote_rtimv::Coord;
+    lr->set_x( m_statsBox_i1 );
+    lr->set_y( m_statsBox_j1 );
+    request.set_allocated_lower_right( lr );
+
+    grpc::Status status = stub_->StatsBox( &context, request, &vals );
+
+    if( !status.ok() )
+    {
+        REPORT_SERVER_DISCONNECTED
+        return;
+    }
+
+    if( !vals.valid() )
+    {
+        return;
+    }
+
+    m_statsBox = true;
+    m_statsBox_i0 = vals.i0();
+    m_statsBox_i1 = vals.i1();
+    m_statsBox_j0 = vals.j0();
+    m_statsBox_j1 = vals.j1();
+    m_statsBox_min = vals.min();
+    m_statsBox_max = vals.max();
+    m_statsBox_mean = vals.mean();
+    m_statsBox_median = vals.median();
 }
 
 void rtimvClientBase::stretch( rtimv::stretch cs )

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -654,6 +654,116 @@ class rtimvClientBase : public mx::app::application
 
     ///@}
 
+    /** @name Stats Box - Data
+     *
+     * @{
+     */
+  private:
+    /// The stats box upper left corner x coordinate.
+    int64_t m_statsBox_i0{ 0 };
+
+    /// The stats box lower right corner x coordinate.
+    int64_t m_statsBox_i1{ 0 };
+
+    /// The stats box upper left corner y coordinate.
+    int64_t m_statsBox_j0{ 0 };
+
+    /// The stats box lower right corner y coordinate.
+    int64_t m_statsBox_j1{ 0 };
+
+  protected:
+    /// Whether stats-box calculations are enabled.
+    bool m_statsBox{ false };
+
+    /// The minimum calibrated value in the stats box.
+    float m_statsBox_min{ 0 };
+
+    /// The maximum calibrated value in the stats box.
+    float m_statsBox_max{ 0 };
+
+    /// The mean calibrated value in the stats box.
+    float m_statsBox_mean{ 0 };
+
+    /// The median calibrated value in the stats box.
+    float m_statsBox_median{ 0 };
+    ///@}
+
+    /** @name Stats Box
+     *
+     * @{
+     */
+  public:
+    /// Set whether stats-box calculations are enabled.
+    void statsBox( bool sb /**< [in] true enables stats-box calculations */ );
+
+    /// Get whether stats-box calculations are enabled.
+    bool statsBox();
+
+    /// Set the stats box upper left corner x coordinate.
+    void statsBox_i0( int64_t i0 /**< [in] the new upper-left x coordinate */ );
+
+    /// Get the stats box upper left corner x coordinate.
+    /**
+     * \returns m_statsBox_i0
+     */
+    int64_t statsBox_i0();
+
+    /// Set the stats box upper left corner y coordinate.
+    void statsBox_j0( int64_t j0 /**< [in] the new upper-left y coordinate */ );
+
+    /// Get the stats box upper left corner y coordinate.
+    /**
+     * \returns m_statsBox_j0
+     */
+    int64_t statsBox_j0();
+
+    /// Set the stats box lower right corner x coordinate.
+    void statsBox_i1( int64_t i1 /**< [in] the new lower-right x coordinate */ );
+
+    /// Get the stats box lower right corner x coordinate.
+    /**
+     * \returns m_statsBox_i1
+     */
+    int64_t statsBox_i1();
+
+    /// Set the stats box lower right corner y coordinate.
+    void statsBox_j1( int64_t j1 /**< [in] the new lower-right y coordinate */ );
+
+    /// Get the stats box lower right corner y coordinate.
+    /**
+     * \returns m_statsBox_j1
+     */
+    int64_t statsBox_j1();
+
+    /// Get the minimum calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_min
+     */
+    float statsBox_min();
+
+    /// Get the maximum calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_max
+     */
+    float statsBox_max();
+
+    /// Get the mean calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_mean
+     */
+    float statsBox_mean();
+
+    /// Get the median calibrated value in the stats box.
+    /**
+     * \returns m_statsBox_median
+     */
+    float statsBox_median();
+
+    /// Request stats-box calculations from the server.
+    void mtxUL_calcStatsBox();
+
+    ///@}
+
     /** @name Color Stretch - Data
      *
      * @{

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -590,6 +590,16 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         reply->set_lp_filter( rtimv::lpFilter2grpc( imageTh->lpFilter() ) );
         reply->set_lpf_fw( imageTh->lpfFW() );
         reply->set_apply_lp_filter( imageTh->applyLPFilter() );
+
+        reply->set_stats_box( imageTh->statsBox() );
+        reply->set_stats_box_i0( imageTh->statsBox_i0() );
+        reply->set_stats_box_i1( imageTh->statsBox_i1() );
+        reply->set_stats_box_j0( imageTh->statsBox_j0() );
+        reply->set_stats_box_j1( imageTh->statsBox_j1() );
+        reply->set_stats_box_min( imageTh->statsBox_min() );
+        reply->set_stats_box_max( imageTh->statsBox_max() );
+        reply->set_stats_box_mean( imageTh->statsBox_mean() );
+        reply->set_stats_box_median( imageTh->statsBox_median() );
     };
 
     if( imageTh->newImage() == false )
@@ -807,6 +817,57 @@ ServerUnaryReactor *rtimvServer::Recolor( CallbackServerContext *context,
     imageTh->mtxUL_recolor();
 
     reactor->Finish( Status::OK ); // maybe send something else?
+    return reactor;
+}
+
+ServerUnaryReactor *rtimvServer::StatsBox( CallbackServerContext *context,
+                                           const remote_rtimv::Box *request,
+                                           remote_rtimv::StatsValues *reply )
+{
+    PREPARE_RPC_REACTOR
+
+    if( !imageTh->connected() )
+    {
+        reply->set_valid( false );
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    if( request->lower_right().x() <= request->upper_left().x() || request->lower_right().y() <= request->upper_left().y() )
+    {
+        imageTh->statsBox( false );
+        reply->set_valid( true );
+        reply->set_i0( imageTh->statsBox_i0() );
+        reply->set_i1( imageTh->statsBox_i1() );
+        reply->set_j0( imageTh->statsBox_j0() );
+        reply->set_j1( imageTh->statsBox_j1() );
+        reply->set_min( imageTh->statsBox_min() );
+        reply->set_max( imageTh->statsBox_max() );
+        reply->set_mean( imageTh->statsBox_mean() );
+        reply->set_median( imageTh->statsBox_median() );
+
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    imageTh->statsBox_i0( request->upper_left().x() );
+    imageTh->statsBox_j0( request->upper_left().y() );
+    imageTh->statsBox_i1( request->lower_right().x() );
+    imageTh->statsBox_j1( request->lower_right().y() );
+    imageTh->statsBox( true );
+    imageTh->mtxUL_calcStatsBox();
+
+    reply->set_valid( true );
+    reply->set_i0( imageTh->statsBox_i0() );
+    reply->set_i1( imageTh->statsBox_i1() );
+    reply->set_j0( imageTh->statsBox_j0() );
+    reply->set_j1( imageTh->statsBox_j1() );
+    reply->set_min( imageTh->statsBox_min() );
+    reply->set_max( imageTh->statsBox_max() );
+    reply->set_mean( imageTh->statsBox_mean() );
+    reply->set_median( imageTh->statsBox_median() );
+
+    reactor->Finish( Status::OK );
     return reactor;
 }
 

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -241,6 +241,10 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                  const remote_rtimv::RecolorRequest *request,
                                  remote_rtimv::RecolorResponse *reply ) override;
 
+    ServerUnaryReactor *StatsBox( CallbackServerContext *context,
+                                  const remote_rtimv::Box *request,
+                                  remote_rtimv::StatsValues *reply ) override;
+
   signals:
 
     void gotConfigure( const configSpec * );


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex in response to the prompt:
"Next project: the rtimvStats calculates image statistics in a box manipulated by the user. in rtimvStats.hpp/cpp the stats calculations are integrated into the Qt GUI connected to rtimvMainWindow. I want to move the stats calculations to be part of rtimvBase rather than rtimvMainWindow, independent of GUI. At a high-level this is similar to how the colorBox works, where the source of the coordinates of the box are not specified. Once we have moved the stats calcs down to rtimvBase, we can then also implement a GRPC interface to it in rtimvClientBase so that both the local application (rtimv) and the rpc application (rtimvClient) behave the same."

## Summary
- moved stats-box calculations from GUI-owned `rtimvStats` worker logic into `rtimvBase`
- added stats-box data/access API to `rtimvBase` and mirrored the same interface in `rtimvClientBase`
- updated `rtimvMainWindow` to set stats-box coordinates via base/client API and trigger backend stats updates
- refactored `rtimvStats` to display-only (reads computed stats from base/client state)
- extended proto/service so stats-box state and computed values are synchronized over gRPC
- implemented `StatsBox` RPC handling on server and client
- added stats-box fields to `Image` state updates for consistent local/remote behavior
- polished doxygen/docs for new stats-box sections and updated `rtimvStats` file/class docs

## Validation
- built successfully:
  - `rtimv`
  - `rtimvClient`
  - `rtimvServer`

## Notes
- stats-box disable is handled for remote clients through the existing `StatsBox` RPC path.
