### PR TITLE
Make Hover/Box RPCs Async with Debounced GUI Updates for Remote Responsiveness

### DIFF
--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -1081,6 +1081,22 @@ float rtimvBase::calPixel( uint32_t x, uint32_t y )
     return m_calData[y * m_nx + x];
 }
 
+void rtimvBase::requestPixelValue( uint32_t x, uint32_t y )
+{
+    if( m_foundation == nullptr )
+    {
+        return;
+    }
+
+    if( m_nx == 0 || m_ny == 0 || m_calData == nullptr || x >= m_nx || y >= m_ny )
+    {
+        m_foundation->emit_pixelValueUpdated( x, y, 0, false );
+        return;
+    }
+
+    m_foundation->emit_pixelValueUpdated( x, y, calPixel( x, y ), true );
+}
+
 uint8_t rtimvBase::satPixel( uint32_t x, uint32_t y )
 {
     return m_satData[y * m_nx + x];
@@ -1365,6 +1381,20 @@ float rtimvBase::colorBox_max()
     return m_colorBox_max;
 }
 
+void rtimvBase::requestColorBoxValues()
+{
+    sharedLockT lock( m_calMutex );
+    mtxL_colormode( rtimv::colormode::minmaxbox, lock );
+
+    if( m_foundation == nullptr )
+    {
+        return;
+    }
+
+    m_foundation->emit_colorBoxUpdated(
+        m_colorBox_i0, m_colorBox_i1, m_colorBox_j0, m_colorBox_j1, m_colorBox_min, m_colorBox_max, true );
+}
+
 void rtimvBase::statsBox( bool sb )
 {
     m_statsBox = sb;
@@ -1448,6 +1478,26 @@ void rtimvBase::mtxUL_calcStatsBox()
     sharedLockT lock( m_calMutex );
 
     mtxL_calcStatsBox( lock );
+}
+
+void rtimvBase::requestStatsBoxValues()
+{
+    mtxUL_calcStatsBox();
+
+    if( m_foundation == nullptr )
+    {
+        return;
+    }
+
+    m_foundation->emit_statsBoxUpdated( m_statsBox_i0,
+                                        m_statsBox_i1,
+                                        m_statsBox_j0,
+                                        m_statsBox_j1,
+                                        m_statsBox_min,
+                                        m_statsBox_max,
+                                        m_statsBox_mean,
+                                        m_statsBox_median,
+                                        true );
 }
 
 void rtimvBase::mtxL_calcStatsBox( const sharedLockT &lock )
@@ -1857,7 +1907,7 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
         if( m_applyHPFilter || m_applyLPFilter )
         {
             mtxL_applyFilter();
-            //m_calData is assigned in applyFilter
+            // m_calData is assigned in applyFilter
         }
         else
         {

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -503,6 +503,13 @@ class rtimvBase : public mx::app::application
     float calPixel( uint32_t x, /**< [in] the x coordinate of the pixel */
                     uint32_t y /**< [in] the y coordinate of the pixel */ );
 
+    /// Request a calibrated pixel value update.
+    /** Local mode resolves this request immediately and emits
+     * rtimvBaseObject::pixelValueUpdated.
+     */
+    void requestPixelValue( uint32_t x, /**< [in] the x coordinate of the pixel */
+                            uint32_t y /**< [in] the y coordinate of the pixel */ );
+
     /// Get the value of a pixel in the saturation mask
     /**
      * \returns the value of the (x,y) pixel in \ref m_satData
@@ -698,6 +705,12 @@ class rtimvBase : public mx::app::application
      */
     float colorBox_max();
 
+    /// Request updated color-box min/max values.
+    /** Local mode resolves this request immediately and emits
+     * rtimvBaseObject::colorBoxUpdated.
+     */
+    void requestColorBoxValues();
+
     ///@}
 
     /** @name Stats Box - Data
@@ -813,6 +826,12 @@ class rtimvBase : public mx::app::application
 
     /// Calculate stats-box values while not holding \ref m_calMutex.
     void mtxUL_calcStatsBox();
+
+    /// Request updated stats-box values.
+    /** Local mode resolves this request immediately and emits
+     * rtimvBaseObject::statsBoxUpdated.
+     */
+    void requestStatsBoxValues();
 
     /// Calculate stats-box values with \ref m_calMutex in shared lock.
     void mtxL_calcStatsBox( const sharedLockT &lock /**<[in] a shared mutex lock which is locked on m_calMutex*/ );

--- a/src/common/rtimvBaseObject.cpp
+++ b/src/common/rtimvBaseObject.cpp
@@ -65,6 +65,23 @@ void rtimvBaseObject::emit_cubeFrameUpdated( uint32_t fno )
     emit cubeFrameUpdated( fno );
 }
 
+void rtimvBaseObject::emit_pixelValueUpdated( uint32_t x, uint32_t y, float value, bool valid )
+{
+    emit pixelValueUpdated( x, y, value, valid );
+}
+
+void rtimvBaseObject::emit_colorBoxUpdated(
+    int64_t i0, int64_t i1, int64_t j0, int64_t j1, float min, float max, bool valid )
+{
+    emit colorBoxUpdated( i0, i1, j0, j1, min, max, valid );
+}
+
+void rtimvBaseObject::emit_statsBoxUpdated(
+    int64_t i0, int64_t i1, int64_t j0, int64_t j1, float min, float max, float mean, float median, bool valid )
+{
+    emit statsBoxUpdated( i0, i1, j0, j1, min, max, mean, median, valid );
+}
+
 void rtimvBaseObject::imageTimeout( int to )
 {
     if( !m_parent )

--- a/src/common/rtimvBaseObject.hpp
+++ b/src/common/rtimvBaseObject.hpp
@@ -6,6 +6,8 @@
 #ifndef rtimv_rtimvBaseObject_hpp
 #define rtimv_rtimvBaseObject_hpp
 
+#include <cstdint>
+
 #include <QObject>
 #include <QTimer>
 
@@ -51,6 +53,35 @@ struct rtimvBaseObject : public QObject
     /// Update the cube frame number
     void emit_cubeFrameUpdated( uint32_t fno /**< [in] the current cube frame number*/ );
 
+    /// Emit a pixel-value update.
+    void emit_pixelValueUpdated( uint32_t x,  /**< [in] x coordinate of the pixel */
+                                 uint32_t y,  /**< [in] y coordinate of the pixel */
+                                 float value, /**< [in] the calibrated pixel value */
+                                 bool valid   /**< [in] true when value is valid */
+    );
+
+    /// Emit a color-box min/max update.
+    void emit_colorBoxUpdated( int64_t i0, /**< [in] upper-left x coordinate */
+                               int64_t i1, /**< [in] lower-right x coordinate */
+                               int64_t j0, /**< [in] upper-left y coordinate */
+                               int64_t j1, /**< [in] lower-right y coordinate */
+                               float min,  /**< [in] minimum calibrated value */
+                               float max,  /**< [in] maximum calibrated value */
+                               bool valid  /**< [in] true when min/max are valid */
+    );
+
+    /// Emit a stats-box update.
+    void emit_statsBoxUpdated( int64_t i0,   /**< [in] upper-left x coordinate */
+                               int64_t i1,   /**< [in] lower-right x coordinate */
+                               int64_t j0,   /**< [in] upper-left y coordinate */
+                               int64_t j1,   /**< [in] lower-right y coordinate */
+                               float min,    /**< [in] minimum calibrated value */
+                               float max,    /**< [in] maximum calibrated value */
+                               float mean,   /**< [in] mean calibrated value */
+                               float median, /**< [in] median calibrated value */
+                               bool valid    /**< [in] true when stats are valid */
+    );
+
   signals:
 
     /// Update the number of images in the cube
@@ -71,6 +102,35 @@ struct rtimvBaseObject : public QObject
 
     /// Update the cube frame number
     void cubeFrameUpdated( uint32_t fno /**< [in] the current cube frame number*/ );
+
+    /// Pixel value updated.
+    void pixelValueUpdated( uint32_t x,  /**< [in] x coordinate of the pixel */
+                            uint32_t y,  /**< [in] y coordinate of the pixel */
+                            float value, /**< [in] the calibrated pixel value */
+                            bool valid   /**< [in] true when value is valid */
+    );
+
+    /// Color-box min/max updated.
+    void colorBoxUpdated( int64_t i0, /**< [in] upper-left x coordinate */
+                          int64_t i1, /**< [in] lower-right x coordinate */
+                          int64_t j0, /**< [in] upper-left y coordinate */
+                          int64_t j1, /**< [in] lower-right y coordinate */
+                          float min,  /**< [in] minimum calibrated value */
+                          float max,  /**< [in] maximum calibrated value */
+                          bool valid  /**< [in] true when min/max are valid */
+    );
+
+    /// Stats-box values updated.
+    void statsBoxUpdated( int64_t i0,   /**< [in] upper-left x coordinate */
+                          int64_t i1,   /**< [in] lower-right x coordinate */
+                          int64_t j0,   /**< [in] upper-left y coordinate */
+                          int64_t j1,   /**< [in] lower-right y coordinate */
+                          float min,    /**< [in] minimum calibrated value */
+                          float max,    /**< [in] maximum calibrated value */
+                          float mean,   /**< [in] mean calibrated value */
+                          float median, /**< [in] median calibrated value */
+                          bool valid    /**< [in] true when stats are valid */
+    );
 
   public slots:
 
@@ -104,7 +164,7 @@ struct rtimvBaseObject : public QObject
     /// Calls the parent's rtimvBase::updateCubeFrame()
     void updateCubeFrame();
 
-//GRPC Stuff:
+    // GRPC Stuff:
 
   public:
     void emit_ImageNeeded();
@@ -124,7 +184,6 @@ struct rtimvBaseObject : public QObject
     void ImagePlease();
 
     void ImageReceived();
-
 };
 
 #endif // rtimv_rtimvBase_hpp

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -1,8 +1,11 @@
 
 #include "rtimvMainWindow.hpp"
+#include <QMetaType>
 
 rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::WindowFlags f ) : QWidget( Parent, f )
 {
+    qRegisterMetaType<uint32_t>( "uint32_t" );
+    qRegisterMetaType<int64_t>( "int64_t" );
 
     m_configPathCLBase_env = "RTIMV_CONFIG_PATH"; // Tells mx::application to look for this env var.
 
@@ -45,6 +48,25 @@ rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::Wi
     m_cenLineHorz = 0;
 
     imStats = 0;
+
+    connect( &m_mousePixelTimer, SIGNAL( timeout() ), this, SLOT( dispatchMousePixelRequest() ) );
+    m_mousePixelTimer.setSingleShot( true );
+
+    connect( &m_colorBoxTimer, SIGNAL( timeout() ), this, SLOT( dispatchColorBoxRequest() ) );
+    m_colorBoxTimer.setSingleShot( true );
+
+    connect( &m_statsBoxTimer, SIGNAL( timeout() ), this, SLOT( dispatchStatsBoxRequest() ) );
+    m_statsBoxTimer.setSingleShot( true );
+
+    connect( m_foundation,
+             SIGNAL( pixelValueUpdated( uint32_t, uint32_t, float, bool ) ),
+             this,
+             SLOT( pixelValueUpdated( uint32_t, uint32_t, float, bool ) ) );
+
+    connect( m_foundation,
+             SIGNAL( colorBoxUpdated( int64_t, int64_t, int64_t, int64_t, float, float, bool ) ),
+             this,
+             SLOT( colorBoxUpdated( int64_t, int64_t, int64_t, int64_t, float, float, bool ) ) );
 
     m_northArrow = m_qgs->addLine( QLineF( 512, 400, 512, 624 ), QColor( ui.graphicsView->gageFontColor() ) );
     m_northArrowTip = m_qgs->addLine( QLineF( 512, 400, 536, 424 ), QColor( ui.graphicsView->gageFontColor() ) );
@@ -960,7 +982,7 @@ void rtimvMainWindow::nullMouseCoords()
     }
 }
 
-void rtimvMainWindow::mtxL_updateMouseCoords( const sharedLockT &lock )
+void rtimvMainWindow::mtxL_updateMouseCoords( const sharedLockT &lock, bool requestPixel )
 {
     assert( lock.owns_lock() );
 
@@ -1006,15 +1028,39 @@ void rtimvMainWindow::mtxL_updateMouseCoords( const sharedLockT &lock )
         if( idx_y > (int64_t)m_ny - 1 )
             idx_y = m_ny - 1;
 
-        float val;
+        if( requestPixel )
+        {
+            m_mousePixelRequestX = idx_x;
+            m_mousePixelRequestY = idx_y;
+            m_mousePixelRequestPending = true;
 
-        val = calPixel( idx_x, idx_y );
+            if( !m_mousePixelTimer.isActive() )
+            {
+                m_mousePixelTimer.start( m_mousePixelTimeout );
+            }
+        }
+
+        bool hasValue = m_mousePixelCacheValid && m_mousePixelCacheX == static_cast<uint32_t>( idx_x ) &&
+                        m_mousePixelCacheY == static_cast<uint32_t>( idx_y );
+
+        float val = 0;
+        if( hasValue )
+        {
+            val = m_mousePixelCacheValue;
+        }
 
         if( m_showStaticCoords )
         {
             ui.graphicsView->textCoordX( mx - 0.5 );
             ui.graphicsView->textCoordY( m_qpmi->boundingRect().height() - my - 0.5 );
-            ui.graphicsView->textPixelVal( val );
+            if( hasValue )
+            {
+                ui.graphicsView->textPixelVal( val );
+            }
+            else
+            {
+                ui.graphicsView->textPixelVal( "" );
+            }
         }
 
         if( m_showToolTipCoords )
@@ -1022,7 +1068,11 @@ void rtimvMainWindow::mtxL_updateMouseCoords( const sharedLockT &lock )
             char valStr[32];
             char posStr[32];
 
-            if( fabs( val ) < 1e-1 )
+            if( !hasValue )
+            {
+                valStr[0] = '\0';
+            }
+            else if( fabs( val ) < 1e-1 )
             {
                 snprintf( valStr, sizeof( valStr ), "%0.04g", val );
             }
@@ -1038,7 +1088,7 @@ void rtimvMainWindow::mtxL_updateMouseCoords( const sharedLockT &lock )
 
         if( imcp )
         {
-            imcp->updateMouseCoords( mx, my, val );
+            imcp->updateMouseCoords( mx, my, hasValue ? val : 0 );
         }
     }
 
@@ -1086,7 +1136,36 @@ void rtimvMainWindow::changeMouseCoords()
     m_nullMouseCoords = false;
 
     sharedLockT lock( m_calMutex );
-    mtxL_updateMouseCoords( lock );
+    mtxL_updateMouseCoords( lock, true );
+}
+
+void rtimvMainWindow::updateMouseCoordsFromCache()
+{
+    m_nullMouseCoords = false;
+
+    sharedLockT lock( m_calMutex );
+    mtxL_updateMouseCoords( lock, false );
+}
+
+void rtimvMainWindow::dispatchMousePixelRequest()
+{
+    if( !m_mousePixelRequestPending )
+    {
+        return;
+    }
+
+    m_mousePixelRequestPending = false;
+    requestPixelValue( m_mousePixelRequestX, m_mousePixelRequestY );
+}
+
+void rtimvMainWindow::pixelValueUpdated( uint32_t x, uint32_t y, float value, bool valid )
+{
+    m_mousePixelCacheX = x;
+    m_mousePixelCacheY = y;
+    m_mousePixelCacheValue = value;
+    m_mousePixelCacheValid = valid;
+
+    updateMouseCoordsFromCache();
 }
 
 void rtimvMainWindow::viewLeftPressed( QPointF mp )
@@ -1213,13 +1292,26 @@ void rtimvMainWindow::mtxTry_userItemMouseCoords( float mx, float my, float dx, 
     if( idx_y > (int64_t)m_ny - 1 )
         idx_y = m_ny - 1;
 
-    float val;
-    val = calPixel( idx_x, idx_y );
+    m_mousePixelRequestX = idx_x;
+    m_mousePixelRequestY = idx_y;
+    m_mousePixelRequestPending = true;
+    if( !m_mousePixelTimer.isActive() )
+    {
+        m_mousePixelTimer.start( m_mousePixelTimeout );
+    }
+
+    bool hasValue = m_mousePixelCacheValid && m_mousePixelCacheX == static_cast<uint32_t>( idx_x ) &&
+                    m_mousePixelCacheY == static_cast<uint32_t>( idx_y );
+    float val = hasValue ? m_mousePixelCacheValue : 0;
 
     char valStr[32];
     char posStr[64];
 
-    if( fabs( val ) < 1e-1 )
+    if( !hasValue )
+    {
+        valStr[0] = '\0';
+    }
+    else if( fabs( val ) < 1e-1 )
     {
         snprintf( valStr, sizeof( valStr ), "%0.04g", val );
     }
@@ -1343,27 +1435,56 @@ void rtimvMainWindow::mtxTry_colorBoxMoved( StretchBox *sb )
     colorBox_j0( (int64_t)m_ny - (int64_t)( np2.y() + .5 ) );
     colorBox_j1( (int64_t)m_ny - (int64_t)np.y() );
 
-    mtxL_colormode( rtimv::colormode::minmaxbox, lock ); // recalcs and recolors.
+    m_colorBoxRequestPending = true;
+    if( !m_colorBoxTimer.isActive() )
+    {
+        m_colorBoxTimer.start( m_colorBoxTimeout );
+    }
+
+    bool hasValues = m_colorBoxCacheValid && m_colorBoxCache_i0 == colorBox_i0() &&
+                     m_colorBoxCache_i1 == colorBox_i1() && m_colorBoxCache_j0 == colorBox_j0() &&
+                     m_colorBoxCache_j1 == colorBox_j1();
+
+    mtxTry_updateColorBoxText( sb, hasValues, m_colorBoxCacheMin, m_colorBoxCacheMax );
+
+    mtxL_fontLuminance( ui.graphicsView->userItemSize(), lock );
+}
+
+void rtimvMainWindow::mtxTry_updateColorBoxText( StretchBox *sb, bool hasValues, float minVal, float maxVal )
+{
+    if( sb == nullptr )
+    {
+        return;
+    }
 
     char tmp[256];
     char valMin[64];
     char valMax[64];
-    if( fabs( colorBox_min() ) < 1e-1 )
-    {
-        snprintf( valMin, sizeof( valMin ), "%0.04g", colorBox_min() );
-    }
-    else
-    {
-        snprintf( valMin, sizeof( valMin ), "%0.02f", colorBox_min() );
-    }
 
-    if( fabs( colorBox_max() ) < 1e-1 )
+    if( !hasValues )
     {
-        snprintf( valMax, sizeof( valMax ), "%0.04g", colorBox_max() );
+        valMin[0] = '\0';
+        valMax[0] = '\0';
     }
     else
     {
-        snprintf( valMax, sizeof( valMax ), "%0.02f", colorBox_max() );
+        if( fabs( minVal ) < 1e-1 )
+        {
+            snprintf( valMin, sizeof( valMin ), "%0.04g", minVal );
+        }
+        else
+        {
+            snprintf( valMin, sizeof( valMin ), "%0.02f", minVal );
+        }
+
+        if( fabs( maxVal ) < 1e-1 )
+        {
+            snprintf( valMax, sizeof( valMax ), "%0.04g", maxVal );
+        }
+        else
+        {
+            snprintf( valMax, sizeof( valMax ), "%0.02f", maxVal );
+        }
     }
 
     snprintf( tmp, 256, "min: %s\nmax: %s", valMin, valMax );
@@ -1372,6 +1493,42 @@ void rtimvMainWindow::mtxTry_colorBoxMoved( StretchBox *sb )
     QPoint qr = ui.graphicsView->mapFromScene( QPointF( sbr.x(), sbr.y() ) );
 
     ui.graphicsView->userItemSizeText( tmp, qr );
+}
+
+void rtimvMainWindow::dispatchColorBoxRequest()
+{
+    if( !m_colorBoxRequestPending )
+    {
+        return;
+    }
+
+    m_colorBoxRequestPending = false;
+    requestColorBoxValues();
+}
+
+void rtimvMainWindow::colorBoxUpdated(
+    int64_t i0, int64_t i1, int64_t j0, int64_t j1, float min, float max, bool valid )
+{
+    m_colorBoxCacheValid = valid;
+    m_colorBoxCache_i0 = i0;
+    m_colorBoxCache_i1 = i1;
+    m_colorBoxCache_j0 = j0;
+    m_colorBoxCache_j1 = j1;
+    m_colorBoxCacheMin = min;
+    m_colorBoxCacheMax = max;
+
+    if( m_colorBox == nullptr )
+    {
+        return;
+    }
+
+    if( i0 != colorBox_i0() || i1 != colorBox_i1() || j0 != colorBox_j0() || j1 != colorBox_j1() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex );
+    mtxTry_updateColorBoxText( m_colorBox, valid, min, max );
 
     mtxL_fontLuminance( ui.graphicsView->userItemSize(), lock );
 }
@@ -1402,6 +1559,8 @@ void rtimvMainWindow::colorBoxRemove( StretchBox *sb )
     }
 
     mtxUL_colormode( rtimv::colormode::minmaxglobal );
+    m_colorBoxRequestPending = false;
+    m_colorBoxTimer.stop();
 
     m_colorBox->disconnect();
     disconnect( m_colorBox );
@@ -1443,6 +1602,8 @@ void rtimvMainWindow::doLaunchStatsBox()
 void rtimvMainWindow::doHideStatsBox()
 {
     statsBox( false );
+    m_statsBoxRequestPending = false;
+    m_statsBoxTimer.stop();
 
     if( imStats )
     {
@@ -1497,9 +1658,24 @@ void rtimvMainWindow::mtxTry_statsBoxMoved( StretchBox *sb )
     statsBox_i1( np2.x() );
     statsBox_j0( m_ny - np2.y() );
     statsBox_j1( m_ny - np.y() );
-    mtxUL_calcStatsBox();
+    m_statsBoxRequestPending = true;
+    if( !m_statsBoxTimer.isActive() )
+    {
+        m_statsBoxTimer.start( m_statsBoxTimeout );
+    }
 
     mtxTry_userBoxMoved( sb );
+}
+
+void rtimvMainWindow::dispatchStatsBoxRequest()
+{
+    if( !m_statsBoxRequestPending )
+    {
+        return;
+    }
+
+    m_statsBoxRequestPending = false;
+    requestStatsBoxValues();
 }
 
 void rtimvMainWindow::mtxTry_statsBoxSelected( StretchBox *sb )
@@ -1519,6 +1695,8 @@ void rtimvMainWindow::statsBoxRemove( StretchBox *sb )
     }
 
     doHideStatsBox();
+    m_statsBoxRequestPending = false;
+    m_statsBoxTimer.stop();
     m_statsBox->disconnect();
     disconnect( m_statsBox );
     m_statsBox->deleteLater();

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -48,6 +48,16 @@
 #define ViewViewNoImage 1
 #define ViewViewModeMax 2
 
+#ifdef RTIMV_GRPC
+    #define RTIMV_MOUSE_PIXEL_TIMEOUT_DEFAULT 35
+    #define RTIMV_COLOR_BOX_TIMEOUT_DEFAULT 75
+    #define RTIMV_STATS_BOX_TIMEOUT_DEFAULT 75
+#else
+    #define RTIMV_MOUSE_PIXEL_TIMEOUT_DEFAULT 5
+    #define RTIMV_COLOR_BOX_TIMEOUT_DEFAULT 5
+    #define RTIMV_STATS_BOX_TIMEOUT_DEFAULT 5
+#endif
+
 class rtimvControlPanel;
 
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
@@ -289,8 +299,8 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     void mtxL_updateMouseCoords( const sharedLockT &lock,
                                  bool requestPixel = true /**< [in] whether to issue a pixel-value request */ );
 
-    QTimer m_mousePixelTimer;                 ///< Debounce timer for mouse pixel requests.
-    int m_mousePixelTimeout{ 35 };            ///< Debounce timeout for mouse pixel requests, ms.
+    QTimer m_mousePixelTimer;                                     ///< Debounce timer for mouse pixel requests.
+    int m_mousePixelTimeout{ RTIMV_MOUSE_PIXEL_TIMEOUT_DEFAULT }; ///< Debounce timeout for mouse pixel requests, ms.
     bool m_mousePixelRequestPending{ false }; ///< True when a mouse pixel request should be dispatched.
     uint32_t m_mousePixelRequestX{ 0 };       ///< Pending mouse pixel request x coordinate.
     uint32_t m_mousePixelRequestY{ 0 };       ///< Pending mouse pixel request y coordinate.
@@ -489,9 +499,9 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     StretchBox *m_colorBox{ nullptr }; ///\todo make this protected, fix imcp
 
   protected:
-    QTimer m_colorBoxTimer;                 ///< Debounce timer for color-box requests.
-    int m_colorBoxTimeout{ 75 };            ///< Debounce timeout for color-box requests, ms.
-    bool m_colorBoxRequestPending{ false }; ///< True when color-box request should be dispatched.
+    QTimer m_colorBoxTimer;                                   ///< Debounce timer for color-box requests.
+    int m_colorBoxTimeout{ RTIMV_COLOR_BOX_TIMEOUT_DEFAULT }; ///< Debounce timeout for color-box requests, ms.
+    bool m_colorBoxRequestPending{ false };                   ///< True when color-box request should be dispatched.
 
     bool m_colorBoxCacheValid{ false }; ///< True when cached color-box min/max are valid.
     int64_t m_colorBoxCache_i0{ 0 };    ///< Cached color-box upper-left x coordinate.
@@ -539,9 +549,9 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
 
     rtimvStats *imStats;
 
-    QTimer m_statsBoxTimer;                 ///< Debounce timer for stats-box requests.
-    int m_statsBoxTimeout{ 75 };            ///< Debounce timeout for stats-box requests, ms.
-    bool m_statsBoxRequestPending{ false }; ///< True when stats-box request should be dispatched.
+    QTimer m_statsBoxTimer;                                   ///< Debounce timer for stats-box requests.
+    int m_statsBoxTimeout{ RTIMV_STATS_BOX_TIMEOUT_DEFAULT }; ///< Debounce timeout for stats-box requests, ms.
+    bool m_statsBoxRequestPending{ false };                   ///< True when stats-box request should be dispatched.
 
   public slots:
 

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -286,7 +286,19 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
      * - If it is, updates the mouse coord text boxes
      * - If the mouse is right-clicked and dragging, updates the strech bias and contrast.
      */
-    void mtxL_updateMouseCoords( const sharedLockT &lock );
+    void mtxL_updateMouseCoords( const sharedLockT &lock,
+                                 bool requestPixel = true /**< [in] whether to issue a pixel-value request */ );
+
+    QTimer m_mousePixelTimer;                 ///< Debounce timer for mouse pixel requests.
+    int m_mousePixelTimeout{ 35 };            ///< Debounce timeout for mouse pixel requests, ms.
+    bool m_mousePixelRequestPending{ false }; ///< True when a mouse pixel request should be dispatched.
+    uint32_t m_mousePixelRequestX{ 0 };       ///< Pending mouse pixel request x coordinate.
+    uint32_t m_mousePixelRequestY{ 0 };       ///< Pending mouse pixel request y coordinate.
+
+    bool m_mousePixelCacheValid{ false }; ///< True when cached mouse pixel value is valid.
+    uint32_t m_mousePixelCacheX{ 0 };     ///< Cached mouse pixel x coordinate.
+    uint32_t m_mousePixelCacheY{ 0 };     ///< Cached mouse pixel y coordinate.
+    float m_mousePixelCacheValue{ 0 };    ///< Cached mouse pixel value.
 
   public:
     /// Get the value of the flag controlling whether tool tip coordinates are shown
@@ -317,6 +329,19 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
   public slots:
     /// Receive signal that the viewport mouse coordinates have changed.
     void changeMouseCoords();
+
+    /// Update mouse coordinate display from cached pixel data without issuing a request.
+    void updateMouseCoordsFromCache();
+
+    /// Dispatch the debounced mouse pixel request.
+    void dispatchMousePixelRequest();
+
+    /// Handle a pixel-value update from the backend.
+    void pixelValueUpdated( uint32_t x,  /**< [in] x coordinate */
+                            uint32_t y,  /**< [in] y coordinate */
+                            float value, /**< [in] calibrated pixel value */
+                            bool valid   /**< [in] true when value is valid */
+    );
 
     void viewLeftPressed( QPointF mp );
     void viewLeftClicked( QPointF mp );
@@ -463,9 +488,42 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
   public:
     StretchBox *m_colorBox{ nullptr }; ///\todo make this protected, fix imcp
 
+  protected:
+    QTimer m_colorBoxTimer;                 ///< Debounce timer for color-box requests.
+    int m_colorBoxTimeout{ 75 };            ///< Debounce timeout for color-box requests, ms.
+    bool m_colorBoxRequestPending{ false }; ///< True when color-box request should be dispatched.
+
+    bool m_colorBoxCacheValid{ false }; ///< True when cached color-box min/max are valid.
+    int64_t m_colorBoxCache_i0{ 0 };    ///< Cached color-box upper-left x coordinate.
+    int64_t m_colorBoxCache_i1{ 0 };    ///< Cached color-box lower-right x coordinate.
+    int64_t m_colorBoxCache_j0{ 0 };    ///< Cached color-box upper-left y coordinate.
+    int64_t m_colorBoxCache_j1{ 0 };    ///< Cached color-box lower-right y coordinate.
+    float m_colorBoxCacheMin{ 0 };      ///< Cached color-box minimum value.
+    float m_colorBoxCacheMax{ 0 };      ///< Cached color-box maximum value.
+
+    /// Update the on-image color-box min/max text.
+    void mtxTry_updateColorBoxText( StretchBox *sb, /**< [in] color box to annotate */
+                                    bool hasValues, /**< [in] true when min/max values are available */
+                                    float minVal,   /**< [in] minimum value */
+                                    float maxVal    /**< [in] maximum value */
+    );
+
   public slots:
 
     void mtxTry_colorBoxMoved( StretchBox *sb );
+
+    /// Dispatch the debounced color-box request.
+    void dispatchColorBoxRequest();
+
+    /// Handle a color-box update from the backend.
+    void colorBoxUpdated( int64_t i0, /**< [in] upper-left x coordinate */
+                          int64_t i1, /**< [in] lower-right x coordinate */
+                          int64_t j0, /**< [in] upper-left y coordinate */
+                          int64_t j1, /**< [in] lower-right y coordinate */
+                          float min,  /**< [in] minimum value */
+                          float max,  /**< [in] maximum value */
+                          bool valid  /**< [in] true when min/max are valid */
+    );
 
     void mtxTry_colorBoxSelected( StretchBox *sb );
 
@@ -481,6 +539,10 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
 
     rtimvStats *imStats;
 
+    QTimer m_statsBoxTimer;                 ///< Debounce timer for stats-box requests.
+    int m_statsBoxTimeout{ 75 };            ///< Debounce timeout for stats-box requests, ms.
+    bool m_statsBoxRequestPending{ false }; ///< True when stats-box request should be dispatched.
+
   public slots:
 
     void doLaunchStatsBox();
@@ -490,6 +552,9 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     void imStatsClosed( int );
 
     void mtxTry_statsBoxMoved( StretchBox * );
+
+    /// Dispatch the debounced stats-box request.
+    void dispatchStatsBoxRequest();
 
     void mtxTry_statsBoxSelected( StretchBox * );
 

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -397,6 +397,14 @@ message Image
     float stats_box_max = 197;
     float stats_box_mean = 198;
     float stats_box_median = 199;
+
+    bool color_box = 200;
+    uint32 color_box_i0 = 201;
+    uint32 color_box_i1 = 202;
+    uint32 color_box_j0 = 203;
+    uint32 color_box_j1 = 204;
+    float color_box_min = 205;
+    float color_box_max = 206;
 }
 
 message Coord

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -63,6 +63,37 @@ rtimvClientBase::~rtimvClientBase()
         }
     }
 
+    {
+        std::lock_guard<std::mutex> asyncLock( m_asyncRpcMutex );
+
+        if( m_GetPixelContext )
+        {
+            m_GetPixelContext->TryCancel();
+        }
+
+        if( m_ColorBoxContext )
+        {
+            m_ColorBoxContext->TryCancel();
+        }
+
+        if( m_StatsBoxContext )
+        {
+            m_StatsBoxContext->TryCancel();
+        }
+    }
+
+    {
+        std::unique_lock<std::mutex> lock( m_asyncRpcMutex );
+
+        while( m_getPixelPending || m_colorBoxPending || m_statsBoxPending )
+        {
+            if( m_asyncRpcCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
+            {
+                std::cerr << "rtimvClient: waiting for async unary RPC callbacks during shutdown.\n";
+            }
+        }
+    }
+
     if( m_configReq )
     {
         delete m_configReq;
@@ -553,6 +584,168 @@ void rtimvClientBase::ImagePlease()
     m_imageRequestPending = true;
 }
 
+void rtimvClientBase::requestPixelValue( uint32_t x, uint32_t y )
+{
+    sharedLockT connLock( m_connectedMutex );
+
+    if( !m_connected )
+    {
+        if( m_foundation )
+        {
+            m_foundation->emit_pixelValueUpdated( x, y, 0, false );
+        }
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+    if( m_shuttingDown )
+    {
+        return;
+    }
+
+    m_getPixelX = x;
+    m_getPixelY = y;
+
+    if( m_getPixelPending )
+    {
+        m_getPixelQueued = true;
+        return;
+    }
+
+    if( m_GetPixelContext )
+    {
+        std::cerr << "bug: in requestPixelValue but GetPixelContext is allocated " << __FILE__ << ' ' << __LINE__
+                  << '\n';
+        return;
+    }
+
+    m_getPixelRequest.set_x( m_getPixelX );
+    m_getPixelRequest.set_y( m_getPixelY );
+    m_getPixelInflightX = m_getPixelX;
+    m_getPixelInflightY = m_getPixelY;
+
+    m_GetPixelContext = new grpc::ClientContext;
+    m_GetPixelContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 2000 ) );
+
+    stub_->async()->GetPixel( m_GetPixelContext,
+                              &m_getPixelRequest,
+                              &m_getPixelReply,
+                              [this]( grpc::Status status ) { this->GetPixel_callback( status ); } );
+
+    m_getPixelPending = true;
+}
+
+void rtimvClientBase::requestColorBoxValues()
+{
+    sharedLockT connLock( m_connectedMutex );
+
+    if( !m_connected )
+    {
+        if( m_foundation )
+        {
+            m_foundation->emit_colorBoxUpdated(
+                m_colorBox_i0, m_colorBox_i1, m_colorBox_j0, m_colorBox_j1, 0, 0, false );
+        }
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+    if( m_shuttingDown )
+    {
+        return;
+    }
+
+    if( m_colorBoxPending )
+    {
+        m_colorBoxQueued = true;
+        return;
+    }
+
+    if( m_ColorBoxContext )
+    {
+        std::cerr << "bug: in requestColorBoxValues but ColorBoxContext is allocated " << __FILE__ << ' ' << __LINE__
+                  << '\n';
+        return;
+    }
+
+    m_colorBoxRequest.mutable_upper_left()->set_x( m_colorBox_i0 );
+    m_colorBoxRequest.mutable_upper_left()->set_y( m_colorBox_j0 );
+    m_colorBoxRequest.mutable_lower_right()->set_x( m_colorBox_i1 );
+    m_colorBoxRequest.mutable_lower_right()->set_y( m_colorBox_j1 );
+
+    m_colorBoxInflight_i0 = m_colorBox_i0;
+    m_colorBoxInflight_i1 = m_colorBox_i1;
+    m_colorBoxInflight_j0 = m_colorBox_j0;
+    m_colorBoxInflight_j1 = m_colorBox_j1;
+
+    m_ColorBoxContext = new grpc::ClientContext;
+    m_ColorBoxContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 2000 ) );
+
+    stub_->async()->ColorBox( m_ColorBoxContext,
+                              &m_colorBoxRequest,
+                              &m_colorBoxReply,
+                              [this]( grpc::Status status ) { this->ColorBox_callback( status ); } );
+
+    m_colorBoxPending = true;
+}
+
+void rtimvClientBase::requestStatsBoxValues()
+{
+    sharedLockT connLock( m_connectedMutex );
+
+    if( !m_connected )
+    {
+        if( m_foundation )
+        {
+            m_foundation->emit_statsBoxUpdated(
+                m_statsBox_i0, m_statsBox_i1, m_statsBox_j0, m_statsBox_j1, 0, 0, 0, 0, false );
+        }
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+    if( m_shuttingDown )
+    {
+        return;
+    }
+
+    if( m_statsBoxPending )
+    {
+        m_statsBoxQueued = true;
+        return;
+    }
+
+    if( m_StatsBoxContext )
+    {
+        std::cerr << "bug: in requestStatsBoxValues but StatsBoxContext is allocated " << __FILE__ << ' ' << __LINE__
+                  << '\n';
+        return;
+    }
+
+    m_statsBoxRequest.mutable_upper_left()->set_x( m_statsBox_i0 );
+    m_statsBoxRequest.mutable_upper_left()->set_y( m_statsBox_j0 );
+    m_statsBoxRequest.mutable_lower_right()->set_x( m_statsBox_i1 );
+    m_statsBoxRequest.mutable_lower_right()->set_y( m_statsBox_j1 );
+
+    m_statsBoxInflight_i0 = m_statsBox_i0;
+    m_statsBoxInflight_i1 = m_statsBox_i1;
+    m_statsBoxInflight_j0 = m_statsBox_j0;
+    m_statsBoxInflight_j1 = m_statsBox_j1;
+
+    m_StatsBoxContext = new grpc::ClientContext;
+    m_StatsBoxContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 2000 ) );
+
+    stub_->async()->StatsBox( m_StatsBoxContext,
+                              &m_statsBoxRequest,
+                              &m_statsBoxReply,
+                              [this]( grpc::Status status ) { this->StatsBox_callback( status ); } );
+
+    m_statsBoxPending = true;
+}
+
 void rtimvClientBase::ImageReceived()
 {
     {
@@ -589,6 +782,9 @@ void rtimvClientBase::ImageReceived()
     bool statsBox;
     uint32_t statsBox_i0, statsBox_i1, statsBox_j0, statsBox_j1;
     float statsBox_min, statsBox_max, statsBox_mean, statsBox_median;
+    bool colorBox;
+    uint32_t colorBox_i0, colorBox_i1, colorBox_j0, colorBox_j1;
+    float colorBox_min, colorBox_max;
     int cubeDir;
     bool hasImagePayload{ false };
 
@@ -668,6 +864,13 @@ void rtimvClientBase::ImageReceived()
         statsBox_max = m_grpcImage.stats_box_max();
         statsBox_mean = m_grpcImage.stats_box_mean();
         statsBox_median = m_grpcImage.stats_box_median();
+        colorBox = m_grpcImage.color_box();
+        colorBox_i0 = m_grpcImage.color_box_i0();
+        colorBox_i1 = m_grpcImage.color_box_i1();
+        colorBox_j0 = m_grpcImage.color_box_j0();
+        colorBox_j1 = m_grpcImage.color_box_j1();
+        colorBox_min = m_grpcImage.color_box_min();
+        colorBox_max = m_grpcImage.color_box_max();
 
         imageTimeout = m_grpcImage.image_timeout();
         cubeDir = m_grpcImage.cube_dir();
@@ -736,6 +939,12 @@ void rtimvClientBase::ImageReceived()
     m_statsBox_max = statsBox_max;
     m_statsBox_mean = statsBox_mean;
     m_statsBox_median = statsBox_median;
+    m_colorBox_i0 = colorBox_i0;
+    m_colorBox_i1 = colorBox_i1;
+    m_colorBox_j0 = colorBox_j0;
+    m_colorBox_j1 = colorBox_j1;
+    m_colorBox_min = colorBox_min;
+    m_colorBox_max = colorBox_max;
     m_imageTimeout = imageTimeout;
     m_quality = quality;
     if( m_cubeDir != cubeDir )
@@ -743,6 +952,19 @@ void rtimvClientBase::ImageReceived()
         m_cubeDir = cubeDir;
         m_foundation->emit_cubeDirUpdated( m_cubeDir );
     }
+
+    m_foundation->emit_statsBoxUpdated( m_statsBox_i0,
+                                        m_statsBox_i1,
+                                        m_statsBox_j0,
+                                        m_statsBox_j1,
+                                        m_statsBox_min,
+                                        m_statsBox_max,
+                                        m_statsBox_mean,
+                                        m_statsBox_median,
+                                        m_statsBox );
+
+    m_foundation->emit_colorBoxUpdated(
+        m_colorBox_i0, m_colorBox_i1, m_colorBox_j0, m_colorBox_j1, m_colorBox_min, m_colorBox_max, colorBox );
 
     if( hasImagePayload )
     {
@@ -837,6 +1059,202 @@ void rtimvClientBase::ImagePlease_callback( grpc::Status status )
     }
 
     // if action stays -1 we just return
+}
+
+void rtimvClientBase::GetPixel_callback( grpc::Status status )
+{
+    bool queueNext{ false };
+    uint32_t nextX{ 0 };
+    uint32_t nextY{ 0 };
+    uint32_t reqX{ 0 };
+    uint32_t reqY{ 0 };
+    float value{ 0 };
+    bool valid{ false };
+
+    {
+        std::lock_guard<std::mutex> asyncLock( m_asyncRpcMutex );
+
+        if( !m_getPixelPending )
+        {
+            std::cerr << "bug: in GetPixel_callback but getPixelPending is false\n";
+            return;
+        }
+
+        reqX = m_getPixelInflightX;
+        reqY = m_getPixelInflightY;
+
+        if( status.ok() )
+        {
+            valid = m_getPixelReply.valid();
+            if( valid )
+            {
+                value = m_getPixelReply.value();
+            }
+        }
+        else
+        {
+            sharedLockT connLock( m_connectedMutex );
+            REPORT_SERVER_DISCONNECTED
+        }
+
+        delete m_GetPixelContext;
+        m_GetPixelContext = nullptr;
+
+        m_getPixelPending = false;
+        queueNext = m_getPixelQueued && !m_shuttingDown;
+        nextX = m_getPixelX;
+        nextY = m_getPixelY;
+        m_getPixelQueued = false;
+    }
+
+    m_asyncRpcCv.notify_all();
+
+    if( m_foundation )
+    {
+        m_foundation->emit_pixelValueUpdated( reqX, reqY, value, valid );
+    }
+
+    if( queueNext )
+    {
+        requestPixelValue( nextX, nextY );
+    }
+}
+
+void rtimvClientBase::ColorBox_callback( grpc::Status status )
+{
+    bool queueNext{ false };
+    bool valid{ false };
+    int64_t i0{ 0 }, i1{ 0 }, j0{ 0 }, j1{ 0 };
+    float min{ 0 }, max{ 0 };
+
+    {
+        std::lock_guard<std::mutex> asyncLock( m_asyncRpcMutex );
+
+        if( !m_colorBoxPending )
+        {
+            std::cerr << "bug: in ColorBox_callback but colorBoxPending is false\n";
+            return;
+        }
+
+        i0 = m_colorBoxInflight_i0;
+        i1 = m_colorBoxInflight_i1;
+        j0 = m_colorBoxInflight_j0;
+        j1 = m_colorBoxInflight_j1;
+
+        if( status.ok() )
+        {
+            valid = m_colorBoxReply.valid();
+            if( valid )
+            {
+                min = m_colorBoxReply.min();
+                max = m_colorBoxReply.max();
+
+                m_colorBox_i0 = i0;
+                m_colorBox_i1 = i1;
+                m_colorBox_j0 = j0;
+                m_colorBox_j1 = j1;
+                m_colorBox_min = min;
+                m_colorBox_max = max;
+            }
+        }
+        else
+        {
+            sharedLockT connLock( m_connectedMutex );
+            REPORT_SERVER_DISCONNECTED
+        }
+
+        delete m_ColorBoxContext;
+        m_ColorBoxContext = nullptr;
+
+        m_colorBoxPending = false;
+        queueNext = m_colorBoxQueued && !m_shuttingDown;
+        m_colorBoxQueued = false;
+    }
+
+    m_asyncRpcCv.notify_all();
+
+    if( m_foundation )
+    {
+        m_foundation->emit_colorBoxUpdated( i0, i1, j0, j1, min, max, valid );
+    }
+
+    if( queueNext )
+    {
+        requestColorBoxValues();
+    }
+}
+
+void rtimvClientBase::StatsBox_callback( grpc::Status status )
+{
+    bool queueNext{ false };
+    bool valid{ false };
+    int64_t i0{ 0 }, i1{ 0 }, j0{ 0 }, j1{ 0 };
+    float min{ 0 }, max{ 0 }, mean{ 0 }, median{ 0 };
+
+    {
+        std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+        if( !m_statsBoxPending )
+        {
+            std::cerr << "bug: in StatsBox_callback but statsBoxPending is false\n";
+            return;
+        }
+
+        i0 = m_statsBoxInflight_i0;
+        i1 = m_statsBoxInflight_i1;
+        j0 = m_statsBoxInflight_j0;
+        j1 = m_statsBoxInflight_j1;
+
+        if( status.ok() )
+        {
+            valid = m_statsBoxReply.valid();
+            if( valid )
+            {
+                i0 = m_statsBoxReply.i0();
+                i1 = m_statsBoxReply.i1();
+                j0 = m_statsBoxReply.j0();
+                j1 = m_statsBoxReply.j1();
+                min = m_statsBoxReply.min();
+                max = m_statsBoxReply.max();
+                mean = m_statsBoxReply.mean();
+                median = m_statsBoxReply.median();
+
+                m_statsBox = true;
+                m_statsBox_i0 = i0;
+                m_statsBox_i1 = i1;
+                m_statsBox_j0 = j0;
+                m_statsBox_j1 = j1;
+                m_statsBox_min = min;
+                m_statsBox_max = max;
+                m_statsBox_mean = mean;
+                m_statsBox_median = median;
+            }
+        }
+        else
+        {
+            sharedLockT connLock( m_connectedMutex );
+            REPORT_SERVER_DISCONNECTED
+        }
+
+        delete m_StatsBoxContext;
+        m_StatsBoxContext = nullptr;
+
+        m_statsBoxPending = false;
+        queueNext = m_statsBoxQueued && !m_shuttingDown;
+        m_statsBoxQueued = false;
+    }
+
+    m_asyncRpcCv.notify_all();
+
+    if( m_foundation )
+    {
+        m_foundation->emit_statsBoxUpdated( i0, i1, j0, j1, min, max, mean, median, valid );
+    }
+
+    if( queueNext )
+    {
+        requestStatsBoxValues();
+    }
 }
 
 bool rtimvClientBase::imageValid()
@@ -1389,31 +1807,8 @@ bool rtimvClientBase::applyLPFilter()
 
 float rtimvClientBase::calPixel( uint32_t x, uint32_t y )
 {
-    SHARED_CONN_LOCK_RET( 0 )
-
-    remote_rtimv::Coord request;
-    remote_rtimv::Pixel pixel;
-    grpc::ClientContext context;
-
-    request.set_x( x );
-    request.set_y( y );
-
-    grpc::Status status = stub_->GetPixel( &context, request, &pixel );
-
-    if( status.ok() )
-    {
-        if( !pixel.valid() )
-        {
-            return 0;
-        }
-
-        return pixel.value();
-    }
-    else
-    {
-        REPORT_SERVER_DISCONNECTED
-        return 0;
-    }
+    requestPixelValue( x, y );
+    return 0;
 }
 
 void rtimvClientBase::mtxL_load_colorbarImpl( rtimv::colorbar cb, bool update )
@@ -1473,42 +1868,14 @@ void rtimvClientBase::mtxL_colormode( rtimv::colormode m, const sharedLockT &loc
 {
     assert( lock.owns_lock() );
 
-    SHARED_CONN_LOCK
-
     if( m == rtimv::colormode::minmaxbox )
     {
-        remote_rtimv::Box request;
-        remote_rtimv::MinvalMaxval vals;
-        grpc::ClientContext context;
-
-        remote_rtimv::Coord *ul = new remote_rtimv::Coord;
-        ul->set_x( m_colorBox_i0 );
-        ul->set_y( m_colorBox_j0 );
-        request.set_allocated_upper_left( ul );
-
-        remote_rtimv::Coord *lr = new remote_rtimv::Coord;
-        lr->set_x( m_colorBox_i1 );
-        lr->set_y( m_colorBox_j1 );
-        request.set_allocated_lower_right( lr );
-
-        grpc::Status status = stub_->ColorBox( &context, request, &vals );
-
-        if( !status.ok() )
-        {
-            REPORT_SERVER_DISCONNECTED
-            return;
-        }
-
-        if( !vals.valid() )
-        {
-            return;
-        }
-
-        m_colorBox_min = vals.min();
-        m_colorBox_max = vals.max();
+        requestColorBoxValues();
     }
     else
     {
+        SHARED_CONN_LOCK
+
         remote_rtimv::ColormodeRequest request;
         remote_rtimv::ColormodeResponse response;
         grpc::ClientContext context;
@@ -1523,6 +1890,8 @@ void rtimvClientBase::mtxL_colormode( rtimv::colormode m, const sharedLockT &loc
             return;
         }
     }
+
+    m_colormode = m;
 
     mtxL_postColormode( m, lock );
 }
@@ -1595,30 +1964,12 @@ void rtimvClientBase::statsBox( bool sb )
     m_statsBox_max = 0;
     m_statsBox_mean = 0;
     m_statsBox_median = 0;
+    m_statsBox_i0 = 1;
+    m_statsBox_j0 = 1;
+    m_statsBox_i1 = 0;
+    m_statsBox_j1 = 0;
 
-    SHARED_CONN_LOCK
-
-    remote_rtimv::Box request;
-    remote_rtimv::StatsValues vals;
-    grpc::ClientContext context;
-
-    remote_rtimv::Coord *ul = new remote_rtimv::Coord;
-    ul->set_x( 1 );
-    ul->set_y( 1 );
-    request.set_allocated_upper_left( ul );
-
-    remote_rtimv::Coord *lr = new remote_rtimv::Coord;
-    lr->set_x( 0 );
-    lr->set_y( 0 );
-    request.set_allocated_lower_right( lr );
-
-    grpc::Status status = stub_->StatsBox( &context, request, &vals );
-
-    if( !status.ok() )
-    {
-        REPORT_SERVER_DISCONNECTED
-        return;
-    }
+    requestStatsBoxValues();
 }
 
 bool rtimvClientBase::statsBox()
@@ -1688,44 +2039,7 @@ float rtimvClientBase::statsBox_median()
 
 void rtimvClientBase::mtxUL_calcStatsBox()
 {
-    SHARED_CONN_LOCK
-
-    remote_rtimv::Box request;
-    remote_rtimv::StatsValues vals;
-    grpc::ClientContext context;
-
-    remote_rtimv::Coord *ul = new remote_rtimv::Coord;
-    ul->set_x( m_statsBox_i0 );
-    ul->set_y( m_statsBox_j0 );
-    request.set_allocated_upper_left( ul );
-
-    remote_rtimv::Coord *lr = new remote_rtimv::Coord;
-    lr->set_x( m_statsBox_i1 );
-    lr->set_y( m_statsBox_j1 );
-    request.set_allocated_lower_right( lr );
-
-    grpc::Status status = stub_->StatsBox( &context, request, &vals );
-
-    if( !status.ok() )
-    {
-        REPORT_SERVER_DISCONNECTED
-        return;
-    }
-
-    if( !vals.valid() )
-    {
-        return;
-    }
-
-    m_statsBox = true;
-    m_statsBox_i0 = vals.i0();
-    m_statsBox_i1 = vals.i1();
-    m_statsBox_j0 = vals.j0();
-    m_statsBox_j1 = vals.j1();
-    m_statsBox_min = vals.min();
-    m_statsBox_max = vals.max();
-    m_statsBox_mean = vals.mean();
-    m_statsBox_median = vals.median();
+    requestStatsBoxValues();
 }
 
 void rtimvClientBase::stretch( rtimv::stretch cs )

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -138,6 +138,15 @@ class rtimvClientBase : public mx::app::application
      */
     grpc::ClientContext *m_ImagePleaseContext{ nullptr };
 
+    /// Context for the GetPixel rpc.
+    grpc::ClientContext *m_GetPixelContext{ nullptr };
+
+    /// Context for the ColorBox rpc.
+    grpc::ClientContext *m_ColorBoxContext{ nullptr };
+
+    /// Context for the StatsBox rpc.
+    grpc::ClientContext *m_StatsBoxContext{ nullptr };
+
   public:
     /// Configure the server
     /**
@@ -163,9 +172,97 @@ class rtimvClientBase : public mx::app::application
     /// Last ImagePlease response payload from the server.
     remote_rtimv::Image m_grpcImage;
 
+    /// Mutex guarding asynchronous unary RPC state for GetPixel/ColorBox/StatsBox.
+    std::mutex m_asyncRpcMutex;
+
+    /// Condition variable used to signal completion of GetPixel/ColorBox/StatsBox requests.
+    std::condition_variable m_asyncRpcCv;
+
+    /// True while a GetPixel request is outstanding.
+    bool m_getPixelPending{ false };
+
+    /// True when a newer GetPixel request should be sent after current completion.
+    bool m_getPixelQueued{ false };
+
+    /// Current desired x coordinate for GetPixel.
+    uint32_t m_getPixelX{ 0 };
+
+    /// Current desired y coordinate for GetPixel.
+    uint32_t m_getPixelY{ 0 };
+
+    /// In-flight x coordinate for the outstanding GetPixel request.
+    uint32_t m_getPixelInflightX{ 0 };
+
+    /// In-flight y coordinate for the outstanding GetPixel request.
+    uint32_t m_getPixelInflightY{ 0 };
+
+    /// Request payload for GetPixel.
+    remote_rtimv::Coord m_getPixelRequest;
+
+    /// Response payload for GetPixel.
+    remote_rtimv::Pixel m_getPixelReply;
+
+    /// True while a ColorBox request is outstanding.
+    bool m_colorBoxPending{ false };
+
+    /// True when a newer ColorBox request should be sent after current completion.
+    bool m_colorBoxQueued{ false };
+
+    /// Request payload for ColorBox.
+    remote_rtimv::Box m_colorBoxRequest;
+
+    /// Response payload for ColorBox.
+    remote_rtimv::MinvalMaxval m_colorBoxReply;
+
+    /// In-flight upper-left x coordinate for ColorBox.
+    int64_t m_colorBoxInflight_i0{ 0 };
+
+    /// In-flight lower-right x coordinate for ColorBox.
+    int64_t m_colorBoxInflight_i1{ 0 };
+
+    /// In-flight upper-left y coordinate for ColorBox.
+    int64_t m_colorBoxInflight_j0{ 0 };
+
+    /// In-flight lower-right y coordinate for ColorBox.
+    int64_t m_colorBoxInflight_j1{ 0 };
+
+    /// True while a StatsBox request is outstanding.
+    bool m_statsBoxPending{ false };
+
+    /// True when a newer StatsBox request should be sent after current completion.
+    bool m_statsBoxQueued{ false };
+
+    /// Request payload for StatsBox.
+    remote_rtimv::Box m_statsBoxRequest;
+
+    /// Response payload for StatsBox.
+    remote_rtimv::StatsValues m_statsBoxReply;
+
+    /// In-flight upper-left x coordinate for StatsBox.
+    int64_t m_statsBoxInflight_i0{ 0 };
+
+    /// In-flight lower-right x coordinate for StatsBox.
+    int64_t m_statsBoxInflight_i1{ 0 };
+
+    /// In-flight upper-left y coordinate for StatsBox.
+    int64_t m_statsBoxInflight_j0{ 0 };
+
+    /// In-flight lower-right y coordinate for StatsBox.
+    int64_t m_statsBoxInflight_j1{ 0 };
+
   public:
     /// Request an image from the server
     void ImagePlease();
+
+    /// Request an updated calibrated pixel value.
+    void requestPixelValue( uint32_t x, /**< [in] x coordinate of the pixel */
+                            uint32_t y /**< [in] y coordinate of the pixel */ );
+
+    /// Request updated color-box min/max values.
+    void requestColorBoxValues();
+
+    /// Request updated stats-box values.
+    void requestStatsBoxValues();
 
     /// Process a received image
     void ImageReceived();
@@ -173,6 +270,15 @@ class rtimvClientBase : public mx::app::application
   protected:
     /// Handle an ImagePlease response from the server
     void ImagePlease_callback( grpc::Status status );
+
+    /// Handle a GetPixel response from the server.
+    void GetPixel_callback( grpc::Status status );
+
+    /// Handle a ColorBox response from the server.
+    void ColorBox_callback( grpc::Status status );
+
+    /// Handle a StatsBox response from the server.
+    void StatsBox_callback( grpc::Status status );
 
     /// Function called on connection
     /**
@@ -851,8 +957,8 @@ class rtimvClientBase : public mx::app::application
     bool m_applyHPFilter{ false };                           ///< Whether the high-pass filter is currently enabled.
 
     rtimv::lpFilter m_lpFilter{ rtimv::lpFilter::none }; ///< Selected low-pass filter type.
-    float m_lpfFW{ 3 };                                      ///< Full width for the low-pass filter in pixels.
-    bool m_applyLPFilter{ false };                           ///< Whether the low-pass filter is currently enabled.
+    float m_lpfFW{ 3 };                                  ///< Full width for the low-pass filter in pixels.
+    bool m_applyLPFilter{ false };                       ///< Whether the low-pass filter is currently enabled.
 
     /// Filtering working buffers are not stored on the client.
     /** The client receives post-filter state through the Image message; filtering work

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -600,6 +600,14 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         reply->set_stats_box_max( imageTh->statsBox_max() );
         reply->set_stats_box_mean( imageTh->statsBox_mean() );
         reply->set_stats_box_median( imageTh->statsBox_median() );
+
+        reply->set_color_box( imageTh->colormode() == rtimv::colormode::minmaxbox );
+        reply->set_color_box_i0( imageTh->colorBox_i0() );
+        reply->set_color_box_i1( imageTh->colorBox_i1() );
+        reply->set_color_box_j0( imageTh->colorBox_j0() );
+        reply->set_color_box_j1( imageTh->colorBox_j1() );
+        reply->set_color_box_min( imageTh->colorBox_min() );
+        reply->set_color_box_max( imageTh->colorBox_max() );
     };
 
     if( imageTh->newImage() == false )
@@ -833,7 +841,8 @@ ServerUnaryReactor *rtimvServer::StatsBox( CallbackServerContext *context,
         return reactor;
     }
 
-    if( request->lower_right().x() <= request->upper_left().x() || request->lower_right().y() <= request->upper_left().y() )
+    if( request->lower_right().x() <= request->upper_left().x() ||
+        request->lower_right().y() <= request->upper_left().y() )
     {
         imageTh->statsBox( false );
         reply->set_valid( true );


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex in response to the initial prompt: "Testing of the rtimvClient-rtimvServer system with a remote server has shown that having RPCs such as GetPixel, ColorBox, StatsBox, implemented as blocking calls is not working. These need to be made async, like ImagePlease. However, this is a major change to the GUI interaction, because the values returned by these calls are used to update th GUI. I have an overall view of how to implement this by developing a way to rate-limit such requests as the mouse moves, perhaps detecting when it has stopped for some period of time, and using signals to update the GUI elements. Please review agent_context.md in this repo, and then analyze this problem."

## Summary
This PR converts high-frequency GUI RPC interactions from blocking unary calls to async/callback-driven updates, with request coalescing and debounce behavior to keep the UI responsive over remote links.

### Key changes
- Converted `GetPixel`, `ColorBox`, and `StatsBox` client paths to async unary RPC usage.
- Added callback/state handling for async unary RPCs in `rtimvClientBase`:
  - pending/queued request state
  - latest-request-wins coalescing
  - shutdown-safe cancellation and callback draining
- Moved GUI update flow to signal-driven cached state updates via `rtimvBaseObject`.
- Removed blocking hot-path calls in mouse-move and box-drag interactions.
- Added `Image` payload synchronization fields for color-box state:
  - active flag
  - box coordinates
  - min/max values
- Added stale-data protection in GUI by matching returned box coordinates.
- Added compile-time debounce defaults split by build mode:
  - gRPC client (`RTIMV_GRPC`): `35/75/75` ms
  - local non-RPC (`rtimv`): `5/5/5` ms

## Files touched
- `src/server/rtimvClientBase.hpp`
- `src/server/rtimvClientBase.cpp`
- `src/server/rtimvServer.cpp`
- `src/common/rtimvBaseObject.hpp`
- `src/common/rtimvBaseObject.cpp`
- `src/common/rtimvBase.hpp`
- `src/common/rtimvBase.cpp`
- `src/gui/rtimvMainWindow.hpp`
- `src/gui/rtimvMainWindow.cpp`
- `src/proto/rtimv.proto`

## Validation
- Built successfully:
  - `rtimv`
  - `rtimvClient`
  - `rtimvServer`
- Runtime-tested:
  - Local non-RPC mode: smooth behavior with `5/5/5` debounce.
  - Remote MagAO-X system (LCO): async behavior verified and working as expected.
