### PR TITLE
Improve client window/info metadata with configured image-name tracking and unary metadata RPCs

### DIFF
--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -261,6 +261,8 @@ void rtimvBase::loadConfig()
     if( config.nonOptions.size() > 3 )
         keys[3] = config.nonOptions[3];
 
+    m_imageNames = keys;
+
     processKeys( keys );
 
     if( m_images[0] == nullptr )
@@ -315,11 +317,14 @@ void rtimvBase::loadConfig()
 void rtimvBase::processKeys( const std::vector<std::string> &shkeys )
 {
     m_images.resize( 4, nullptr );
+    m_imageNames.resize( 4 );
 
     for( size_t i = 0; i < m_images.size(); ++i )
     {
         if( shkeys.size() > i )
         {
+            m_imageNames[i] = shkeys[i];
+
             if( shkeys[i] != "" )
             {
                 // safely accept several different common fits extensions
@@ -481,12 +486,12 @@ double rtimvBase::fpsEst( size_t n )
 
 std::string rtimvBase::imageName( size_t n )
 {
-    if( !imageValid( n ) )
+    if( n >= m_imageNames.size() )
     {
         return std::string();
     }
 
-    return m_images[n]->imageName();
+    return m_imageNames[n];
 }
 
 uint32_t rtimvBase::imageNo( size_t n )

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -111,6 +111,9 @@ class rtimvBase : public mx::app::application
      */
     std::vector<rtimvImage *> m_images;
 
+    /// Configured image names/keys by image index, used before streams are connected.
+    std::vector<std::string> m_imageNames;
+
     /// Flag used to indicate that the main image, m_images[0], is connected to its first image
     bool m_connected{ false };
 

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -156,9 +156,14 @@ rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::Wi
         }
     }
 
-    setWindowTitle( m_title.c_str() );
-
     startup();
+
+    std::string imageTitle = imageName( 0 );
+    if( imageTitle != "" )
+    {
+        m_title = imageTitle;
+    }
+    setWindowTitle( m_title.c_str() );
 }
 
 rtimvMainWindow::~rtimvMainWindow()
@@ -171,7 +176,6 @@ rtimvMainWindow::~rtimvMainWindow()
 
 void rtimvMainWindow::setupConfig()
 {
-
     RTIMV_BASE::setupConfig();
 
     config.add( "nofpsgage",
@@ -319,13 +323,9 @@ void rtimvMainWindow::setupConfig()
 
 void rtimvMainWindow::loadConfig()
 {
-
     RTIMV_BASE::loadConfig();
 
-    if( imageValid() )
-    {
-        m_title = imageName( 0 );
-    }
+    m_title = imageName( 0 );
 
     // Now load remaining options, respecting coded defaults.
 
@@ -353,8 +353,6 @@ void rtimvMainWindow::loadConfig()
 
 void rtimvMainWindow::onConnect()
 {
-    setWindowTitle( m_title.c_str() );
-
     squareDown();
 
     if( nz() > 1 && !m_cubeCtrl )

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -56,6 +56,8 @@ service rtimv
 
     rpc GetImageName(ImageNameRequest) returns (ImageNameResponse);
 
+    rpc GetInfo(InfoRequest) returns (InfoResponse);
+
     rpc GetImageNo(ImageNoRequest) returns (ImageNoResponse);
 
     rpc ColorBox(Box) returns (MinvalMaxval);
@@ -435,6 +437,17 @@ message ImageNameResponse
 {
     bool valid = 1;
     string name = 2;
+}
+
+message InfoRequest
+{
+    uint32 image = 1;
+}
+
+message InfoResponse
+{
+    bool valid = 1;
+    repeated string info = 2;
 }
 
 message ImageNoResponse

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -54,6 +54,8 @@ service rtimv
 
     rpc GetPixel(Coord) returns(Pixel);
 
+    rpc GetImageName(ImageNameRequest) returns (ImageNameResponse);
+
     rpc GetImageNo(ImageNoRequest) returns (ImageNoResponse);
 
     rpc ColorBox(Box) returns (MinvalMaxval);
@@ -422,6 +424,17 @@ message Pixel
 message ImageNoRequest
 {
     uint32 image = 1;
+}
+
+message ImageNameRequest
+{
+    uint32 image = 1;
+}
+
+message ImageNameResponse
+{
+    bool valid = 1;
+    string name = 2;
 }
 
 message ImageNoResponse

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -107,16 +107,6 @@ rtimvClientBase::~rtimvClientBase()
 
 void rtimvClientBase::setupConfig()
 {
-    config.add( "localConfig",
-                "l",
-                "localConfig",
-                mx::app::argType::Required,
-                "",
-                "localConfig",
-                false,
-                "string",
-                "A local configuration file." );
-
     config.add( "server",
                 "S",
                 "server",
@@ -277,14 +267,10 @@ void rtimvClientBase::setupConfig()
                 "specific port specified in a key." );
 }
 
-void rtimvClientBase::loadStandardConfig()
-{
-    config( m_configPathCL, "localConfig" );
-    m_configPathCL = m_configPathCLBase + m_configPathCL;
-}
-
 void rtimvClientBase::loadConfig()
 {
+    std::vector<std::string> imageNames( 4 );
+
     if( m_configReq )
     {
         delete m_configReq;
@@ -292,66 +278,73 @@ void rtimvClientBase::loadConfig()
 
     m_configReq = new remote_rtimv::Config;
 
-    if( config.isSet( "config" ) )
+    std::string configFile;
+    config( configFile, "config" );
+    if( configFile != "" )
     {
-        std::string configFile;
-        config( configFile, "config" );
         m_configReq->set_file( configFile );
     }
 
     config( m_server, "server" );
     config( m_port, "port" );
 
-    if( config.isSet( "image.key" ) )
+    std::string imKey;
+    config( imKey, "image.key" );
+    if( imKey != "" )
     {
-        std::string imKey;
-        config( imKey, "image.key" );
         m_configReq->set_image_key( imKey );
+        imageNames[0] = imKey;
     }
 
-    if( config.isSet( "dark.key" ) )
+    std::string darkKey;
+    config( darkKey, "dark.key" );
+    if( darkKey != "" )
     {
-        std::string darkKey;
-        config( darkKey, "dark.key" );
         m_configReq->set_dark_key( darkKey );
+        imageNames[1] = darkKey;
     }
 
-    if( config.isSet( "flat.key" ) )
+    std::string flatKey;
+    config( flatKey, "flat.key" );
+    if( flatKey != "" )
     {
-        std::string flatKey;
-        config( flatKey, "flat.key" );
         m_configReq->set_mask_key( flatKey );
     }
 
-    if( config.isSet( "mask.key" ) )
+    std::string maskKey;
+    config( maskKey, "mask.key" );
+    if( maskKey != "" )
     {
-        std::string maskKey;
-        config( maskKey, "mask.key" );
         m_configReq->set_mask_key( maskKey );
+        imageNames[2] = maskKey;
     }
 
-    if( config.isSet( "satMask.key" ) )
+    std::string satMaskKey;
+    config( satMaskKey, "satMask.key" );
+    if( satMaskKey != "" )
     {
-        std::string satMaskKey;
-        config( satMaskKey, "satMask.key" );
         m_configReq->set_sat_mask_key( satMaskKey );
+        imageNames[3] = satMaskKey;
     }
 
     // The command line always overrides the config
     if( config.nonOptions.size() > 0 )
     {
         m_configReq->set_image_key( config.nonOptions[0] );
+        imageNames[0] = config.nonOptions[0];
     }
 
     if( config.nonOptions.size() > 1 )
     {
         m_configReq->set_dark_key( config.nonOptions[1] );
+        imageNames[1] = config.nonOptions[1];
         // darkKey = config.nonOptions[1]
     }
 
     if( config.nonOptions.size() > 2 )
     {
         m_configReq->set_mask_key( config.nonOptions[2] );
+        imageNames[2] = config.nonOptions[2];
     }
 
     if( config.nonOptions.size() > 3 )
@@ -362,7 +355,10 @@ void rtimvClientBase::loadConfig()
     if( config.nonOptions.size() > 4 )
     {
         m_configReq->set_sat_mask_key( config.nonOptions[4] );
+        imageNames[3] = config.nonOptions[4];
     }
+
+    m_imageNames = imageNames;
 
     if( m_configReq->file() == "" && m_configReq->image_key() == "" )
     {
@@ -532,6 +528,7 @@ void rtimvClientBase::Configure()
     if( status.ok() )
     {
         m_connected = true;
+        updateImageNamesFromServer();
         std::cerr << "rtimvClient connected to: " << m_server << ':' << m_port << '\n';
         m_connectionFailReported = false;
     }
@@ -542,6 +539,37 @@ void rtimvClientBase::Configure()
         {
             std::cerr << "rtimvClient: " << status.error_message() << std::endl;
             m_connectionFailReported = true;
+        }
+    }
+}
+
+void rtimvClientBase::updateImageNamesFromServer()
+{
+    if( !stub_ )
+    {
+        return;
+    }
+
+    if( m_imageNames.size() < 4 )
+    {
+        m_imageNames.resize( 4 );
+    }
+
+    for( uint32_t n = 0; n < 4; ++n )
+    {
+        remote_rtimv::ImageNameRequest request;
+        remote_rtimv::ImageNameResponse response;
+        grpc::ClientContext context;
+
+        request.set_image( n );
+
+        grpc::Status status = stub_->GetImageName( &context, request, &response );
+        if( status.ok() && response.valid() )
+        {
+            if( m_imageNames[n] == "" )
+            {
+                m_imageNames[n] = response.name();
+            }
         }
     }
 }
@@ -1301,8 +1329,12 @@ double rtimvClientBase::fpsEst( size_t n )
 
 std::string rtimvClientBase::imageName( size_t n )
 {
-    // get from server?
-    return "";
+    if( n >= m_imageNames.size() )
+    {
+        return "";
+    }
+
+    return m_imageNames[n];
 }
 
 uint32_t rtimvClientBase::imageNo( size_t n )

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -1372,8 +1372,42 @@ uint32_t rtimvClientBase::imageNo( size_t n )
 
 std::vector<std::string> rtimvClientBase::info( size_t n )
 {
-    // get from server (maybe once and cache?)
-    return std::vector<std::string>( { "" } );
+    SHARED_CONN_LOCK_RET( std::vector<std::string>( { "" } ) )
+
+    remote_rtimv::InfoRequest request;
+    remote_rtimv::InfoResponse response;
+    grpc::ClientContext context;
+
+    request.set_image( static_cast<uint32_t>( n ) );
+
+    grpc::Status status = stub_->GetInfo( &context, request, &response );
+
+    if( status.ok() )
+    {
+        if( !response.valid() )
+        {
+            return std::vector<std::string>( { "" } );
+        }
+
+        std::vector<std::string> info;
+        info.reserve( response.info_size() );
+        for( const auto &s : response.info() )
+        {
+            info.push_back( s );
+        }
+
+        if( info.size() == 0 )
+        {
+            return std::vector<std::string>( { "" } );
+        }
+
+        return info;
+    }
+    else
+    {
+        REPORT_SERVER_DISCONNECTED
+        return std::vector<std::string>( { "" } );
+    }
 }
 
 void rtimvClientBase::mtxL_setImsize( uint32_t x, uint32_t y, uint32_t z, const uniqueLockT &lock )

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -81,8 +81,6 @@ class rtimvClientBase : public mx::app::application
 
     virtual void setupConfig();
 
-    virtual void loadStandardConfig();
-
     virtual void loadConfig();
 
     ///@}
@@ -132,6 +130,9 @@ class rtimvClientBase : public mx::app::application
     void reconnect();
 
   protected:
+    /// Refresh configured image names from the server.
+    void updateImageNamesFromServer();
+
     /// Context for the ImagePlease rpc.
     /** This has to stay alive until the rpc finishes and can not be reused
      *
@@ -297,6 +298,15 @@ class rtimvClientBase : public mx::app::application
      * @{
      */
   protected:
+    /// Configured image names/keys by image index, used before receiving first image.
+    /** By index:
+     * - 0 is the main image.
+     * - 1 is the dark image which is (optionally) subtracted from the main image.
+     * - 2 is the mask image which is (optionally) multiplied by the dark-subtracted image.  Normally a 1/0 image.
+     * - 3 is the saturation mask which (optionally) denotes which pixels to turn the saturation color.
+     */
+    std::vector<std::string> m_imageNames;
+
     float m_fpsEst;
 
     double m_imageTime{ 0 };

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -751,6 +751,28 @@ rtimvServer::GetPixel( CallbackServerContext *context, const remote_rtimv::Coord
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::GetImageName( CallbackServerContext *context,
+                                               const remote_rtimv::ImageNameRequest *request,
+                                               remote_rtimv::ImageNameResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+
+    uint32_t n = request->image();
+    if( n >= 4 )
+    {
+        reply->set_valid( false );
+        reply->set_name( "" );
+        reactor->Finish( Status::OK );
+        return reactor;
+    }
+
+    reply->set_valid( true );
+    reply->set_name( imageTh->imageName( n ) );
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::GetImageNo( CallbackServerContext *context,
                                              const remote_rtimv::ImageNoRequest *request,
                                              remote_rtimv::ImageNoResponse *reply )

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -773,6 +773,31 @@ ServerUnaryReactor *rtimvServer::GetImageName( CallbackServerContext *context,
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::GetInfo( CallbackServerContext *context,
+                                          const remote_rtimv::InfoRequest *request,
+                                          remote_rtimv::InfoResponse *reply )
+{
+    PREPARE_RPC_REACTOR
+
+    uint32_t n = request->image();
+    std::vector<std::string> info = imageTh->info( n );
+    if( info.size() == 0 )
+    {
+        reply->set_valid( false );
+    }
+    else
+    {
+        reply->set_valid( true );
+        for( size_t i = 0; i < info.size(); ++i )
+        {
+            reply->add_info( info[i] );
+        }
+    }
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::GetImageNo( CallbackServerContext *context,
                                              const remote_rtimv::ImageNoRequest *request,
                                              remote_rtimv::ImageNoResponse *reply )

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -233,6 +233,11 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                       const remote_rtimv::ImageNameRequest *request,
                                       remote_rtimv::ImageNameResponse *reply ) override;
 
+    /// Get info strings for a requested image index.
+    ServerUnaryReactor *GetInfo( CallbackServerContext *context,
+                                 const remote_rtimv::InfoRequest *request,
+                                 remote_rtimv::InfoResponse *reply ) override;
+
     /// Get the image number for a requested image index.
     ServerUnaryReactor *GetImageNo( CallbackServerContext *context,
                                     const remote_rtimv::ImageNoRequest *request,

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -228,6 +228,11 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
     ServerUnaryReactor *
     GetPixel( CallbackServerContext *context, const remote_rtimv::Coord *request, remote_rtimv::Pixel *reply ) override;
 
+    /// Get the image name/key for a requested image index.
+    ServerUnaryReactor *GetImageName( CallbackServerContext *context,
+                                      const remote_rtimv::ImageNameRequest *request,
+                                      remote_rtimv::ImageNameResponse *reply ) override;
+
     /// Get the image number for a requested image index.
     ServerUnaryReactor *GetImageNo( CallbackServerContext *context,
                                     const remote_rtimv::ImageNoRequest *request,


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex 

## Summary
This PR fixes window-title initialization for both local and gRPC client modes, and adds explicit client/server metadata RPCs so `rtimvClient` can display image metadata even when configured remotely.

## What Changed
1. Added config-backed image-name tracking in base/client classes:
- `rtimvBase`: added `m_imageNames` populated from effective config keys.
- `rtimvClientBase`: added `m_imageNames` populated from local effective config + CLI overrides.

2. Fixed title initialization timing in Qt:
- `rtimvMainWindow` now applies final `setWindowTitle(...)` after `ui.setupUi(...)` and `startup()`, preventing `.ui` default title (`imviewer`) from overwriting configured title.
- Keeps title set before `show()`.

3. Restored standard mx::application config flow in client:
- Removed custom `loadStandardConfig()` override and `localConfig` path.
- Uses base `--config` handling so local config values are available consistently.

4. Added unary image-name RPC:
- New RPC: `GetImageName(ImageNameRequest) -> ImageNameResponse`.
- Server implementation returns `imageName(n)`.
- Client calls this after successful `Configure()` and fills missing local names only.
- Preserves precedence: local CLI/config > remote-config-derived names.

5. Added unary info RPC for non-realtime info panel:
- New RPC: `GetInfo(InfoRequest) -> InfoResponse` (`repeated string info`).
- Server implementation returns `imageTh->info(n)`.
- Client implementation wires `rtimvClientBase::info(size_t)` to this RPC.
- Enables `rtimvMainWindow::generateInfo()` to show remote image info correctly.

6. Cleanups:
- Removed zero-length `snprintf("", ...)` usage in `rtimvMainWindow.cpp` to eliminate `gnu_printf` warnings.

## Files Touched
- `src/common/rtimvBase.hpp`
- `src/common/rtimvBase.cpp`
- `src/gui/rtimvMainWindow.cpp`
- `src/server/rtimvClientBase.hpp`
- `src/server/rtimvClientBase.cpp`
- `src/server/rtimvServer.hpp`
- `src/server/rtimvServer.cpp`
- `src/proto/rtimv.proto`

## Behavior/Precedence
Final image-name precedence on client:
1. Command line
2. Local config file (`--config`, via mx::application)
3. Remote-config-derived values fetched post-`Configure()` (only fills missing local names)

## Validation
- Built successfully:
  - `cmake --build _build --target rtimvClient rtimvServer -j4`
- Verified manually:
  - Title sets correctly with local config/CLI.
  - Title also sets correctly with remote-only config (no local key names).
  - Info panel works in client mode using unary `GetInfo` RPC.