### PR TITLE
Add rolling transport stats to rtimvClient and surface them in the control panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ Follow these code style and documentation rules exactly.
 14) Header Declaration Parameter Docs
 - In headers, prefer inline parameter documentation on declarations (`type name /**< ... */`) rather than separate `\param` lists, unless there is a specific reason to deviate.
 
+14.1) Multi-Line Declaration Closing Paren Style
+- For multi-line function declarations, prefer placing the closing `)` on its own line.
+- This is preferred when using inline parameter documentation so `clang-format` can align the trailing comment blocks cleanly.
+
 15) PR Prompt Attribution
 - At the top of PR descriptions, include an explicit attribution line when work was performed with Codex.
 - Preferred format:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@ Follow these code style and documentation rules exactly.
 - Keep non-trivial definitions out of headers.
 - Move implementations to `.cpp` unless intentionally inline.
 
+7.1) Accessor Definition Placement
+- Even simple accessors such as `bytesPerPixel()` should be defined in `.cpp` files rather than inline in headers unless there is a specific reason to keep them inline.
+
 8) Editing Discipline
 - Preserve existing behavior unless explicitly requested.
 - When renaming members/APIs, update all dependent call sites.
@@ -96,7 +99,7 @@ Follow these code style and documentation rules exactly.
     - `{ // mutex scope`
 
 19) Keep This File Current
-  - Add new standing style/documentation instructions and coding conventions to `agent_context.md` as they are introduced.
+  - Add new standing style/documentation instructions and coding conventions to `AGENTS.md` as they are introduced.
 
 When you finish:
 - Summarize what changed.

--- a/agents/plans/logging_prefix_plan.md
+++ b/agents/plans/logging_prefix_plan.md
@@ -1,0 +1,154 @@
+# rtimv Logging Prefix + Formatter Implementation Plan
+
+## Goal
+Standardize all log/status messages to:
+
+`called-name (client: client-id image: image0-name): message`
+
+with these rules:
+- `called-name` is `argv[0]` (or equivalent executable name).
+- `called-name` output is explicitly configurable (`log.appname` / `--no-log-appname`), with default `on`.
+- `client: client-id` appears only in `rtimvClient` and `rtimvServer` outputs.
+- `image: image0-name` is the primary image name/key.
+- Message body follows the prefix consistently for both normal status and errors.
+
+## Scope
+- `src/common`: common formatter and helpers.
+- `src/server`: server/client adoption.
+- `src/proto/rtimv.proto`: add `client_id` to `ConfigResult`.
+- Build/proto generated outputs as needed.
+
+## Proposed Design
+
+### 1. Add common formatter utility
+Create a shared utility in `src/common` (e.g. `rtimvLog.hpp/.cpp`) providing:
+- `struct logContext`
+  - `std::string calledName`
+  - `std::string image0`
+  - `std::string clientId` (optional)
+  - `bool includeClient` (default false)
+- `std::string formatPrefix(const logContext&)`
+- `std::string formatMessage(const logContext&, std::string_view message)`
+
+Behavior:
+- Base (default): `<called-name> (`
+- If `log.appname=false`: `(`
+- Include `client: ... ` only if `includeClient == true` and `clientId` non-empty.
+- Always include `image: ...` (fallback `unknown` if empty).
+- Close with `): ` and append message.
+
+Example outputs:
+- `rtimvServer (client: ipv4:10.1.2.3:50482 image: cam0): configured`
+- `rtimvClient (client: ipv4:10.1.2.3:50482 image: cam0): connected`
+- `rtimv (image: cam0): loaded plugin foo`
+- `(client: ipv4:10.1.2.3:50482 image: cam0): configured` (with `--no-log-appname`)
+
+### 2. Normalize called-name extraction
+Implement helper in app base/utility layer:
+- Prefer configured argv/program name (already available through mx app setup paths).
+- Fallback: executable basename from argv[0].
+- Apply explicit enable/disable:
+  - Config key: `log.appname` (bool, default `true`)
+  - CLI convenience flag: `--no-log-appname` (sets `log.appname=false`)
+- Do not auto-detect systemd by default (keep behavior explicit and unit-file controlled).
+
+Ensure this is available in:
+- `rtimvBase`
+- `rtimvClientBase`
+- `rtimvServer`
+
+### 3. Add `client_id` to proto
+Update `src/proto/rtimv.proto`:
+- Add field in `ConfigResult`, e.g.:
+  - `string client_id = <next available tag>;`
+
+Server behavior:
+- In `Configure`, set `client_id` to the canonical server-side client id (currently `context->peer()`).
+
+Client behavior:
+- Store returned `client_id` in `rtimvClientBase` member (new field `m_clientId`).
+- Use that id in all client log prefixes.
+
+Compatibility notes:
+- Adding a new optional scalar field is wire-compatible in protobuf.
+- Old clients ignore unknown `client_id`.
+- New clients should tolerate empty `client_id` if connected to old servers.
+
+### 4. Server-side logging adoption
+In `src/server/rtimvServer.cpp`:
+- Replace ad-hoc `std::cerr`/`std::cout` strings with formatter-backed helpers:
+  - Connection/configure messages
+  - Reconfigure attempts
+  - Thread sleep/disconnect notices
+  - Error branches (`null thread`, `missing thread`, terminate path)
+
+Context mapping:
+- `called-name`: server program name.
+- `client`: peer/client id.
+- `image`: `image0OrUnknown(imageTh)` or configured `image_key` fallback.
+
+### 5. Client-side logging adoption
+In `src/server/rtimvClientBase.cpp`:
+- Route existing status/error outputs through formatter:
+  - Configure success/failure
+  - Server disconnection/deadline messages
+  - Reconnect transitions
+  - Key async RPC failure logs
+
+Context mapping:
+- `called-name`: client program name.
+- `client`: `m_clientId` (from `ConfigResult.client_id`; fallback empty before configure).
+- `image`: local image0 key/name currently configured.
+
+### 6. Common GUI/non-client/server logging adoption (optional first pass)
+For `rtimv` GUI and common modules:
+- Use same formatter with `includeClient=false`.
+- Keep scope limited initially to high-value log points to reduce patch size.
+
+## Implementation Steps (Order)
+1. Add formatter utility files and unit-test-style coverage (if test infra available).
+2. Add explicit app-name controls (`log.appname`, `--no-log-appname`) in config parsing.
+3. Add `client_id` field to proto and regenerate gRPC/protobuf outputs.
+4. Update server `Configure` to populate `ConfigResult.client_id`.
+5. Update client `Configure` handling to persist `client_id`.
+6. Migrate server logs to formatter helper.
+7. Migrate client logs to formatter helper.
+8. Optional: migrate selected GUI/common logs.
+9. Build + smoke tests with mixed-version client/server.
+
+## Validation Plan
+
+### Functional checks
+- Start server/client normally; verify prefix format on connect/disconnect.
+- Start server with `--no-log-appname`; verify prefix omits app name cleanly.
+- Missing image path: verify `image: unknown` or configured key fallback.
+- High-load multi-client run: verify every server/client log has consistent prefix.
+- Confirm client receives and uses `client_id` from `ConfigResult`.
+
+### Compatibility checks
+- New server + old client: no breakage.
+- Old server + new client: client handles missing `client_id` gracefully.
+
+### Regression checks
+- Build targets:
+  - `rtimvServer`
+  - `rtimvClient`
+  - `rtimv`
+- Existing load scenario still stable with updated log paths.
+
+## Suggested Follow-on (after baseline)
+- Add lightweight log level enum (`ERROR/WARN/INFO/DEBUG`) to formatter output.
+- Add runtime switch for terse vs verbose formatting.
+- Add compile-time option to disable expensive context fetches in hot paths.
+- Optional (future, not baseline): add systemd environment auto-detect (`INVOCATION_ID`) only as an override layer if explicitly requested.
+
+## Estimated Change Set
+- Proto: 1 file (`src/proto/rtimv.proto`)
+- Shared formatter: 2 new files (`src/common/rtimvLog.hpp/.cpp`)
+- Client/server adoption: 3-5 existing files
+- Generated protobuf/grpc files: build-generated artifacts
+
+## Review Notes
+- Keep first patch focused on infrastructure + server/client paths only.
+- Avoid refactoring unrelated logging in same commit.
+- Preserve existing message semantics while normalizing prefix.

--- a/agents/plans/transport_stats_summary.md
+++ b/agents/plans/transport_stats_summary.md
@@ -1,0 +1,76 @@
+# Transport Stats And Control Panel Summary
+
+## Overview
+
+This summary captures the recent `rtimvClient` and control-panel updates for rolling transport statistics and related UI changes.
+
+## Backend Changes
+
+- Added rolling transport statistics to `rtimvClientBase`.
+- Added configurable rolling window length with default `10` frames.
+- Added client-side rolling average of:
+  - compression ratio
+  - frame arrival rate
+- Kept these calculations in `rtimvClientBase` rather than GUI code.
+
+## Compression Ratio Definition
+
+- Compression ratio is now based on the native source image size, not the decoded Qt image size.
+- Added `bytesPerPixel()` to the `rtimvImage` interface and implemented it for:
+  - `shmimImage`
+  - `mzmqImage`
+  - `fitsImage`
+  - `fitsDirectory`
+- Added `rtimvBase::bytesPerPixel(size_t)` so server-side code can query native source pixel size.
+- Added `source_bytes_per_pixel` to the gRPC `Image` message.
+- `rtimvServer` now includes source bytes-per-pixel in each `ImagePlease` reply.
+- `rtimvClient` computes compression ratio as:
+
+```text
+(nx * ny * source_bytes_per_pixel) / compressed_jpeg_bytes
+```
+
+## Arrival Rate Definition
+
+- The rolling FPS-like metric now measures local frame arrival rate on the client.
+- It no longer uses remote `fpsEst`, which reflects source acquisition cadence.
+- The arrival rate is computed from monotonic time deltas between consecutive `ImageReceived()` calls.
+
+## Control Panel Changes
+
+- Added three display-only fields on the Color tab:
+  - last compression ratio
+  - rolling average compression ratio
+  - rolling average arrival rate
+- Positioned these to the right of the JPEG quality slider.
+- Updated displayed precision to one decimal place.
+- Compression values are shown like `99.1:1`.
+- Arrival rate is shown with one decimal place.
+
+## Tab Behavior Changes
+
+- The Color tab is now moved to the first position in the control panel.
+- The Color tab is the default selected tab when the control panel opens.
+
+## Configuration
+
+- Added client config key:
+
+```text
+update.rollingStatsFrames
+```
+
+- Meaning: number of frames used in the rolling averages.
+- Default: `10`
+
+## Verification Performed
+
+- Ran `clang-format` on touched source/header files.
+- Built:
+  - `rtimvClient`
+  - `rtimvServer`
+
+## Current Assumptions
+
+- The reported compression ratio is for the single 2D frame that is JPEG-encoded for transport.
+- The calculation uses the source image's native bytes-per-pixel for that frame.

--- a/src/common/images/fitsDirectory.cpp
+++ b/src/common/images/fitsDirectory.cpp
@@ -70,11 +70,11 @@ uint32_t fitsDirectory::imageNo()
     return m_imageNo;
 }
 
-void fitsDirectory::imageNo(uint32_t ino)
+void fitsDirectory::imageNo( uint32_t ino )
 {
     if( ino > nz() - 1 )
     {
-        m_nextImageNo = nz()-1;
+        m_nextImageNo = nz() - 1;
     }
     else
     {
@@ -106,30 +106,28 @@ void fitsDirectory::decImageNo()
     }
 }
 
-void fitsDirectory::deltaImageNo(int32_t dino)
+void fitsDirectory::deltaImageNo( int32_t dino )
 {
-    if(abs(dino) > nz())
+    if( abs( dino ) > nz() )
     {
         dino %= nz();
     }
 
-    uint32_t absdino = abs(dino);
+    uint32_t absdino = abs( dino );
 
-    if(dino < 0 && absdino > m_imageNo)
+    if( dino < 0 && absdino > m_imageNo )
     {
-        m_nextImageNo = nz() + (m_imageNo+dino);
+        m_nextImageNo = nz() + ( m_imageNo + dino );
     }
-    else if(dino > 0 && absdino > (nz()-1 - m_imageNo))
+    else if( dino > 0 && absdino > ( nz() - 1 - m_imageNo ) )
     {
-        m_nextImageNo = dino - (nz() - m_imageNo);
+        m_nextImageNo = dino - ( nz() - m_imageNo );
     }
     else
     {
         m_nextImageNo += dino;
     }
-
 }
-
 
 double fitsDirectory::imageTime()
 {
@@ -184,6 +182,35 @@ int fitsDirectory::readImage( size_t imno )
         return -1;
     }
     m_reported = false;
+
+    int bitpix;
+    fits_get_img_type( fptr, &bitpix, &fstatus );
+    if( fstatus )
+    {
+        if( !m_reported )
+            std::cerr << "rtimv: error getting data type in file " << m_fileList[imno] << "\n";
+        m_reported = true;
+
+        fstatus = 0;
+        fits_close_file( fptr, &fstatus );
+
+        return -1;
+    }
+    m_reported = false;
+
+    const size_t typeSize = static_cast<size_t>( bitpix < 0 ? -bitpix : bitpix ) / 8;
+    if( typeSize == 0 )
+    {
+        if( !m_reported )
+            std::cerr << "rtimv: unsupported data type in file " << m_fileList[imno] << "\n";
+        m_reported = true;
+
+        fstatus = 0;
+        fits_close_file( fptr, &fstatus );
+
+        return -1;
+    }
+    m_typeSize = typeSize;
 
     long *naxes = new long[naxis];
 
@@ -277,9 +304,9 @@ void fitsDirectory::imConnect()
 
     mx::error_t errc = mx::ioutils::getFileNames( m_fileList, m_dirPath, "", "", ".fits" );
 
-    if(errc != mx::error_t::noerror)
+    if( errc != mx::error_t::noerror )
     {
-        mx::error_report<mx::verbose::vvv>(errc);
+        mx::error_report<mx::verbose::vvv>( errc );
         return;
     }
 
@@ -369,8 +396,7 @@ float fitsDirectory::pixel( size_t n )
 std::vector<std::string> fitsDirectory::info()
 {
     std::vector<std::string> info = rtimvImage::info();
-    info.push_back( std::string("path: ") + imageKey() );
+    info.push_back( std::string( "path: " ) + imageKey() );
 
     return info;
 }
-

--- a/src/common/images/fitsDirectory.cpp
+++ b/src/common/images/fitsDirectory.cpp
@@ -393,6 +393,11 @@ float fitsDirectory::pixel( size_t n )
     return pixget( m_data, n );
 }
 
+size_t fitsDirectory::bytesPerPixel()
+{
+    return m_typeSize;
+}
+
 std::vector<std::string> fitsDirectory::info()
 {
     std::vector<std::string> info = rtimvImage::info();

--- a/src/common/images/fitsDirectory.hpp
+++ b/src/common/images/fitsDirectory.hpp
@@ -217,10 +217,7 @@ struct fitsDirectory : public rtimvImage
     float pixel( size_t n );
 
     /// Get the native source bytes per pixel.
-    size_t bytesPerPixel()
-    {
-        return m_typeSize;
-    }
+    size_t bytesPerPixel();
 
     std::vector<std::string> info();
 };

--- a/src/common/images/fitsDirectory.hpp
+++ b/src/common/images/fitsDirectory.hpp
@@ -130,7 +130,7 @@ struct fitsDirectory : public rtimvImage
     /// Set the current image in the cube.
     /**
      */
-    virtual void imageNo(uint32_t ino /**< [in] the new image number to display */);
+    virtual void imageNo( uint32_t ino /**< [in] the new image number to display */ );
 
     /// Increment the current image number.
     /** Cause the next image in the cube to be presented as an update on the
@@ -151,7 +151,7 @@ struct fitsDirectory : public rtimvImage
      *  next call to update().
      *
      */
-    virtual void deltaImageNo(int32_t dino /**< [in] the change in image number */);
+    virtual void deltaImageNo( int32_t dino /**< [in] the change in image number */ );
 
     /// Get the image acquisition time
     /** Gets the acquisition time converted to double, giving time since the epoch.
@@ -213,6 +213,12 @@ struct fitsDirectory : public rtimvImage
 
   public:
     float pixel( size_t n );
+
+    /// Get the native source bytes per pixel.
+    size_t bytesPerPixel()
+    {
+        return sizeof( float );
+    }
 
     std::vector<std::string> info();
 };

--- a/src/common/images/fitsDirectory.hpp
+++ b/src/common/images/fitsDirectory.hpp
@@ -31,8 +31,8 @@ struct fitsDirectory : public rtimvImage
 
     bool m_reported{ false }; ///< Switch to provide reporting errors only once.
 
-    std::filesystem::file_time_type
-        m_lastWriteTime; ///< The last write time of the directory.  Used for tracking changes.
+    std::filesystem::file_time_type m_lastWriteTime; /**< The last write time of the directory.
+                                                          Used for tracking changes.*/
 
     int m_imageTimeout{ 1000 }; ///< The timeout for checking for shared memory file existence.
 
@@ -46,6 +46,8 @@ struct fitsDirectory : public rtimvImage
     uint32_t m_imageNo{ 0 }; ///< The current image number.
 
     uint32_t m_nextImageNo{ 0 }; ///< The next image number.
+
+    size_t m_typeSize{ sizeof( float ) }; ///< Native source bytes per pixel as stored in the FITS file.
 
     char *m_data{ nullptr }; ///< Pointer to the image data
 
@@ -217,7 +219,7 @@ struct fitsDirectory : public rtimvImage
     /// Get the native source bytes per pixel.
     size_t bytesPerPixel()
     {
-        return sizeof( float );
+        return m_typeSize;
     }
 
     std::vector<std::string> info();

--- a/src/common/images/fitsImage.cpp
+++ b/src/common/images/fitsImage.cpp
@@ -69,11 +69,11 @@ uint32_t fitsImage::imageNo()
     return m_imageNo;
 }
 
-void fitsImage::imageNo(uint32_t ino)
+void fitsImage::imageNo( uint32_t ino )
 {
     if( ino > nz() - 1 )
     {
-        m_nextImageNo = nz()-1;
+        m_nextImageNo = nz() - 1;
     }
     else
     {
@@ -91,45 +91,41 @@ void fitsImage::incImageNo()
     {
         m_nextImageNo = m_imageNo + 1;
     }
-
 }
 
 void fitsImage::decImageNo()
 {
     if( m_imageNo == 0 )
     {
-        m_nextImageNo = m_nz-1;
+        m_nextImageNo = m_nz - 1;
     }
     else
     {
         m_nextImageNo = m_imageNo - 1;
     }
-
 }
 
-void fitsImage::deltaImageNo(int32_t dino)
+void fitsImage::deltaImageNo( int32_t dino )
 {
-    if(abs(dino) > nz())
+    if( abs( dino ) > nz() )
     {
         dino %= nz();
     }
 
-    uint32_t absdino = abs(dino);
+    uint32_t absdino = abs( dino );
 
-    if(dino < 0 && absdino > m_imageNo)
+    if( dino < 0 && absdino > m_imageNo )
     {
-        m_nextImageNo = nz() + (m_imageNo+dino);
+        m_nextImageNo = nz() + ( m_imageNo + dino );
     }
-    else if(dino > 0 && absdino > (nz()-1 - m_imageNo))
+    else if( dino > 0 && absdino > ( nz() - 1 - m_imageNo ) )
     {
-        m_nextImageNo = dino - (nz() - m_imageNo);
+        m_nextImageNo = dino - ( nz() - m_imageNo );
     }
     else
     {
         m_nextImageNo += dino;
     }
-
-
 }
 
 double fitsImage::imageTime()
@@ -192,6 +188,39 @@ int fitsImage::readImage()
 
         return -1;
     }
+
+    int bitpix;
+    fits_get_img_type( fptr, &bitpix, &fstatus );
+    if( fstatus )
+    {
+        if( m_reported == m_reportThresh )
+        {
+            std::cerr << "rtimv: error getting data type in file " << m_imagePath << "\n";
+        }
+        ++m_reported;
+
+        fstatus = 0;
+        fits_close_file( fptr, &fstatus );
+
+        return -1;
+    }
+
+    const size_t typeSize = static_cast<size_t>( bitpix < 0 ? -bitpix : bitpix ) / 8;
+    if( typeSize == 0 )
+    {
+        if( m_reported == m_reportThresh )
+        {
+            std::cerr << "rtimv: unsupported data type in file " << m_imagePath << "\n";
+        }
+        ++m_reported;
+
+        fstatus = 0;
+        fits_close_file( fptr, &fstatus );
+
+        return -1;
+    }
+
+    m_typeSize = typeSize;
 
     long *naxes = new long[naxis];
 
@@ -394,7 +423,7 @@ float fitsImage::pixel( size_t n )
 std::vector<std::string> fitsImage::info()
 {
     std::vector<std::string> info = rtimvImage::info();
-    info.push_back( std::string("path: ") + imageKey() );
+    info.push_back( std::string( "path: " ) + imageKey() );
 
     return info;
 }

--- a/src/common/images/fitsImage.cpp
+++ b/src/common/images/fitsImage.cpp
@@ -420,6 +420,11 @@ float fitsImage::pixel( size_t n )
     return pixget( m_currData, n );
 }
 
+size_t fitsImage::bytesPerPixel()
+{
+    return m_typeSize;
+}
+
 std::vector<std::string> fitsImage::info()
 {
     std::vector<std::string> info = rtimvImage::info();

--- a/src/common/images/fitsImage.hpp
+++ b/src/common/images/fitsImage.hpp
@@ -213,10 +213,7 @@ struct fitsImage : public rtimvImage
     float pixel( size_t n );
 
     /// Get the native source bytes per pixel.
-    size_t bytesPerPixel()
-    {
-        return m_typeSize;
-    }
+    size_t bytesPerPixel();
 
     virtual std::vector<std::string> info();
 };

--- a/src/common/images/fitsImage.hpp
+++ b/src/common/images/fitsImage.hpp
@@ -48,6 +48,8 @@ struct fitsImage : public rtimvImage
 
     uint32_t m_nextImageNo{ 0 }; ///< The next image number.
 
+    size_t m_typeSize{ sizeof( float ) }; ///< Native source bytes per pixel as stored in the FITS file.
+
     char *m_data{ nullptr }; ///< Pointer to the image data
 
     char *m_currData{ nullptr }; ///< Pointer to the image data
@@ -213,7 +215,7 @@ struct fitsImage : public rtimvImage
     /// Get the native source bytes per pixel.
     size_t bytesPerPixel()
     {
-        return sizeof( float );
+        return m_typeSize;
     }
 
     virtual std::vector<std::string> info();

--- a/src/common/images/fitsImage.hpp
+++ b/src/common/images/fitsImage.hpp
@@ -124,7 +124,7 @@ struct fitsImage : public rtimvImage
     /// Set the current image in the cube.
     /**
      */
-    void imageNo(uint32_t ino /**< [in] the new image number to display */);
+    void imageNo( uint32_t ino /**< [in] the new image number to display */ );
 
     /// Increment the current image number.
     /** If not a cube this has no effect.  If it is a cube it
@@ -147,7 +147,7 @@ struct fitsImage : public rtimvImage
      *  next call to update().
      *
      */
-    void deltaImageNo(int32_t dino /**< [in] the change in image number */);
+    void deltaImageNo( int32_t dino /**< [in] the change in image number */ );
 
     /// Get the image acquisition time
     /** Gets the acquisition time converted to double, giving time since the epoch.
@@ -209,6 +209,12 @@ struct fitsImage : public rtimvImage
 
   public:
     float pixel( size_t n );
+
+    /// Get the native source bytes per pixel.
+    size_t bytesPerPixel()
+    {
+        return sizeof( float );
+    }
 
     virtual std::vector<std::string> info();
 };

--- a/src/common/images/mzmqImage.cpp
+++ b/src/common/images/mzmqImage.cpp
@@ -577,6 +577,11 @@ float mzmqImage::fpsEst()
     return m_fpsEst;
 }
 
+size_t mzmqImage::bytesPerPixel()
+{
+    return m_typeSize;
+}
+
 std::vector<std::string> mzmqImage::info()
 {
     std::vector<std::string> info = rtimvImage::info();

--- a/src/common/images/mzmqImage.hpp
+++ b/src/common/images/mzmqImage.hpp
@@ -197,6 +197,9 @@ struct mzmqImage : public rtimvImage
      */
     float fpsEst();
 
+    /// Get the native source bytes per pixel.
+    size_t bytesPerPixel();
+
     virtual std::vector<std::string> info();
 };
 

--- a/src/common/images/shmimImage.cpp
+++ b/src/common/images/shmimImage.cpp
@@ -367,4 +367,9 @@ float shmimImage::fpsEst()
     return m_fpsEst;
 }
 
+size_t shmimImage::bytesPerPixel()
+{
+    return m_typeSize;
+}
+
 #endif // MXLIB_MILK

--- a/src/common/images/shmimImage.hpp
+++ b/src/common/images/shmimImage.hpp
@@ -175,6 +175,9 @@ struct shmimImage : public rtimvImage
      * \returns the latest FPS estimate.
      */
     float fpsEst();
+
+    /// Get the native source bytes per pixel.
+    size_t bytesPerPixel();
 };
 
 #endif // MXLIB_MILK

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -584,6 +584,16 @@ std::vector<std::string> rtimvBase::info( size_t n )
     return m_images[n]->info();
 }
 
+size_t rtimvBase::bytesPerPixel( size_t n )
+{
+    if( !imageValid( n ) )
+    {
+        return 0;
+    }
+
+    return m_images[n]->bytesPerPixel();
+}
+
 void rtimvBase::mtxL_setImsize( uint32_t x, uint32_t y, uint32_t z, const uniqueLockT &lock )
 {
     assert( lock.owns_lock() );

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -234,6 +234,13 @@ class rtimvBase : public mx::app::application
      */
     std::vector<std::string> info( size_t n /**< [in] the image number */ );
 
+    /// Get the native source bytes per pixel for an image.
+    /**
+     * \returns native source bytes per pixel if valid
+     * \returns 0 if not valid
+     */
+    size_t bytesPerPixel( size_t n /**< [in] the image number */ );
+
     ///@}
 
     /** @name Image Size Data

--- a/src/common/rtimvImage.hpp
+++ b/src/common/rtimvImage.hpp
@@ -105,9 +105,9 @@ struct rtimvImage : public QObject
     /** If not a cube this will have no effect.
      *
      */
-    virtual void imageNo(uint32_t ino /**< [in] then new image number to display */)
+    virtual void imageNo( uint32_t ino /**< [in] then new image number to display */ )
     {
-        static_cast<void>(ino);
+        static_cast<void>( ino );
     }
 
     /// Increment the current image number.
@@ -136,9 +136,9 @@ struct rtimvImage : public QObject
      *  next call to update().
      *
      */
-    virtual void deltaImageNo(int32_t dino /**< [in] the change in image number */)
+    virtual void deltaImageNo( int32_t dino /**< [in] the change in image number */ )
     {
-        static_cast<void>(dino);
+        static_cast<void>( dino );
     }
 
     /// Get the image acquisition time
@@ -187,16 +187,23 @@ struct rtimvImage : public QObject
      */
     virtual float fpsEst() = 0;
 
+    /// Get the number of bytes in one source pixel sample.
+    /**
+     * \returns the native source bytes per pixel.
+     */
+    virtual size_t bytesPerPixel() = 0;
+
     virtual std::vector<std::string> info()
     {
         std::vector<std::string> vinfo;
 
         vinfo.push_back( imageName() );
-        vinfo.push_back( "size: [" + std::to_string( nx() ) + "x" + std::to_string( ny() ) + "x" + std::to_string( nz() ) + "]" );
+        vinfo.push_back( "size: [" + std::to_string( nx() ) + "x" + std::to_string( ny() ) + "x" +
+                         std::to_string( nz() ) + "]" );
         double age = mx::sys::get_curr_time() - imageTime();
         if( age > 10 )
         {
-            vinfo.push_back(std::string("age: ") + std::to_string( (int)age ) + " sec" );
+            vinfo.push_back( std::string( "age: " ) + std::to_string( (int)age ) + " sec" );
         }
 
         return vinfo;

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -11,6 +11,15 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
     m_ui.setupUi( this );
     m_imv = v;
 
+    const int colorTabIndex = m_ui.tabWidget->indexOf( m_ui.tabColor );
+    if( colorTabIndex > 0 )
+    {
+        const QString colorTabText = m_ui.tabWidget->tabText( colorTabIndex );
+        const QIcon colorTabIcon = m_ui.tabWidget->tabIcon( colorTabIndex );
+        m_ui.tabWidget->removeTab( colorTabIndex );
+        m_ui.tabWidget->insertTab( 0, m_ui.tabColor, colorTabIcon, colorTabText );
+    }
+
     setupMode();
     setupCombos();
     m_ui.tabWidget->setCurrentIndex( 0 );
@@ -60,10 +69,22 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
     m_ui.qualityLabel->setVisible( true );
     m_ui.qualitySlider->setVisible( true );
     m_ui.qualityEntry->setVisible( true );
+    m_ui.lastCompressionRatioLabel->setVisible( true );
+    m_ui.lastCompressionRatioEntry->setVisible( true );
+    m_ui.avgCompressionRatioLabel->setVisible( true );
+    m_ui.avgCompressionRatioEntry->setVisible( true );
+    m_ui.avgFrameRateLabel->setVisible( true );
+    m_ui.avgFrameRateEntry->setVisible( true );
 #else
     m_ui.qualityLabel->setVisible( false );
     m_ui.qualitySlider->setVisible( false );
     m_ui.qualityEntry->setVisible( false );
+    m_ui.lastCompressionRatioLabel->setVisible( false );
+    m_ui.lastCompressionRatioEntry->setVisible( false );
+    m_ui.avgCompressionRatioLabel->setVisible( false );
+    m_ui.avgCompressionRatioEntry->setVisible( false );
+    m_ui.avgFrameRateLabel->setVisible( false );
+    m_ui.avgFrameRateEntry->setVisible( false );
 #endif
 
     init_panel();
@@ -134,6 +155,7 @@ void rtimvControlPanel::init_panel()
 #ifdef RTIMV_GRPC
     update_qualitySlider();
     update_qualityEntry();
+    update_transportStats();
 #endif
     update_hpFilter();
     update_lpFilter();
@@ -175,6 +197,7 @@ void rtimvControlPanel::update_panel()
 #ifdef RTIMV_GRPC
     update_qualitySlider();
     update_qualityEntry();
+    update_transportStats();
 #endif
 
     update_hpFilter();
@@ -765,6 +788,15 @@ void rtimvControlPanel::update_qualityEntry()
         m_ui.qualityEntry->setText( QString::number( m_imv->quality() ) );
         m_ui.qualityEntry->blockSignals( false );
     }
+#endif
+}
+
+void rtimvControlPanel::update_transportStats()
+{
+#ifdef RTIMV_GRPC
+    m_ui.lastCompressionRatioEntry->setText( QString::number( m_imv->lastCompressionRatio(), 'f', 1 ) + ":1" );
+    m_ui.avgCompressionRatioEntry->setText( QString::number( m_imv->avgCompressionRatio(), 'f', 1 ) + ":1" );
+    m_ui.avgFrameRateEntry->setText( QString::number( m_imv->avgFrameRate(), 'f', 1 ) );
 #endif
 }
 

--- a/src/gui/rtimvControlPanel.hpp
+++ b/src/gui/rtimvControlPanel.hpp
@@ -263,6 +263,9 @@ class rtimvControlPanel : public QWidget
     /// Synchronize JPEG quality entry from model state.
     void update_qualityEntry();
 
+    /// Synchronize the displayed transport statistics from model state.
+    void update_transportStats();
+
     /// Synchronize high-pass filter controls from model state.
     void update_hpFilter();
 

--- a/src/gui/rtimvControlPanel.ui
+++ b/src/gui/rtimvControlPanel.ui
@@ -1799,6 +1799,93 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
+    <widget class="QLabel" name="lastCompressionRatioLabel">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>40</y>
+       <width>171</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Last Compression</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lastCompressionRatioEntry">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>60</y>
+       <width>171</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QLabel" name="avgCompressionRatioLabel">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>100</y>
+       <width>171</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Avg Compression</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="avgCompressionRatioEntry">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>120</y>
+       <width>171</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QLabel" name="avgFrameRateLabel">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>160</y>
+       <width>171</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Avg Arrival Rate</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="avgFrameRateEntry">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>180</y>
+       <width>171</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabFilters">
     <attribute name="title">

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -369,6 +369,7 @@ message Image
     float max_image_data = 111;
     float min_scale_data = 112;
     float max_scale_data = 113;
+    uint32 source_bytes_per_pixel = 114;
 
     Colorbar  colorbar = 115;
     Colormode colormode = 120;

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -226,6 +226,17 @@ void rtimvClientBase::setupConfig()
                 "real",
                 "Specify the image cube update rate in FPS.  Default is 20 FPS." );
 
+    config.add( "update.rollingStatsFrames",
+                "",
+                "update.rollingStatsFrames",
+                mx::app::argType::Required,
+                "update",
+                "rollingStatsFrames",
+                false,
+                "int",
+                "Specify the number of frames used for rolling averages of compression ratio and frame rate. "
+                "Default is 10." );
+
     config.add( "autoscale",
                 "",
                 "autoscale",
@@ -481,6 +492,15 @@ void rtimvClientBase::loadConfig()
         config( cubeFPS, "update.cubeFPS" );
         m_configReq->set_update_cube_fps( cubeFPS );
         m_configReq->set_update_cube_fps_set( true );
+    }
+
+    if( config.isSet( "update.rollingStatsFrames" ) )
+    {
+        config( m_rollingStatsFrames, "update.rollingStatsFrames" );
+        if( m_rollingStatsFrames < 1 )
+        {
+            m_rollingStatsFrames = 1;
+        }
     }
 
     if( config.isSet( "autoscale" ) )
@@ -936,6 +956,7 @@ void rtimvClientBase::ImageReceived()
     float fpsEst;
     double imageTime;
     uint32_t saturated;
+    uint32_t sourceBytesPerPixel;
     float minsc, maxsc, minim, maxim;
     int imageTimeout;
     int quality;
@@ -962,6 +983,7 @@ void rtimvClientBase::ImageReceived()
     float colorBox_min, colorBox_max;
     int cubeDir;
     bool hasImagePayload{ false };
+    size_t compressedBytes{ 0 };
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
@@ -1002,6 +1024,7 @@ void rtimvClientBase::ImageReceived()
 
         if( m_grpcImage.image().size() > 0 )
         {
+            compressedBytes = static_cast<size_t>( m_grpcImage.image().size() );
             hasImagePayload = m_qim->loadFromData(
                 reinterpret_cast<const uchar *>( m_grpcImage.image().data() ), m_grpcImage.image().size(), "jpeg" );
         }
@@ -1010,6 +1033,7 @@ void rtimvClientBase::ImageReceived()
         fpsEst = m_grpcImage.fps();
 
         saturated = m_grpcImage.saturated();
+        sourceBytesPerPixel = m_grpcImage.source_bytes_per_pixel();
 
         minim = m_grpcImage.min_image_data();
         maxim = m_grpcImage.max_image_data();
@@ -1075,6 +1099,7 @@ void rtimvClientBase::ImageReceived()
     }
 
     m_fpsEst = fpsEst;
+    updateRollingTransportStats( nx, ny, compressedBytes, sourceBytesPerPixel, hasImagePayload );
     m_imageTime = imageTime;
     m_imageNo = imageNo;
     m_saturated = saturated;
@@ -1740,6 +1765,21 @@ double rtimvClientBase::fpsEst( size_t n )
     return 0;
 }
 
+double rtimvClientBase::lastCompressionRatio()
+{
+    return m_lastCompressionRatio;
+}
+
+double rtimvClientBase::avgCompressionRatio()
+{
+    return m_avgCompressionRatio;
+}
+
+double rtimvClientBase::avgFrameRate()
+{
+    return m_avgFrameRate;
+}
+
 std::string rtimvClientBase::imageName( size_t n )
 {
     if( n >= m_imageNames.size() )
@@ -2061,6 +2101,69 @@ void rtimvClientBase::setCurrImageTimeout()
         }
 
         m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
+    }
+}
+
+void rtimvClientBase::updateRollingTransportStats(
+    uint32_t nx, uint32_t ny, size_t compressedBytes, uint32_t sourceBytesPerPixel, bool validPayload )
+{
+    if( m_rollingStatsFrames < 1 )
+    {
+        m_rollingStatsFrames = 1;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if( m_lastArrivalTime != std::chrono::steady_clock::time_point{} )
+    {
+        const std::chrono::duration<double> dt = now - m_lastArrivalTime;
+        const double seconds = dt.count();
+        if( seconds > 0 )
+        {
+            const double arrivalFps = 1.0 / seconds;
+            m_recentFps.push_back( arrivalFps );
+            m_fpsRollingSum += arrivalFps;
+
+            while( static_cast<int>( m_recentFps.size() ) > m_rollingStatsFrames )
+            {
+                m_fpsRollingSum -= m_recentFps.front();
+                m_recentFps.pop_front();
+            }
+
+            if( !m_recentFps.empty() )
+            {
+                m_avgFrameRate = m_fpsRollingSum / static_cast<double>( m_recentFps.size() );
+            }
+        }
+    }
+    m_lastArrivalTime = now;
+
+    if( !validPayload || compressedBytes == 0 || sourceBytesPerPixel == 0 )
+    {
+        return;
+    }
+
+    const double sourceBytes =
+        static_cast<double>( nx ) * static_cast<double>( ny ) * static_cast<double>( sourceBytesPerPixel );
+    if( sourceBytes <= 0 )
+    {
+        return;
+    }
+
+    const double compressionRatio = sourceBytes / static_cast<double>( compressedBytes );
+    m_lastCompressionRatio = compressionRatio;
+
+    m_recentCompressionRatios.push_back( compressionRatio );
+    m_compressionRollingSum += compressionRatio;
+
+    while( static_cast<int>( m_recentCompressionRatios.size() ) > m_rollingStatsFrames )
+    {
+        m_compressionRollingSum -= m_recentCompressionRatios.front();
+        m_recentCompressionRatios.pop_front();
+    }
+
+    if( !m_recentCompressionRatios.empty() )
+    {
+        m_avgCompressionRatio = m_compressionRollingSum / static_cast<double>( m_recentCompressionRatios.size() );
     }
 }
 

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -2119,19 +2119,22 @@ void rtimvClientBase::updateRollingTransportStats(
         const double seconds = dt.count();
         if( seconds > 0 )
         {
-            const double arrivalFps = 1.0 / seconds;
-            m_recentFps.push_back( arrivalFps );
-            m_fpsRollingSum += arrivalFps;
+            m_recentFrameIntervals.push_back( seconds );
+            m_fpsRollingSum += seconds;
 
-            while( static_cast<int>( m_recentFps.size() ) > m_rollingStatsFrames )
+            while( static_cast<int>( m_recentFrameIntervals.size() ) > m_rollingStatsFrames )
             {
-                m_fpsRollingSum -= m_recentFps.front();
-                m_recentFps.pop_front();
+                m_fpsRollingSum -= m_recentFrameIntervals.front();
+                m_recentFrameIntervals.pop_front();
             }
 
-            if( !m_recentFps.empty() )
+            if( !m_recentFrameIntervals.empty() )
             {
-                m_avgFrameRate = m_fpsRollingSum / static_cast<double>( m_recentFps.size() );
+                const double avgFrameInterval = m_fpsRollingSum / static_cast<double>( m_recentFrameIntervals.size() );
+                if( avgFrameInterval > 0 )
+                {
+                    m_avgFrameRate = 1.0 / avgFrameInterval;
+                }
             }
         }
     }

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -12,6 +12,8 @@
 #include <mutex>
 #include <shared_mutex>
 #include <condition_variable>
+#include <chrono>
+#include <deque>
 #include <string_view>
 
 #include <QImage>
@@ -422,6 +424,24 @@ class rtimvClientBase : public mx::app::application
 
     float m_fpsEst;
 
+    int m_rollingStatsFrames{ 10 }; ///< Number of frames used for rolling transport-stat averages.
+
+    double m_lastCompressionRatio{ 0 }; ///< Compression ratio of the most recently received image payload.
+
+    double m_avgCompressionRatio{ 0 }; ///< Rolling average compression ratio over recent received frames.
+
+    double m_avgFrameRate{ 0 }; ///< Rolling average frame rate over recent received frames.
+
+    double m_fpsRollingSum{ 0 }; ///< Running sum for the rolling frame-rate average.
+
+    double m_compressionRollingSum{ 0 }; ///< Running sum for the rolling compression-ratio average.
+
+    std::deque<double> m_recentFps; ///< Recent FPS samples used to form the rolling average.
+
+    std::deque<double> m_recentCompressionRatios; ///< Recent compression-ratio samples used to form the average.
+
+    std::chrono::steady_clock::time_point m_lastArrivalTime; ///< Monotonic arrival time of the previous received frame.
+
     double m_imageTime{ 0 };
 
     uint32_t m_imageNo{ 0 };
@@ -595,6 +615,14 @@ class rtimvClientBase : public mx::app::application
   private:
     void setCurrImageTimeout();
 
+    /// Update rolling transport statistics from the latest received frame.
+    void updateRollingTransportStats( uint32_t nx /**< [in] frame width in pixels */,
+                                      uint32_t ny /**< [in] frame height in pixels */,
+                                      size_t compressedBytes /**< [in] compressed JPEG payload size in bytes */,
+                                      uint32_t sourceBytesPerPixel /**< [in] native source bytes per pixel */,
+                                      bool validPayload /**< [in] true if a JPEG payload was received and decoded */
+    );
+
   public:
     /// Set the image display timeout.
     /** This sets the maximum display frame rate, e.g. a timeout of 50 msec will
@@ -642,6 +670,15 @@ class rtimvClientBase : public mx::app::application
 
     /// Change the cube frame number by a delta
     void cubeFrameDelta( int32_t dfno /**< [in] the change in image number */ );
+
+    /// Get the compression ratio of the most recently received frame.
+    double lastCompressionRatio();
+
+    /// Get the rolling average compression ratio.
+    double avgCompressionRatio();
+
+    /// Get the rolling average frame rate.
+    double avgFrameRate();
 
     /// @}
 

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -436,7 +436,7 @@ class rtimvClientBase : public mx::app::application
 
     double m_compressionRollingSum{ 0 }; ///< Running sum for the rolling compression-ratio average.
 
-    std::deque<double> m_recentFps; ///< Recent FPS samples used to form the rolling average.
+    std::deque<double> m_recentFrameIntervals; ///< Recent inter-arrival times used to form the rolling average.
 
     std::deque<double> m_recentCompressionRatios; ///< Recent compression-ratio samples used to form the average.
 

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -769,6 +769,7 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         reply->set_max_image_data( imageTh->maxImageData() );
         reply->set_min_scale_data( imageTh->minScaleData() );
         reply->set_max_scale_data( imageTh->maxScaleData() );
+        reply->set_source_bytes_per_pixel( imageTh->bytesPerPixel( 0 ) );
 
         reply->set_colorbar( rtimv::colorbar2grpc( imageTh->colorbar() ) );
 


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex in response to the prompt: "I would like to add a rolling average of the frame rate and compression ratio to rtimvClient. The length of the average should start with 10 frames, but should be configurable. The compression ratio of the last frame, the rolling average compression ratio, and the rolling average frame rate should be displayed on the color tab of the control panel, to the right of the quality slider."

This PR adds rolling transport statistics to the gRPC client and exposes them on the control panel Color tab.

## Changes included:
- Added rolling transport-stat tracking in rtimvClientBase
- Added configurable rolling window length with default update.rollingStatsFrames=10
- The rolling frame-rate metric uses the local frame arrival rate on the client
- Added native source bytes-per-pixel support to image backends and propagated it through gRPC Image state
- Compression-ratio calculation uses native source frame size rather than decoded Qt image size
- Added Color-tab readouts for:
  - last compression ratio
  - average compression ratio
  - average arrival rate
- Moved the Color tab to the first position and made it the default selected tab
- Cleaned up related docs/style and updated agent_context.md
- renamed agent_context.md to AGENT.md, and made an agents folder to hold plans, etc.

## Verification:
- Built rtimvClient
- Built rtimvServer
- tested with local rtimvServer

##Notes:
- Compression ratio is computed for the 2D frame actually JPEG-encoded for transport
- Arrival rate reflects network delivery cadence, not remote source acquisition FPS