### PR TITLE
Feature jpeg quality config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,9 +81,10 @@ Follow these code style and documentation rules exactly.
 - This is preferred when using inline parameter documentation so `clang-format` can align the trailing comment blocks cleanly.
 
 15) PR Prompt Attribution
-- At the top of PR descriptions, include an explicit attribution line when work was performed with Codex.
+- At the top of PR descriptions, include an explicit attribution line when work was performed with an AI agent.
 - Preferred format:
-  - `This work was performed by GPT-5.3-Codex in response to the prompt: "...".`
+  - `This work was performed by <current agent model name> in response to the prompt: "...".`
+- Substitute the actual model name used for the work instead of hardcoding a specific release name.
 - Include the primary user prompt verbatim (or a faithful condensed version if it is extremely long).
 
 16) Stats Architecture Rule

--- a/agents/plans/jpeg_quality_config_plan.md
+++ b/agents/plans/jpeg_quality_config_plan.md
@@ -1,0 +1,202 @@
+# JPEG Quality Configuration Plan
+
+## Goal
+
+Make JPEG quality a configurable startup parameter for the gRPC client/server path with these behaviors:
+
+- The setting is loaded from config files on both the client and server sides.
+- `rtimvServer` can define a default JPEG quality applied to all served images.
+- The client can override the configured value from the command line.
+- Per-image startup configuration overrides the server default.
+- The value is scoped per configured remote image stream, not as one global server setting.
+
+## Current State
+
+- Transport quality already exists as runtime state in [`src/server/rtimvServerThread.hpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.hpp) and [`src/server/rtimvServerThread.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.cpp):
+  - `m_quality` defaults to `50`.
+  - JPEG encoding uses that value in `mtxuL_render()`.
+  - `SetQuality` updates it at runtime.
+  - `ImagePlease` returns it to the client in the `Image` payload.
+- The client already tracks and displays the active server quality in [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp) and the control panel.
+- There is no config-file or CLI startup path for quality in:
+  - [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp)
+  - [`src/common/rtimvBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/common/rtimvBase.cpp)
+  - [`src/server/rtimvServer.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServer.cpp)
+- The `remote_rtimv::Config` message in [`src/proto/rtimv.proto`](/home/jrmales/Source/rtimv/rtimv/src/proto/rtimv.proto) does not currently carry a quality field for startup configuration.
+- `rtimvServer` currently has no server-level default-quality setting for newly configured image threads.
+
+## Interpretation Of "Per Image"
+
+The existing transport architecture creates one `rtimvServerThread` per configured remote image stream/client configuration. That thread renders one JPEG payload for the displayed image state.
+
+Because only the rendered transport image is JPEG-encoded, the clean interpretation is:
+
+- "Per image" means per configured remote image stream / per `Configure()` session.
+- It does not need separate JPEG quality values for dark, mask, flat, and sat-mask inputs, since those are not individually transported as JPEGs.
+
+If you intended per auxiliary-image quality fields anyway, that would be a larger schema change and does not match the current transport model.
+
+## Proposed Design
+
+### Precedence
+
+Use this startup precedence, highest to lowest:
+
+1. Client command-line `quality`
+2. Client config-file `quality`
+3. `rtimvServer` default `quality`
+4. Built-in default `50`
+
+This preserves the current client-driven per-image model while adding a server-side fallback for every newly served image.
+
+### 1. Add a startup config field to the gRPC `Config` message
+
+Update [`src/proto/rtimv.proto`](/home/jrmales/Source/rtimv/rtimv/src/proto/rtimv.proto) so `Config` carries:
+
+- `bool quality_set`
+- `int32 quality`
+
+This matches the existing `*_set` pattern already used for optional startup overrides like `update_timeout`, `autoscale`, and `mzmq_port`.
+
+Why:
+
+- The client needs to tell the server whether a quality value was explicitly configured.
+- The server needs to preserve its default when the field is absent.
+
+### 2. Add `quality` to client config and CLI parsing
+
+In [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp):
+
+- Add a config entry for `quality` in `setupConfig()`.
+- In `loadConfig()`, if `quality` is set:
+  - read it from the config system,
+  - clamp or validate it to `[0,100]`,
+  - store it into `m_configReq`,
+  - set `quality_set = true`.
+
+Behavior:
+
+- Client config file can define the default quality for that remote image configuration.
+- Client CLI can override the config file automatically via the existing `mx::app::application` precedence rules already used elsewhere.
+
+### 3. Pass configured quality through server `Configure()`
+
+In [`src/server/rtimvServer.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServer.cpp):
+
+- Add a documented server member, likely `m_qualityDefault`, defaulting to `50`.
+- Add a `quality` config entry in `setupConfig()` for `rtimvServer`.
+- Read that value in `loadConfig()`.
+- In `doConfigure()`, always seed the spawned argv with the server default:
+  - `--quality`
+  - `<m_qualityDefault>`
+- If `cspec->m_config.quality_set()` is true, append a second:
+  - `--quality`
+  - `<client/image-specific value>`
+
+to the argv vector used to configure the new [`src/server/rtimvServerThread.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.cpp) instance.
+
+Why this fits the current structure:
+
+- Server-side per-client image threads already bootstrap from argv plus an optional config file.
+- Forwarding both values through argv keeps startup behavior aligned with how other image-specific startup options are applied.
+- Because later command-line occurrences should win, the image-specific override can cleanly supersede the server default without introducing a second override path inside `rtimvServerThread`.
+
+### 4. Add quality to `rtimvBase` startup configuration
+
+In [`src/common/rtimvBase.hpp`](/home/jrmales/Source/rtimv/rtimv/src/common/rtimvBase.hpp) and [`src/common/rtimvBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/common/rtimvBase.cpp):
+
+- Add a stored startup quality member in the base class, likely defaulting to `50`.
+- Add `quality` to `setupConfig()`.
+- Read `quality` in `loadConfig()`.
+- Expose a non-inline accessor if needed, following the project rule to keep even simple accessors in `.cpp`.
+
+Why `rtimvBase` is the right place:
+
+- `rtimvServerThread` derives from `rtimvBase`, and its per-image startup behavior is already driven by `rtimvBase` config parsing.
+- This keeps startup configuration centralized instead of duplicating parsing logic in the server thread.
+
+### 5. Seed `rtimvServerThread` runtime quality from configured base state
+
+In [`src/server/rtimvServerThread.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.cpp):
+
+- After `setup()`/`loadConfig()` completes during `configure()`, initialize `m_quality` from the configured startup quality value.
+- Reuse the existing `quality( int )` setter so clamping and `m_newImage` behavior stay consistent.
+
+Expected result:
+
+- The first JPEG served after configuration uses the configured quality.
+- Runtime `SetQuality` continues to work exactly as it does now.
+
+### 6. Keep passive state sync via `ImagePlease`
+
+No architectural change is needed here.
+
+- [`src/server/rtimvServer.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServer.cpp) already includes `quality` in the `Image` reply.
+- [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp) already refreshes local cached quality from received `Image` state.
+
+This already matches the standing rule in `AGENTS.md` that `Image` should remain the authoritative sync payload for frequently changing backend state.
+
+## File-Level Implementation Plan
+
+### Proto and generated interfaces
+
+- Update [`src/proto/rtimv.proto`](/home/jrmales/Source/rtimv/rtimv/src/proto/rtimv.proto) `Config`.
+- Regenerate protobuf/gRPC sources through the project build.
+
+### Common base config
+
+- Update [`src/common/rtimvBase.hpp`](/home/jrmales/Source/rtimv/rtimv/src/common/rtimvBase.hpp).
+- Update [`src/common/rtimvBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/common/rtimvBase.cpp).
+
+### Client startup config path
+
+- Update [`src/server/rtimvClientBase.hpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.hpp) only if a documented member is needed for startup/default quality state.
+- Update [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp).
+
+### Server configure/bootstrap path
+
+- Update [`src/server/rtimvServer.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServer.cpp).
+- Update [`src/server/rtimvServer.hpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServer.hpp).
+- Update [`src/server/rtimvServerThread.hpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.hpp) only if an accessor or documented startup helper is required.
+- Update [`src/server/rtimvServerThread.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvServerThread.cpp).
+
+## Validation Plan
+
+### Functional checks
+
+- Start `rtimvServer` with a config file containing `quality`, connect a client with no image-specific quality, and verify the first returned `Image.quality` matches the server default.
+- Start `rtimvClient` with a config file containing `quality`, connect to the server, and verify the configured value is sent during `Configure()`.
+- Start `rtimvClient` with both config-file `quality` and CLI `--quality`; verify CLI wins.
+- Start `rtimvServer` with one default quality and `rtimvClient` with a different per-image quality; verify the per-image value wins.
+- Change quality at runtime from the control panel and verify it still propagates through `SetQuality` and `ImagePlease`.
+- Verify out-of-range values are clamped or rejected consistently on both startup and runtime paths.
+
+### Regression checks
+
+- Confirm the existing effective default remains `50` when neither server nor client config supplies `quality`.
+- Confirm reconnect/configure still works when `quality` is absent.
+- Confirm the control panel still reflects server-authoritative quality after startup and after runtime changes.
+
+### Build checks
+
+- Build `rtimvServer`.
+- Build `rtimvClient`.
+- Run `clang-format -i` on touched C++/proto-adjacent source files.
+
+## Risks And Edge Cases
+
+- Proto change requires regenerated sources; any stale generated files will cause confusing build failures.
+- Startup quality should be applied before the first rendered response, otherwise the first frame may still go out at the default `50`.
+- Validation policy should be chosen once and applied consistently:
+  - clamp to `[0,100]`, or
+  - reject invalid startup values with a configuration error.
+
+Clamping is more consistent with the existing runtime `rtimvServerThread::quality( int )` behavior and is likely the least disruptive choice.
+
+## One Existing Ambiguity Worth Resolving During Implementation
+
+While reviewing `rtimvClientBase::loadConfig()`, I noticed [`src/server/rtimvClientBase.cpp`](/home/jrmales/Source/rtimv/rtimv/src/server/rtimvClientBase.cpp) currently does:
+
+- `flatKey` -> `m_configReq->set_mask_key( flatKey )`
+
+That looks unrelated to JPEG quality, but it may be an existing bug or stale path in the config packing logic. I would leave it untouched for a minimal quality-only patch unless you want that cleaned up in the same change.

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -8,7 +8,6 @@
 #include "rtimvBase.hpp"
 #include "rtimvBaseObject.hpp"
 #include "rtimvLog.hpp"
-
 #include <cmath>
 
 #ifdef MXLIB_MILK

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -104,6 +104,9 @@ message Config
 
     bool mzmq_port_set = 24;
     uint32 mzmq_port = 25;
+
+    bool quality_set = 26;
+    int32 quality = 27;
 }
 
 message ConfigResult

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -226,6 +226,16 @@ void rtimvClientBase::setupConfig()
                 "real",
                 "Specify the image cube update rate in FPS.  Default is 20 FPS." );
 
+    config.add( "quality",
+                "",
+                "quality",
+                mx::app::argType::Required,
+                "",
+                "quality",
+                false,
+                "int",
+                "JPEG transport quality for this remote image stream.  Range is 0 to 100." );
+
     config.add( "update.rollingStatsFrames",
                 "",
                 "update.rollingStatsFrames",
@@ -395,7 +405,7 @@ void rtimvClientBase::loadConfig()
     config( flatKey, "flat.key" );
     if( flatKey != "" )
     {
-        m_configReq->set_mask_key( flatKey );
+        m_configReq->set_flat_key( flatKey );
     }
 
     std::string maskKey;
@@ -492,6 +502,15 @@ void rtimvClientBase::loadConfig()
         config( cubeFPS, "update.cubeFPS" );
         m_configReq->set_update_cube_fps( cubeFPS );
         m_configReq->set_update_cube_fps_set( true );
+    }
+
+    if( config.isSet( "quality" ) )
+    {
+        int quality;
+        config( quality, "quality" );
+        quality = std::clamp( quality, 0, 100 );
+        m_configReq->set_quality( quality );
+        m_configReq->set_quality_set( true );
     }
 
     if( config.isSet( "update.rollingStatsFrames" ) )

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -8,6 +8,7 @@
 #include "rtimvServer.hpp"
 #include "rtimvLog.hpp"
 
+#include <algorithm>
 #include <filesystem>
 
 namespace
@@ -174,6 +175,16 @@ void rtimvServer::setupConfig()
                 "real",
                 "Time in seconds after which a thread with no requests will be disconnected. Default is 120 s." );
 
+    config.add( "quality",
+                "",
+                "quality",
+                mx::app::argType::Required,
+                "",
+                "quality",
+                false,
+                "int",
+                "Default JPEG quality for served images when no per-image quality is configured." );
+
     config.add( "log.appname",
                 "",
                 "log.appname",
@@ -203,6 +214,8 @@ void rtimvServer::loadConfig()
     config( m_waitSleep, "image.sleep" );
     config( m_clientSleep, "client.sleep" );
     config( m_clientDisconnect, "client.disconnect" );
+    config( m_qualityDefault, "quality" );
+    m_qualityDefault = std::clamp( m_qualityDefault, 0, 100 );
 
     if( config.isSet( "log.appname" ) )
     {
@@ -1232,6 +1245,12 @@ void rtimvServer::doConfigure( const configSpec *cspec )
         argv->push_back( std::to_string( cspec->m_config.mzmq_port() ) );
     }
 
+    if( cspec->m_config.quality_set() )
+    {
+        argv->push_back( "--quality" );
+        argv->push_back( std::to_string( cspec->m_config.quality() ) );
+    }
+
     delete cspec;
 
     { // mutex scope
@@ -1247,8 +1266,11 @@ void rtimvServer::doConfigure( const configSpec *cspec )
             return;
         }
 
-        rtimvServerThread *imageTh =
-            new rtimvServerThread( uri, argv, m_calledName, m_logAppName ); // takes ownership of argv
+        rtimvServerThread *imageTh = new rtimvServerThread( uri,
+                                                            argv,
+                                                            m_qualityDefault,
+                                                            m_calledName,
+                                                            m_logAppName ); // takes ownership of argv
 
         m_clients.insert( clientT( uri, imageTh ) );
 

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -62,6 +62,8 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
     float m_clientDisconnect{ 120 }; /**< Time in seconds after which a thread with no requests will be disconnected.
                                           Default is 120 s.*/
 
+    int m_qualityDefault{ 50 }; ///< Default JPEG quality for new image threads when no per-image value is configured.
+
     bool m_logAppName{ true }; ///< True to include called-name in log prefixes.
 
     std::string m_calledName{ "rtimvServer" }; ///< Program called-name used in standardized log prefixes.

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -1,7 +1,15 @@
+/** \file rtimvServerThread.cpp
+ * \brief Definitions for the rtimvServerThread class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include "rtimvServerThread.hpp"
 #include "rtimvLog.hpp"
 
 #include <QBuffer>
+#include <algorithm>
 
 namespace
 {
@@ -25,10 +33,12 @@ std::string image0OrUnknown( rtimvServerThread *imageTh )
 
 rtimvServerThread::rtimvServerThread( const std::string &uri,
                                       std::shared_ptr<std::vector<std::string>> argv,
+                                      int defaultQuality,
                                       const std::string &calledName,
                                       bool includeAppName,
                                       QObject *parent )
-    : QThread( parent ), m_uri( uri ), m_calledName( calledName ), m_includeAppName( includeAppName )
+    : QThread( parent ), m_uri( uri ), m_defaultQuality( defaultQuality ), m_calledName( calledName ),
+      m_includeAppName( includeAppName )
 {
     m_configPathCLBase_env = "RTIMV_CONFIG_PATH"; // Tells mx::application to look for this env var.
 
@@ -48,6 +58,30 @@ rtimvServerThread::rtimvServerThread( const std::string &uri,
 
 rtimvServerThread::~rtimvServerThread()
 {
+}
+
+void rtimvServerThread::setupConfig()
+{
+    rtimvBase::setupConfig();
+
+    config.add( "quality",
+                "",
+                "quality",
+                mx::app::argType::Required,
+                "",
+                "quality",
+                false,
+                "int",
+                "JPEG transport quality for this image stream.  Range is 0 to 100." );
+}
+
+void rtimvServerThread::loadConfig()
+{
+    rtimvBase::loadConfig();
+
+    m_startupQualitySet = config.isSet( "quality" );
+    config( m_startupQuality, "quality" );
+    m_startupQuality = std::clamp( m_startupQuality, 0, 100 );
 }
 
 void rtimvServerThread::configure()
@@ -80,6 +114,11 @@ void rtimvServerThread::configure()
     try
     {
         setup( argv.size() - 1, const_cast<char **>( argv.data() ) );
+        quality( m_defaultQuality );
+        if( m_startupQualitySet )
+        {
+            quality( m_startupQuality );
+        }
         m_configured.store( 1, std::memory_order_relaxed );
         m_foundation->m_imageTimer.start( m_imageTimeout );
         std::cout << rtimv::formatServerLogMessage(

--- a/src/server/rtimvServerThread.hpp
+++ b/src/server/rtimvServerThread.hpp
@@ -1,3 +1,9 @@
+/** \file rtimvServerThread.hpp
+ * \brief Declarations for the rtimvServerThread class
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
 
 #ifndef rtimvServerThread_hpp
 #define rtimvServerThread_hpp
@@ -24,6 +30,15 @@ class rtimvServerThread : public QThread, public rtimvBase
     std::shared_ptr<std::vector<std::string>> m_argv; /**< The command line argv.  This is set in the constructor, and
                                                       destroyed after configure is called.*/
 
+    /// Default JPEG quality to use when no per-image startup quality is configured.
+    int m_defaultQuality{ 50 };
+
+    /// Configured startup JPEG quality for this image stream.
+    int m_startupQuality{ 50 };
+
+    /// True when startup JPEG quality was explicitly configured.
+    bool m_startupQualitySet{ false };
+
     std::atomic<bool> m_newImage{ false }; ///< Flag indicating a new image is ready after the last render.
 
     std::atomic<int> m_quality{ 50 }; ///< The JPEG quality factor (0-100).  Default is 50.
@@ -43,12 +58,19 @@ class rtimvServerThread : public QThread, public rtimvBase
   public:
     rtimvServerThread( const std::string &uri,                         /**< [in] client uri */
                        std::shared_ptr<std::vector<std::string>> argv, /**< [in] The argv vector. */
+                       int defaultQuality,            /**< [in] default JPEG quality when not configured per image */
                        const std::string &calledName, /**< [in] Program called-name for log prefixes. */
                        bool includeAppName,           /**< [in] True to include called-name in log prefixes. */
                        QObject *parent = nullptr      /**< [in] [opt] the parent of this thread */
     );
 
     ~rtimvServerThread();
+
+    /// Register server-thread-specific config options, including per-image JPEG quality.
+    virtual void setupConfig();
+
+    /// Load server-thread-specific config values after the base image configuration is parsed.
+    virtual void loadConfig();
 
     void configure();
 


### PR DESCRIPTION
This work was performed by GPT-5.4-Codex in response to the prompt: "I would like to make the JPEG quality be a configurable parameter in rtimvClient/Server. It should be a per image setting that is read from a file both on the server side and the client side, and can be set by command line on the client. Let's also add a configuration for rtimvServer to change the default for all images served by the server, which is overridden by the image configs."

## Summary

Adds configurable JPEG transport quality for the gRPC client/server path.

The new behavior is:

- `rtimvServer` supports a server-wide default `quality`
- each configured remote image stream can override that default with its own `quality`
- `rtimvClient` can set per-image `quality` from config file or command line
- plain `rtimv` does not expose this new option

## Precedence

Startup quality now resolves in this order:

1. client command-line `quality`
2. client config-file `quality`
3. server-side per-image `quality`
4. `rtimvServer` default `quality`
5. built-in default `50`

## Implementation

- Added `quality_set` and `quality` to `remote_rtimv::Config`
- Added client-side config/CLI packing of per-image quality
- Added `rtimvServer` default quality config and clamping
- Added server-thread-specific parsing/application of startup quality so the option remains hidden from non-gRPC `rtimv`
- Preserved passive synchronization through the `Image` payload

## Verification

- Built `rtimv`
- Built `rtimvServer`
- Built `rtimvClient`
- Tested end to end locally:
  - server default quality works
  - per-image override works
  - client CLI/config override works
  - behavior matches the planned precedence
