### PR TITLE
Fix shmim resize deadlock

### DIFF
--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -1880,6 +1880,7 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
     }
 
     bool resized = false;
+    bool resetZoom = false;
 
     if( newdata )
     { // mutex scope
@@ -2119,7 +2120,7 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
         if( resized )
         {
             // Always switch to zoom 1 after a resize occurs
-            zoomLevel( 1 );
+            resetZoom = true;
         }
 
         RTIMV_DEBUG_BREADCRUMB
@@ -2127,6 +2128,11 @@ void rtimvBase::mtxUL_changeImdata( bool newdata )
     } // shared mutex scope. - at this point we're done with calData
 
     RTIMV_DEBUG_BREADCRUMB
+
+    if( resetZoom )
+    {
+        zoomLevel( 1 );
+    }
 
 } // void rtimvBase::mtxUL_changeImdata()
 

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -440,7 +440,29 @@ void rtimvMainWindow::mtxL_postSetImsize( const uniqueLockT &lock )
 
     statsBoxRemove( m_statsBox );
 
-    colorBoxRemove( m_colorBox );
+    if( m_colorBox )
+    {
+        if( m_colorBox->isSelected() )
+        {
+            colorBoxDeselected( m_colorBox );
+        }
+
+        m_colormode = rtimv::colormode::minmaxglobal;
+        m_colorBoxRequestPending = false;
+        m_colorBoxTimer.stop();
+
+        m_colorBox->disconnect();
+        disconnect( m_colorBox );
+        m_colorBox->deleteLater();
+        m_colorBox = nullptr;
+
+        ui.graphicsView->userItemSize()->setVisible( false );
+        ui.graphicsView->userItemMouseCoords()->setVisible( false );
+        m_objCenH->setVisible( false );
+        m_objCenV->setVisible( false );
+        m_nullMouseCoords = false;
+        m_userItemSelected = false;
+    }
 
     auto ubit = m_userBoxes.begin();
     while( ubit != m_userBoxes.end() )
@@ -1324,7 +1346,12 @@ void rtimvMainWindow::updateNC()
 
 void rtimvMainWindow::mtxTry_userItemMouseCoords( float mx, float my, float dx, float dy )
 {
-    sharedLockT lock( m_calMutex );
+    if( !m_calMutex.try_lock_shared() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex, std::adopt_lock );
 
     if( m_qpmi == nullptr )
         return;
@@ -1457,7 +1484,12 @@ void rtimvMainWindow::userItemCross( const QPointF &pos, const QRectF &rect, con
 
 void rtimvMainWindow::mtxTry_colorBoxMoved( StretchBox *sb )
 {
-    sharedLockT lock( m_calMutex );
+    if( !m_calMutex.try_lock_shared() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex, std::adopt_lock );
 
     if( !m_colorBox )
     {
@@ -2110,7 +2142,12 @@ void rtimvMainWindow::addUserLine()
 
 void rtimvMainWindow::mtxTry_userLineSize( StretchLine *sl )
 {
-    sharedLockT lock( m_calMutex );
+    if( !m_calMutex.try_lock_shared() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex, std::adopt_lock );
 
     if( !m_qpmi )
         return;

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -3306,14 +3306,24 @@ void rtimvMainWindow::mtxL_fontLuminance( QTextEdit *qte, const sharedLockT &loc
 
 void rtimvMainWindow::mtxTry_fontLuminance( QTextEdit *qte, bool print )
 {
-    sharedLockT lock( m_calMutex );
+    if( !m_calMutex.try_lock_shared() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex, std::adopt_lock );
 
     return mtxL_fontLuminance( qte, lock, print );
 }
 
 void rtimvMainWindow::mtxTry_fontLuminance()
 {
-    sharedLockT lock( m_calMutex );
+    if( !m_calMutex.try_lock_shared() )
+    {
+        return;
+    }
+
+    sharedLockT lock( m_calMutex, std::adopt_lock );
 
     mtxL_fontLuminance( ui.graphicsView->fpsGage(), lock );
 


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to the prompt: "using rtimv connected to local shmimImage shared memory buffers, we are seeing crashes when the image size chages.  Message: \"Qt has caught an exception thrown from an event handler...Resource deadlock avoided\".  Sometimes \"Connected\" is printed first, sometimes not.  Possbily relevant is that MagAO-X plugins are loaded, with cameraStatus, indiDictionary, and warnings configured and enabled."

## Summary
This PR reduces same-thread mutex re-entry during local `shmimImage` reconnect and resize handling.

The original crash rate dropped after removing one UI-refresh re-lock path, but rare `Resource deadlock avoided` exceptions still remained. This follow-up also removes additional resize-time and selected-item UI re-entry paths that could attempt to lock `m_calMutex` while it was already held on the same thread.

## What Changed
- Make `rtimvMainWindow::mtxTry_fontLuminance()` skip work if `m_calMutex` is already held instead of trying to re-lock it.
- Defer the resize-triggered `zoomLevel(1)` reset until after `rtimvBase::mtxUL_changeImdata()` releases its shared lock.
- Remove a resize-time color-box teardown path that called back into `mtxUL_colormode()` while `mtxL_postSetImsize()` already held `m_calMutex`.
- Convert additional GUI-side `mtxTry_...` helpers to actual `try_lock_shared()` behavior so selected-item and overlay-adjacent updates do not throw when reached from an already-locked image update path.

## Affected Files
- `src/common/rtimvBase.cpp`
- `src/gui/rtimvMainWindow.cpp`

## Commits
- `1717856` Fix shmim resize deadlock in UI refresh
- `cf8d85d` Reduce resize-time UI mutex reentry

## Verification
- Ran `clang-format` on touched files.
- Built successfully with:
  - `cmake --build build --target rtimv -j4`

## Follow-Up / Edge Cases
- This still needs runtime validation under load with local shmim size changes and the MagAO-X `cameraStatus`, `indiDictionary`, and `warnings` plugins enabled.
- If `Resource deadlock avoided` still appears after this series, the next likely area is plugin-driven synchronous UI work during reconnect or resize, especially anything that updates overlays or status widgets from within an image-update callback.
