### PR TITLE
Add plugin text overlay support

### DIFF
--- a/doc/PluginGuide.md
+++ b/doc/PluginGuide.md
@@ -1,0 +1,318 @@
+# Plugin System Guide
+
+This document is for programmers writing `rtimv` plugins. It describes how plugins are discovered, which interfaces are available, how the data dictionary works, and how to add plugin-specific help overlays.
+
+## Overview
+
+`rtimv` plugins are Qt plugins built around the interfaces declared in [rtimvInterfaces.hpp](../src/librtimv/rtimvInterfaces.hpp).
+
+There are two primary plugin roles:
+
+- `rtimvDictionaryInterface`
+  Exposes a shared key/value dictionary to a plugin so it can publish or consume auxiliary state.
+- `rtimvOverlayInterface`
+  Gives a plugin access to selected GUI objects so it can draw overlays, react to keypresses, and update display state.
+
+A single plugin class may implement one or both interfaces.
+
+All plugin interfaces derive from `rtimvInterface`, which provides:
+
+- `info()` for user-visible plugin information shown in the `i` info overlay
+- standardized plugin log formatting helpers
+- optional plugin text-overlay help hooks
+
+As of interface version `1.4`, `rtimvInterface` also provides optional default methods for plugin text overlays:
+
+- `hasTextOverlay()`
+- `textOverlayKey()`
+- `textOverlayTitle()`
+- `textOverlayText()`
+
+These default to the no-overlay case, so existing plugins do not need to implement them unless they want a dedicated help/info panel.
+
+## Plugin Discovery and Loading
+
+`rtimvMainWindow` loads plugins in three ways:
+
+- static Qt plugins returned by `QPluginLoader::staticInstances()`
+- dynamic plugins found in directories listed in `RTIMV_PLUGIN_PATH`
+- dynamic plugins found in the application `plugins` directory next to the installed executable
+
+Each candidate plugin object is passed through `rtimvMainWindow::loadPlugin()`. That function:
+
+- detects which supported interfaces the plugin implements
+- sets plugin log context with `setLogContext()`
+- sets a plugin label with `setPluginName()`
+- calls `attachDictionary()` when the plugin implements `rtimvDictionaryInterface`
+- calls `attachOverlay()` when the plugin implements `rtimvOverlayInterface`
+- registers optional plugin text overlays when `hasTextOverlay()` returns `true`
+
+Plugin attachment return values follow the established convention:
+
+- `0`: configured and attached successfully
+- `> 0`: not configured or intentionally unused, but not an error
+- `< 0`: hard error
+
+If a dynamically loaded plugin is unused, `rtimv` attempts to unload it.
+
+## Base Interface
+
+Every supported plugin derives from `rtimvInterface`.
+
+The required method is:
+
+```cpp
+virtual std::vector<std::string> info() = 0;
+```
+
+This should return programmer- or operator-facing summary lines for the `i` info overlay. The first line should identify the plugin and its type. Later lines should align visually with that first line.
+
+Useful inherited helpers include:
+
+- `setLogContext()`
+- `setPluginName()`
+- `formatPluginLogMessage()`
+- `pluginLogInfo()`
+- `pluginLogError()`
+
+These keep plugin log output consistent with the rest of `rtimv`.
+
+## Dictionary Plugins
+
+Dictionary plugins implement `rtimvDictionaryInterface`:
+
+```cpp
+virtual int attachDictionary( dictionaryT *, mx::app::appConfigurator & ) = 0;
+```
+
+The dictionary itself is a shared `std::map<std::string, rtimvDictBlob>`, typedef’d as `dictionaryT`.
+
+The intent is that plugins can exchange lightweight state through stable string keys without introducing direct coupling between unrelated plugin classes and GUI code.
+
+### Blob Storage
+
+Each dictionary entry is an `rtimvDictBlob`, which stores:
+
+- a byte buffer
+- the current payload size
+- the allocated size
+- ownership state
+- a `CLOCK_REALTIME` modification timestamp
+- an internal mutex protecting access
+
+The main accessors are:
+
+- `setBlob(const void *blob, size_t sz)`
+- `getBlob(char *blob, size_t mxsz, timespec *ts = nullptr)`
+- `getBlobStr(char *blob, size_t mxsz, timespec *ts = nullptr)`
+- `getBlobSize()`
+
+### Dictionary Usage Pattern
+
+Writers typically:
+
+1. choose a stable namespaced key such as `rtimv.pluginName.state`
+2. fill a POD struct or C string with the desired content
+3. call `setBlob()` on the target dictionary entry
+
+Readers typically:
+
+1. look up the key in `dictionaryT`
+2. allocate a destination buffer of suitable size
+3. call `getBlob()` or `getBlobStr()`
+4. optionally compare or inspect the returned timestamp
+
+### Recommended Dictionary Practices
+
+- Use namespaced keys such as `rtimv.<plugin>.<field>` to avoid collisions.
+- Prefer fixed-layout POD structs or null-terminated strings for simple interoperability.
+- Document the payload format in the plugin source when the blob is not self-describing.
+- Treat missing keys as a normal startup condition.
+- Do not assume another plugin is already loaded unless that dependency is explicit and documented.
+- Keep payloads small and cheap to copy.
+- Prefer replacing the whole blob with `setBlob()` rather than inventing partial-update semantics.
+
+### Dictionary Example
+
+For a simple string status:
+
+```cpp
+std::string status = "camera connected";
+auto &blob = ( *m_dictionary )["rtimv.example.status"];
+blob.setBlob( status.c_str(), status.size() + 1 );
+```
+
+And the corresponding reader:
+
+```cpp
+char buffer[256];
+timespec ts;
+
+auto it = m_dictionary->find( "rtimv.example.status" );
+if( it != m_dictionary->end() )
+{
+    it->second.getBlobStr( buffer, sizeof( buffer ), &ts );
+}
+```
+
+## Overlay Plugins
+
+Overlay plugins implement `rtimvOverlayInterface`:
+
+```cpp
+virtual int attachOverlay( rtimvOverlayAccess &, mx::app::appConfigurator & ) = 0;
+virtual int updateOverlay() = 0;
+virtual void keyPressEvent( QKeyEvent *ke ) = 0;
+virtual bool overlayEnabled() = 0;
+virtual void enableOverlay() = 0;
+virtual void disableOverlay() = 0;
+```
+
+The `rtimvOverlayAccess` struct exposes selected GUI internals:
+
+- `m_mainWindowObject`
+- `m_colorBox`
+- `m_statsBox`
+- `m_userBoxes`
+- `m_userCircles`
+- `m_userLines`
+- `m_graphicsView`
+- `m_dictionary`
+
+Plugins should copy the passed `rtimvOverlayAccess` into internal state during `attachOverlay()`.
+
+### Overlay Responsibilities
+
+An overlay plugin usually does one or more of the following:
+
+- add or update `QGraphicsItem` overlays in the main scene
+- react to keyboard events not handled centrally by `rtimvMainWindow`
+- read shared state from the dictionary
+- publish plugin state back into the dictionary
+
+### Key Handling
+
+Overlay plugins still receive raw `keyPressEvent()` callbacks after `rtimvMainWindow` has handled built-in shortcuts and any registered text-overlay shortcut.
+
+That means:
+
+- built-in `rtimv` shortcuts remain centralized in `rtimvMainWindow`
+- plugin text overlays should use the `rtimvInterface` text-overlay API, not ad hoc overlay key handling
+- other plugin-specific hotkeys can continue to be handled in `rtimvOverlayInterface::keyPressEvent()`
+
+Avoid conflicting with built-in keys unless the collision is intentional and coordinated.
+
+## Plugin Text Overlays
+
+If a plugin wants the same full-screen text panel used by `h` help and `i` info, implement these optional `rtimvInterface` methods:
+
+```cpp
+bool hasTextOverlay() override;
+char textOverlayKey() override;
+std::string textOverlayTitle() override;
+std::string textOverlayText() override;
+```
+
+Recommended behavior:
+
+- return `true` from `hasTextOverlay()`
+- use a lowercase printable key such as `w`
+- return a short label such as `warnings` from `textOverlayTitle()`
+- generate current text on demand in `textOverlayText()`
+
+`rtimvMainWindow` owns registration and toggling of these overlays. The behavior is:
+
+- pressing the registered key shows the plugin text overlay
+- pressing the same key again hides it
+- pressing a different registered text-overlay key switches the shared panel contents
+
+If a plugin registers a shortcut that is already in use, `rtimv` logs the collision and keeps the first registration.
+
+## Minimal Skeleton
+
+The exact Qt boilerplate depends on how you package the plugin, but the conceptual shape is:
+
+```cpp
+class examplePlugin : public QObject, public rtimvOverlayInterface
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA( IID rtimvOverlayInterface_iid )
+    Q_INTERFACES( rtimvOverlayInterface )
+
+  public:
+    std::vector<std::string> info() override
+    {
+        return { "example overlay", "                demo plugin" };
+    }
+
+    int attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &config ) override
+    {
+        static_cast<void>( config );
+        m_roa = roa;
+        return 0;
+    }
+
+    int updateOverlay() override
+    {
+        return 0;
+    }
+
+    void keyPressEvent( QKeyEvent *ke ) override
+    {
+        static_cast<void>( ke );
+    }
+
+    bool overlayEnabled() override
+    {
+        return true;
+    }
+
+    void enableOverlay() override
+    {
+    }
+
+    void disableOverlay() override
+    {
+    }
+
+    bool hasTextOverlay() override
+    {
+        return true;
+    }
+
+    char textOverlayKey() override
+    {
+        return 'w';
+    }
+
+    std::string textOverlayTitle() override
+    {
+        return "warnings";
+    }
+
+    std::string textOverlayText() override
+    {
+        return "Current warnings go here.\n";
+    }
+
+  protected:
+    rtimvOverlayAccess m_roa;
+};
+```
+
+If the plugin also needs dictionary access, implement `rtimvDictionaryInterface` as well and add the corresponding `Q_INTERFACES(...)` entry.
+
+## Compatibility Notes
+
+- `rtimvDictionaryInterface_iid` is currently `rtimv.dictionaryInterface/1.4`.
+- `rtimvOverlayInterface_iid` is currently `rtimv.overlayInterface/1.4`.
+- If the interface ID changes, out-of-tree plugins must be rebuilt and updated to advertise the new IID.
+- The optional text-overlay methods were added with defaults in `rtimvInterface`, so existing plugin source code can remain unchanged unless it wants to participate in the new help system.
+
+## Practical Advice
+
+- Keep plugin `info()` output concise. It is displayed directly to users.
+- Prefer using the shared dictionary for cross-plugin state instead of passing raw object pointers around.
+- Generate plugin text-overlay help dynamically if it reflects live state.
+- Log plugin failures with the standardized helpers so load and runtime problems are easy to diagnose.
+- Return `> 0` from `attachDictionary()` or `attachOverlay()` when the plugin is simply not configured for the current environment, and reserve negative returns for actual errors.

--- a/doc/rtimv-dox.in
+++ b/doc/rtimv-dox.in
@@ -866,6 +866,7 @@ WARN_LOGFILE           =
 
 INPUT                  = ../readme.md \
                          ./Installation.md \
+                         ./PluginGuide.md \
                          ./UserGuide.md
 
 # This tag can be used to specify the character encoding of the source files

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -8,6 +8,7 @@
 
 #include "rtimvMainWindow.hpp"
 #include <algorithm>
+#include <cctype>
 #include <QMetaType>
 
 rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::WindowFlags f ) : QWidget( Parent, f )
@@ -41,6 +42,9 @@ rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::Wi
     m_qgs->installEventFilter( this );
 
     ui.graphicsView->setScene( m_qgs );
+
+    registerTextOverlay( 'h', "help", [this]() { return generateHelp(); }, "rtimv" );
+    registerTextOverlay( 'i', "info", [this]() { return generateInfo(); }, "rtimv" );
 
     rightClickDragging = false;
 
@@ -2457,7 +2461,16 @@ void rtimvMainWindow::keyPressEvent( QKeyEvent *ke )
     }
     else // Finally deal with unmodified keys
     {
-        char key = ke->text()[0].toLatin1();
+        char key = '\0';
+        if( !ke->text().isEmpty() )
+        {
+            key = ke->text()[0].toLatin1();
+        }
+
+        if( key != '\0' && hasTextOverlay( key ) )
+        {
+            return toggleTextOverlay( key );
+        }
 
         switch( ke->key() )
         {
@@ -2484,14 +2497,6 @@ void rtimvMainWindow::keyPressEvent( QKeyEvent *ke )
                 return toggleFPSGage();
             if( key == 'F' )
                 return toggleFilter();
-            break;
-        case Qt::Key_H:
-            if( key == 'h' )
-                return toggleHelp();
-            break;
-        case Qt::Key_I:
-            if( key == 'i' )
-                return toggleInfo();
             break;
         case Qt::Key_L:
             if( key == 'l' )
@@ -3004,6 +3009,80 @@ void rtimvMainWindow::showQualityMessage( int q )
     mtxTry_fontLuminance( ui.graphicsView->zoomText() );
 }
 
+bool rtimvMainWindow::registerTextOverlay( char key,
+                                           const std::string &title,
+                                           std::function<std::string()> provider,
+                                           const std::string &source )
+{
+    if( key == '\0' || !provider || !std::isprint( static_cast<unsigned char>( key ) ) ||
+        std::isspace( static_cast<unsigned char>( key ) ) )
+    {
+        std::cerr << formatBaseLogMessage( std::string( "invalid text overlay registration from " ) + source ) << '\n';
+        return false;
+    }
+
+    if( m_textOverlays.contains( key ) )
+    {
+        std::cerr << formatBaseLogMessage( std::string( "skipping text overlay registration from " ) + source +
+                                           ": shortcut '" + key + "' is already registered" )
+                  << '\n';
+        return false;
+    }
+
+    textOverlayEntry toe;
+    toe.m_title = title.empty() ? source : title;
+    toe.m_textProvider = std::move( provider );
+    toe.m_builtin = ( source == "rtimv" );
+    toe.m_source = source;
+
+    m_textOverlays[key] = std::move( toe );
+    return true;
+}
+
+bool rtimvMainWindow::hasTextOverlay( char key ) const
+{
+    return m_textOverlays.contains( key );
+}
+
+void rtimvMainWindow::hideTextOverlay()
+{
+    ui.graphicsView->helpText()->setVisible( false );
+    m_activeTextOverlayKey = '\0';
+}
+
+void rtimvMainWindow::showTextOverlay( char key )
+{
+    auto it = m_textOverlays.find( key );
+    if( it == m_textOverlays.end() )
+    {
+        return;
+    }
+
+    std::string text = it->second.m_textProvider();
+    if( text.empty() )
+    {
+        std::cerr << formatBaseLogMessage( std::string( "text overlay '" ) + key + "' from " + it->second.m_source +
+                                           " returned empty text" )
+                  << '\n';
+        return;
+    }
+
+    ui.graphicsView->helpTextText( text.c_str() );
+    ui.graphicsView->helpText()->setVisible( true );
+    m_activeTextOverlayKey = key;
+    mtxTry_fontLuminance( ui.graphicsView->helpText() );
+}
+
+void rtimvMainWindow::toggleTextOverlay( char key )
+{
+    if( m_activeTextOverlayKey == key )
+    {
+        return hideTextOverlay();
+    }
+
+    return showTextOverlay( key );
+}
+
 std::string rtimvMainWindow::generateHelp()
 {
     std::string help;
@@ -3032,6 +3111,16 @@ std::string rtimvMainWindow::generateHelp()
 #endif
     help += "z: toggle color box\n";
 
+    for( const auto &[key, overlay] : m_textOverlays )
+    {
+        if( overlay.m_builtin )
+        {
+            continue;
+        }
+
+        help += std::string( 1, key ) + ": toggle " + overlay.m_title + "\n";
+    }
+
     help += "\n";
     help += "C: toggle cube control        D: toggle dark subtraction     \n";
     help += "F: toggle filters             L: toggle log scale           \n";
@@ -3053,19 +3142,7 @@ std::string rtimvMainWindow::generateHelp()
 
 void rtimvMainWindow::toggleHelp()
 {
-    if( m_helpVisible )
-    {
-        ui.graphicsView->helpText()->setVisible( false );
-        m_helpVisible = false;
-    }
-    else
-    {
-        std::string help = generateHelp();
-        ui.graphicsView->helpTextText( help.c_str() );
-        ui.graphicsView->helpText()->setVisible( true );
-        m_helpVisible = true;
-        m_infoVisible = false;
-    }
+    return toggleTextOverlay( 'h' );
 }
 
 std::string rtimvMainWindow::generateInfo()
@@ -3165,19 +3242,7 @@ std::string rtimvMainWindow::generateInfo()
 
 void rtimvMainWindow::toggleInfo()
 {
-    if( m_infoVisible )
-    {
-        ui.graphicsView->helpText()->setVisible( false );
-        m_infoVisible = false;
-    }
-    else
-    {
-        std::string info = generateInfo();
-        ui.graphicsView->helpTextText( info.c_str() );
-        ui.graphicsView->helpText()->setVisible( true );
-        m_infoVisible = true;
-        m_helpVisible = false;
-    }
+    return toggleTextOverlay( 'i' );
 }
 
 void rtimvMainWindow::borderWarningLevel( rtimv::warningLevel lvl )
@@ -3391,6 +3456,11 @@ void rtimvMainWindow::mtxTry_fontLuminance()
 
     mtxL_fontLuminance( ui.graphicsView->saveBox(), lock );
 
+    if( ui.graphicsView->helpText()->isVisible() )
+    {
+        mtxL_fontLuminance( ui.graphicsView->helpText(), lock );
+    }
+
     return;
 }
 
@@ -3460,6 +3530,15 @@ int rtimvMainWindow::loadPlugin( QObject *plugin )
     // If ri is not null, we store it.  Note this could be many types of interfaces at once.
     if( ri )
     {
+        if( ri->hasTextOverlay() )
+        {
+            registerTextOverlay(
+                ri->textOverlayKey(),
+                ri->textOverlayTitle(),
+                [ri]() { return ri->textOverlayText(); },
+                plugin->metaObject()->className() );
+        }
+
         m_plugins.push_back( ri );
         return 0;
     }

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -1,8 +1,17 @@
 
+/** \file rtimvMainWindow.hpp
+ * \brief Declaration of the rtimvMainWindow class.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #ifndef rtimvMainWindow_hpp_inc
 #define rtimvMainWindow_hpp_inc
 
 #include <cstdio>
+#include <functional>
+#include <map>
 #include <unordered_set>
 
 #include <QWidget>
@@ -784,15 +793,78 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     /// Show the transient JPEG quality status text.
     void showQualityMessage( int q /**< [in] JPEG quality value to display */ );
 
-    bool m_helpVisible{ false };
+    /** \name Text Overlays - Data
+     *
+     * Shared state for the full-screen text overlays toggled by shortcut keys.
+     *
+     * @{
+     */
+  protected:
+    /// Describes one registered text overlay entry.
+    struct textOverlayEntry
+    {
+        /// Short title used in the built-in help listing.
+        std::string m_title;
+
+        /// Generates the current overlay text on demand.
+        std::function<std::string()> m_textProvider;
+
+        /// True when this entry is one of the built-in overlays.
+        bool m_builtin{ false };
+
+        /// Source label used in log messages.
+        std::string m_source;
+    };
+
+    /// Registry of overlay shortcuts to text providers.
+    std::map<char, textOverlayEntry> m_textOverlays;
+
+    /// Active text overlay shortcut, or `'\0'` when hidden.
+    char m_activeTextOverlayKey{ '\0' };
+
+    ///@}
+
+    /** \name Text Overlays
+     *
+     * Helpers for registering and toggling shared text overlays.
+     *
+     * @{
+     */
+  public:
+    /// Register a toggleable text overlay shortcut.
+    bool
+    registerTextOverlay( char key,                              /**< [in] Shortcut key used to toggle the overlay. */
+                         const std::string &title,              /**< [in] Short title shown in the help listing. */
+                         std::function<std::string()> provider, /**< [in] Generator for the current overlay text. */
+                         const std::string &source              /**< [in] Source label for collision log messages. */
+    );
+
+    /// Check if a shortcut has a registered text overlay.
+    bool hasTextOverlay( char key /**< [in] Shortcut key to look up. */ ) const;
+
+  protected:
+    /// Hide the shared text overlay widget.
+    void hideTextOverlay();
+
+    /// Show the shared text overlay widget for a registered shortcut.
+    void showTextOverlay( char key /**< [in] Shortcut key identifying the overlay to show. */ );
+
+    /// Toggle the shared text overlay widget for a registered shortcut.
+    void toggleTextOverlay( char key /**< [in] Shortcut key identifying the overlay to toggle. */ );
+
+    ///@}
+
+  public:
+    /// Generate the built-in keyboard help overlay.
     std::string generateHelp();
 
+    /// Toggle the built-in keyboard help overlay.
     void toggleHelp();
 
-    bool m_infoVisible{ false };
-
+    /// Generate the built-in image and plugin info overlay.
     std::string generateInfo();
 
+    /// Toggle the built-in image and plugin info overlay.
     void toggleInfo();
 
     /** \name Border Colors

--- a/src/librtimv/rtimvInterfaces.hpp
+++ b/src/librtimv/rtimvInterfaces.hpp
@@ -1,4 +1,11 @@
 
+/** \file rtimvInterfaces.hpp
+ * \brief Interface definitions shared by rtimv plugins and overlays.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #ifndef rtimvInterfaces_hpp
 #define rtimvInterfaces_hpp
 
@@ -255,6 +262,30 @@ class rtimvInterface : public QObject
      */
     virtual std::vector<std::string> info() = 0;
 
+    /// Report whether this plugin provides a toggleable text overlay.
+    virtual bool hasTextOverlay()
+    {
+        return false;
+    }
+
+    /// Get the shortcut key used to toggle the plugin text overlay.
+    virtual char textOverlayKey()
+    {
+        return '\0';
+    }
+
+    /// Get the short title used to describe the plugin text overlay.
+    virtual std::string textOverlayTitle()
+    {
+        return "";
+    }
+
+    /// Generate the plugin text overlay contents on demand.
+    virtual std::string textOverlayText()
+    {
+        return "";
+    }
+
     /// Set context used by standardized plugin log formatters.
     void setLogContext( const std::string &calledName, /**< [in] Program called-name for log prefix. */
                         bool includeAppName,           /**< [in] True to include called-name in log prefix. */
@@ -287,7 +318,7 @@ class rtimvInterface : public QObject
         ctx.image0 = m_logImage0;
         ctx.includeAppName = m_logIncludeAppName;
 
-        return rtimv::formatLogMessage( ctx, std::format("[plugin: {}] {}", m_pluginName, message) );
+        return rtimv::formatLogMessage( ctx, std::format( "[plugin: {}] {}", m_pluginName, message ) );
     }
 
     /// Write a standardized plugin info message to stdout.
@@ -320,7 +351,7 @@ class rtimvDictionaryInterface : public rtimvInterface
                                   ) = 0;
 };
 
-#define rtimvDictionaryInterface_iid "rtimv.dictionaryInterface/1.3"
+#define rtimvDictionaryInterface_iid "rtimv.dictionaryInterface/1.4"
 
 Q_DECLARE_INTERFACE( rtimvDictionaryInterface, rtimvDictionaryInterface_iid )
 
@@ -401,7 +432,7 @@ class rtimvOverlayInterface : public rtimvInterface
     virtual void disableOverlay() = 0;
 };
 
-#define rtimvOverlayInterface_iid "rtimv.overlayInterface/1.3"
+#define rtimvOverlayInterface_iid "rtimv.overlayInterface/1.4"
 
 Q_DECLARE_INTERFACE( rtimvOverlayInterface, rtimvOverlayInterface_iid )
 


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "please see agents/plans/plugin_help.md" and follow-on prompts to implement plugin overlay help, document the plugin system, and move the work onto a feature branch.

## Summary

Adds a shared text-overlay framework so built-in help/info and plugin-provided overlays all use the same registration and toggle path.

This change:
- refactors `h` and `i` to use a centralized text-overlay registry in `rtimvMainWindow`
- adds optional default text-overlay methods to `rtimvInterface`
- registers plugin text overlays during plugin load
- appends plugin overlay shortcuts to the built-in help screen
- bumps plugin interface IIDs from `1.3` to `1.4`
- adds programmer documentation for the plugin system and data dictionary

## Testing

- Built successfully with:
  - `cmake --build build --target rtimv -j4`
- Manually verified:
  - `h` toggles help on/off
  - `i` toggles info on/off
  - switching between `h` and `i` reuses the shared overlay correctly

## Notes

- Existing plugins remain source-compatible because the new text-overlay hooks in `rtimvInterface` have no-overlay defaults.
- Out-of-tree plugins should be rebuilt and updated for the `1.4` interface IDs.
- This PR adds the framework but does not yet add an in-tree plugin consumer such as a `w` warnings overlay.
