### PR TITLE
Codex/dynamic text overlay refresh

### DIFF
--- a/agents/plans/overlay-dynamic-updates.md
+++ b/agents/plans/overlay-dynamic-updates.md
@@ -1,0 +1,67 @@
+Problem: right now the help/info overlays are static, and only update if they've been toggled. we need to implement a method for the help overlays to update dynamically.  A good working case is the image age in the info overlay: it should update in the overlay whenever it is updated by the image itself.  Plugin overlays should likewise be able to signal an update is needed. Ideally the signal will indicate which line to update. Please review AGENTS.md and fill in this document with a plan below.
+
+Plan:
+1. Document the current shared overlay flow and keep the change centered in `rtimvMainWindow`.
+   The current text overlay path is `registerTextOverlay(...) -> showTextOverlay(...) -> ui.graphicsView->helpTextText(...)`.
+   Today the provider is evaluated only when the overlay is first shown, so `generateInfo()` and plugin `textOverlayText()` results go stale while the overlay remains visible.
+   The least invasive fix is to keep the existing shared `helpText()` widget and add a refresh path in `rtimvMainWindow` rather than introducing a second overlay system.
+
+2. Extend the text overlay registry so an active overlay can be refreshed in place.
+   Add per-overlay refresh metadata to the existing `textOverlayEntry` in `src/gui/rtimvMainWindow.hpp`.
+   Keep the existing full-text provider for backward compatibility.
+   Add optional support for line-oriented refreshes so the active overlay can either:
+   refresh the entire text block, or
+   refresh a single line identified by index.
+   Add helpers in `rtimvMainWindow` along the lines of:
+   `refreshActiveTextOverlay()`
+   `refreshTextOverlay(char key)`
+   `refreshTextOverlayLine(char key, size_t line)`
+   These helpers should no-op when the requested overlay is not active or not visible.
+
+3. Hook overlay refresh into the existing image update path.
+   The natural place is in `rtimvMainWindow.cpp` wherever image updates already drive UI refresh, especially the path that already updates the FPS/age gauge and calls `m_overlays[n]->updateOverlay()`.
+   When the image reports `RTIMVIMAGE_AGEUPDATE` or a full image update, call the new overlay refresh helper for the active text overlay.
+   This will make the built-in info overlay update its age text continuously without requiring a toggle.
+   Keep the refresh conditional on an overlay actually being visible so normal image update cost stays minimal.
+
+4. Keep built-in help and info overlays compatible with the new API.
+   Leave `generateHelp()` and `generateInfo()` as the canonical full-text builders.
+   For the first pass, allow the built-in overlays to refresh by regenerating the full text block; this is simple and low risk.
+   If needed afterward, add an internal helper that returns the image info lines separately so the info overlay can update just the age line without rebuilding the whole string.
+
+5. Add plugin-facing refresh signaling without forcing every plugin to change immediately.
+   Use Qt signals/slots through `rtimvOverlayAccess::m_mainWindowObject`, which already exposes the main window `QObject *` to overlay plugins.
+   Add `rtimvMainWindow` slots that accept a plugin overlay shortcut and request either:
+   a full overlay refresh, or
+   a single-line refresh.
+   Plugins can then connect their own signals directly to these slots during `attachOverlay(...)`.
+   This keeps visibility and active-overlay state in `rtimvMainWindow` and avoids making plugins track whether their overlay is currently visible.
+   Preserve the current `hasTextOverlay() / textOverlayKey() / textOverlayText()` interface, and add only optional line-provider support for plugins that want targeted line replacement.
+
+6. Keep line-level updates practical but not over-engineered.
+   Store the currently displayed overlay text as split lines when an overlay is shown or refreshed.
+   For a line refresh request, replace only that line, then push the rebuilt text back through `helpTextText(...)`.
+   This still redraws the shared `QTextEdit`, but it gives plugins a stable way to target one line and avoids designing a brand new widget layout.
+   If a plugin requests an out-of-range line, fall back to a full refresh and log once if useful.
+
+7. Verify behavior with one built-in case and one plugin case.
+   Built-in case:
+   show the `i` overlay and confirm the image age changes while the overlay remains visible.
+   Plugin case:
+   use or create a plugin overlay that changes one reported line and emits a signal connected to the new main-window refresh slot.
+   Confirm that:
+   the visible overlay updates without retoggling,
+   hidden overlays are not unnecessarily regenerated,
+   help overlay behavior is unchanged,
+   existing plugins without the new callback API still work.
+
+8. Files likely to change.
+   `src/gui/rtimvMainWindow.hpp`
+   `src/gui/rtimvMainWindow.cpp`
+   `src/librtimv/rtimvInterfaces.hpp`
+   Possibly one plugin implementation or test fixture to exercise the callback-driven refresh path.
+
+9. Main risks to watch.
+   Refreshes must stay on the Qt GUI thread.
+   Plugin callbacks must not outlive `rtimvMainWindow` shutdown.
+   Full-text regeneration on every image age tick is acceptable as a first pass, but if a remote client drives very frequent updates we should watch for unnecessary churn and then tighten to line-only refresh for the info overlay.

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -9,6 +9,7 @@
 #include "rtimvMainWindow.hpp"
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 #include <QMetaType>
 #include <QFontMetrics>
 
@@ -44,8 +45,10 @@ rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::Wi
 
     ui.graphicsView->setScene( m_qgs );
 
-    registerTextOverlay( 'h', "help", [this]() { return generateHelp(); }, "rtimv" );
-    registerTextOverlay( 'i', "info", [this]() { return generateInfo(); }, "rtimv" );
+    registerTextOverlay(
+        'h', "help", [this]() { return generateHelp(); }, []( size_t ) { return std::string(); }, "rtimv" );
+    registerTextOverlay(
+        'i', "info", [this]() { return generateInfo(); }, []( size_t ) { return std::string(); }, "rtimv" );
 
     rightClickDragging = false;
 
@@ -1328,6 +1331,8 @@ void rtimvMainWindow::updateAge()
     // Check the font luminance to make sure it is visible
     mtxTry_fontLuminance();
 
+    refreshActiveTextOverlay();
+
     if( m_showFPSGage && imageValid() )
     {
         struct timespec tstmp;
@@ -1374,6 +1379,8 @@ void rtimvMainWindow::updateAge()
 
 void rtimvMainWindow::updateNC()
 {
+    refreshActiveTextOverlay();
+
     for( size_t n = 0; n < m_overlays.size(); ++n )
     {
         m_overlays[n]->updateOverlay();
@@ -3320,9 +3327,46 @@ void rtimvMainWindow::showQualityMessage( int q )
     mtxTry_fontLuminance( ui.graphicsView->zoomText() );
 }
 
+std::vector<std::string> rtimvMainWindow::splitTextOverlayLines( const std::string &text ) const
+{
+    std::vector<std::string> lines;
+    std::stringstream sstr( text );
+    std::string line;
+
+    while( std::getline( sstr, line ) )
+    {
+        lines.push_back( line );
+    }
+
+    if( !text.empty() && text.back() == '\n' )
+    {
+        lines.push_back( "" );
+    }
+
+    return lines;
+}
+
+std::string rtimvMainWindow::joinTextOverlayLines( const std::vector<std::string> &lines ) const
+{
+    std::string text;
+
+    for( size_t n = 0; n < lines.size(); ++n )
+    {
+        text += lines[n];
+
+        if( n + 1 < lines.size() )
+        {
+            text += '\n';
+        }
+    }
+
+    return text;
+}
+
 bool rtimvMainWindow::registerTextOverlay( char key,
                                            const std::string &title,
                                            std::function<std::string()> provider,
+                                           std::function<std::string( size_t )> lineProvider,
                                            const std::string &source )
 {
     if( key == '\0' || !provider || !std::isprint( static_cast<unsigned char>( key ) ) ||
@@ -3343,6 +3387,7 @@ bool rtimvMainWindow::registerTextOverlay( char key,
     textOverlayEntry toe;
     toe.m_title = title.empty() ? source : title;
     toe.m_textProvider = std::move( provider );
+    toe.m_lineProvider = std::move( lineProvider );
     toe.m_builtin = ( source == "rtimv" );
     toe.m_source = source;
 
@@ -3359,6 +3404,7 @@ void rtimvMainWindow::hideTextOverlay()
 {
     ui.graphicsView->helpText()->setVisible( false );
     m_activeTextOverlayKey = '\0';
+    m_activeTextOverlayLines.clear();
 }
 
 void rtimvMainWindow::showTextOverlay( char key )
@@ -3380,8 +3426,101 @@ void rtimvMainWindow::showTextOverlay( char key )
 
     ui.graphicsView->helpText()->setVisible( true );
     m_activeTextOverlayKey = key;
+    m_activeTextOverlayLines = splitTextOverlayLines( text );
     mtxTry_fontLuminance( ui.graphicsView->helpText() );
     ui.graphicsView->helpTextText( text.c_str() );
+}
+
+void rtimvMainWindow::refreshActiveTextOverlay()
+{
+    if( m_activeTextOverlayKey == '\0' )
+    {
+        return;
+    }
+
+    refreshTextOverlay( m_activeTextOverlayKey );
+}
+
+void rtimvMainWindow::refreshActiveTextOverlayLine( size_t line )
+{
+    if( m_activeTextOverlayKey == '\0' )
+    {
+        return;
+    }
+
+    refreshTextOverlayLine( m_activeTextOverlayKey, line );
+}
+
+void rtimvMainWindow::refreshTextOverlay( char key )
+{
+    if( m_activeTextOverlayKey != key || !ui.graphicsView->helpText()->isVisible() )
+    {
+        return;
+    }
+
+    auto it = m_textOverlays.find( key );
+    if( it == m_textOverlays.end() )
+    {
+        return;
+    }
+
+    std::string text = it->second.m_textProvider();
+    if( text.empty() )
+    {
+        return;
+    }
+
+    m_activeTextOverlayLines = splitTextOverlayLines( text );
+    mtxTry_fontLuminance( ui.graphicsView->helpText() );
+    ui.graphicsView->helpTextText( text.c_str() );
+}
+
+void rtimvMainWindow::refreshTextOverlayLine( char key, size_t line )
+{
+    if( m_activeTextOverlayKey != key || !ui.graphicsView->helpText()->isVisible() )
+    {
+        return;
+    }
+
+    auto it = m_textOverlays.find( key );
+    if( it == m_textOverlays.end() )
+    {
+        return;
+    }
+
+    if( !it->second.m_lineProvider || line >= m_activeTextOverlayLines.size() )
+    {
+        refreshTextOverlay( key );
+        return;
+    }
+
+    std::string newLine = it->second.m_lineProvider( line );
+    if( newLine.empty() && line < m_activeTextOverlayLines.size() && !m_activeTextOverlayLines[line].empty() )
+    {
+        refreshTextOverlay( key );
+        return;
+    }
+
+    m_activeTextOverlayLines[line] = std::move( newLine );
+
+    std::string text = joinTextOverlayLines( m_activeTextOverlayLines );
+    mtxTry_fontLuminance( ui.graphicsView->helpText() );
+    ui.graphicsView->helpTextText( text.c_str() );
+}
+
+void rtimvMainWindow::textOverlayRefreshRequested( char key )
+{
+    refreshTextOverlay( key );
+}
+
+void rtimvMainWindow::textOverlayLineRefreshRequested( char key, int lineNo )
+{
+    if( lineNo < 0 )
+    {
+        return;
+    }
+
+    refreshTextOverlayLine( key, static_cast<size_t>( lineNo ) );
 }
 
 void rtimvMainWindow::toggleTextOverlay( char key )
@@ -3847,6 +3986,7 @@ int rtimvMainWindow::loadPlugin( QObject *plugin )
                 ri->textOverlayKey(),
                 ri->textOverlayTitle(),
                 [ri]() { return ri->textOverlayText(); },
+                [ri]( size_t line ) { return ri->textOverlayLine( line ); },
                 plugin->metaObject()->className() );
         }
 

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -13,7 +13,9 @@
 #include <cmath>
 #include <functional>
 #include <map>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <QWidget>
 #include <QScrollBar>
@@ -857,6 +859,9 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
         /// Generates the current overlay text on demand.
         std::function<std::string()> m_textProvider;
 
+        /// Generates one line of overlay text on demand, or empty to request a full refresh.
+        std::function<std::string( size_t )> m_lineProvider;
+
         /// True when this entry is one of the built-in overlays.
         bool m_builtin{ false };
 
@@ -870,6 +875,15 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     /// Active text overlay shortcut, or `'\0'` when hidden.
     char m_activeTextOverlayKey{ '\0' };
 
+    /// Cached lines for the currently visible shared text overlay.
+    std::vector<std::string> m_activeTextOverlayLines;
+
+    /// Split overlay text into line cache entries.
+    std::vector<std::string> splitTextOverlayLines( const std::string &text /**< [in] Overlay text to split. */ ) const;
+
+    /// Join cached overlay lines into the text shown by the shared widget.
+    std::string joinTextOverlayLines( const std::vector<std::string> &lines /**< [in] Overlay lines to join. */ ) const;
+
     ///@}
 
     /** \name Text Overlays
@@ -880,11 +894,12 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
      */
   public:
     /// Register a toggleable text overlay shortcut.
-    bool
-    registerTextOverlay( char key,                              /**< [in] Shortcut key used to toggle the overlay. */
-                         const std::string &title,              /**< [in] Short title shown in the help listing. */
-                         std::function<std::string()> provider, /**< [in] Generator for the current overlay text. */
-                         const std::string &source              /**< [in] Source label for collision log messages. */
+    bool registerTextOverlay(
+        char key,                                          /**< [in] Shortcut key used to toggle the overlay. */
+        const std::string &title,                          /**< [in] Short title shown in the help listing. */
+        std::function<std::string()> provider,             /**< [in] Generator for the current overlay text. */
+        std::function<std::string( size_t )> lineProvider, /**< [in] Optional generator for one overlay line. */
+        const std::string &source                          /**< [in] Source label for collision log messages. */
     );
 
     /// Check if a shortcut has a registered text overlay.
@@ -896,6 +911,20 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
 
     /// Show the shared text overlay widget for a registered shortcut.
     void showTextOverlay( char key /**< [in] Shortcut key identifying the overlay to show. */ );
+
+    /// Refresh the currently active shared text overlay.
+    void refreshActiveTextOverlay();
+
+    /// Refresh one line of the currently active shared text overlay.
+    void refreshActiveTextOverlayLine( size_t line /**< [in] Zero-based line index to refresh. */ );
+
+    /// Refresh the shared text overlay widget for a registered shortcut.
+    void refreshTextOverlay( char key /**< [in] Shortcut key identifying the overlay to refresh. */ );
+
+    /// Refresh one line of the shared text overlay widget for a registered shortcut.
+    void refreshTextOverlayLine( char key,   /**< [in] Shortcut key identifying the overlay to refresh. */
+                                 size_t line /**< [in] Zero-based line index to refresh. */
+    );
 
     /// Toggle the shared text overlay widget for a registered shortcut.
     void toggleTextOverlay( char key /**< [in] Shortcut key identifying the overlay to toggle. */ );
@@ -914,6 +943,15 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
 
     /// Toggle the built-in image and plugin info overlay.
     void toggleInfo();
+
+  public slots:
+    /// Request a full shared text overlay refresh for a registered shortcut.
+    void textOverlayRefreshRequested( char key /**< [in] Shortcut key identifying the overlay to refresh. */ );
+
+    /// Request a single-line shared text overlay refresh for a registered shortcut.
+    void textOverlayLineRefreshRequested( char key,  /**< [in] Shortcut key identifying the overlay to refresh. */
+                                          int lineNo /**< [in] Zero-based line index to refresh. */
+    );
 
     /** \name Border Colors
      * @{

--- a/src/librtimv/rtimvInterfaces.hpp
+++ b/src/librtimv/rtimvInterfaces.hpp
@@ -286,6 +286,15 @@ class rtimvInterface : public QObject
         return "";
     }
 
+    /// Generate one line of plugin text overlay contents on demand.
+    /** Return an empty string to request that the caller regenerate the full overlay text instead.
+     */
+    virtual std::string textOverlayLine( size_t line /**< [in] Zero-based line index to regenerate. */ )
+    {
+        static_cast<void>( line );
+        return "";
+    }
+
     /// Set context used by standardized plugin log formatters.
     void setLogContext( const std::string &calledName, /**< [in] Program called-name for log prefix. */
                         bool includeAppName,           /**< [in] True to include called-name in log prefix. */


### PR DESCRIPTION
This work was performed by GPT-5 Codex.

## Summary

This change makes the shared help/info text overlay refresh dynamically while it remains visible.

The main window now owns refresh handling for active text overlays, including:
- full-overlay refreshes
- optional single-line refreshes
- automatic refresh when image age updates occur

This allows the built-in info overlay to update image age continuously without requiring the user to toggle the overlay off and back on.

## What Changed

- added active text overlay refresh helpers and cached line handling in `rtimvMainWindow`
- refreshed the active shared text overlay from the existing image update path
- added `rtimvMainWindow` slots for plugin-triggered full and line-specific overlay refresh requests
- extended `rtimvInterface` with an optional `textOverlayLine(size_t)` method so plugins can opt into targeted line refreshes
- updated the implementation plan in `agents/plans/overlay-dynamic-updates.md`

## Why

The existing overlay system only generated text when the overlay was shown, so info such as image age became stale while the overlay stayed open. Plugin overlays had the same limitation.

## User Impact

- the `i` info overlay now updates live as image age changes
- plugin overlays can request refreshes through Qt signal/slot connections to `rtimvMainWindow`
- existing plugins remain compatible and fall back to full-text refresh behavior

## Validation

- ran `clang-format` on touched files
- configured a fresh build in `/tmp/rtimv-build`
- built successfully through the client-side targets including `rtimvClient` and `rtimvClientBaseAsyncRaceTest`
- manually tested the info overlay and saw no visible refresh glitches on this machine
