### PR TITLE
Feature/toggle sync startup bools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ res/qrc_imviewer.cpp
 doc/html
 .vscode
 .DS_Store
+.codex
 
-#cmake
 _build
 

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -39,7 +39,7 @@ but this is somewhat different than for local `rtimv`.  This config file path wi
 The name and location of an image is specified by its `key`.  The following rules are followed in the given order to determine how to find an image:
 - If the `key` ends in `.fits`, `.fit`, `.FITS`, or `.FIT`, then the image is treated as a FITS file stored on local disk with `key` specifying a valid path.
 - if the `key` ends in `/`, e.g. `/path/to/directory/`, then rtimv will treat the FITS files in that directory as a cube, enabling playback and incrementing through the images in lexical sort order.
-- If the `key` contains `@` or `:`, or the configuration option `--mzmq.always=true` (`-Z`) is set, then the `key` is interpreted as a `milkzmq` address of the form `name@server:port`.  If `mzmq.always` is set, then `@` and `:` are optional. The default server is `localhost` and the default port is `5556`.
+- If the `key` contains `@` or `:`, or the configuration option `--mzmq.always` (`-Z`) or `--mzmq.always=true` is set, then the `key` is interpreted as a `milkzmq` address of the form `name@server:port`. If `mzmq.always` is set, then `@` and `:` are optional. The default server is `localhost` and the default port is `5556`.
 - Otherwise, `key` is treated as a local `milk` `shmim` name and the standard path is followed, e.g. `/milk/shm/image.im.shm` for `key=image`.
 
 ## Cube Mode
@@ -178,14 +178,14 @@ This means local client overrides always win for options/keys set locally, while
 |  | `--update.cubeFPS` | `update.cubeFPS` | real | Specify the image cube update rate in FPS. Default is 20 FPS. |
 |  | `--update.rollingStatsFrames` | `update.rollingStatsFrames` | int | Number of frames used for rolling averages of compression ratio and frame rate. `rtimvClient` only. Default is 10. |
 |  | `--quality` | `quality` | int | JPEG transport quality for the remote image stream. `rtimvClient` only. Range is 0 to 100. |
-|  | `--autoscale` | `autoscale` | bool | Turn autoscaling on at startup. |
+|  | `--autoscale` | `autoscale` | bool | Set autoscaling at startup. Bare `--autoscale` is true; `--autoscale=true` and `--autoscale=false` are also accepted. |
 |  | `--nofpsgage` | `nofpsgage` | bool | Turn the FPS gauge off at startup. |
-|  | `--darksub` | `darksub` | bool | Set to false to turn off dark subtraction at startup. If a dark is supplied, `darksub` is otherwise on. |
+|  | `--darksub` | `darksub` | bool | Set dark subtraction at startup. Bare `--darksub` is true; `--darksub=true` and `--darksub=false` are also accepted. If a dark is supplied, `darksub` is otherwise on. |
 |  | `--satLevel` | `satLevel` | float | The saturation level for this camera. |
-|  | `--masksat` | `masksat` | bool | Set to false to turn off saturation masking at startup. If a saturation mask is supplied, `masksat` is otherwise on. |
+|  | `--masksat` | `masksat` | bool | Set saturation masking at startup. Bare `--masksat` is true; `--masksat=true` and `--masksat=false` are also accepted. If a saturation mask is supplied, `masksat` is otherwise on. |
 |  | `--targetXc` | `targetXc` | float | The fractional x-coordinate of the target, `0 <= x <= 1`. |
 |  | `--targetYc` | `targetYc` | float | The fractional y-coordinate of the target, `0 <= y <= 1`. |
-| `-Z` | `--mzmq.always` | `mzmq.always` | bool | Make `milkzmq` the protocol for bare image names. Local shmims can not be used if this is set. |
+| `-Z` | `--mzmq.always` | `mzmq.always` | bool | Set whether `milkzmq` is the protocol for bare image names. Bare `--mzmq.always` is true; `--mzmq.always=true` and `--mzmq.always=false` are also accepted. Local shmims can not be used if this is set. |
 | `-s` | `--mzmq.server` | `mzmq.server` | string | Default server for `milkzmq`. The default default is `localhost`. Overridden by an image-specific server specified in a key. |
 | `-p` | `--mzmq.port` | `mzmq.port` | int | Default port for `milkzmq`. The default default is `5556`. Overridden by an image-specific port specified in a key. |
 |  | `--mouse.pointerCoords` | `mouse.pointerCoords` | bool | Show or do not show the pointer coordinates. Default is true. |
@@ -200,7 +200,7 @@ This means local client overrides always win for options/keys set locally, while
 |  | `--tools.crossWidthMin` | `tools.crossWidthMin` | float | Minimum half-width of the center cross, in screen pixels. Default is 5. |
 |  | `--tools.warningBorderWidth` | `tools.warningBorderWidth` | float | Width of the warning border in screen pixels. Default is 5. |
 |  | `--log.appname` | `log.appname` | bool | Set true or false to include or exclude the called program name in log prefixes. |
-|  | `--no-log-appname` | `no-log-appname` | bool | Disable the called program name in log prefixes. |
+|  | `--no-log-appname` | `log.no-appname` | bool | Disable the called program name in log prefixes. |
 
 The Config-File options of the form `section.keyword` specify the form
 ```

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -22,11 +22,31 @@
     #include "images/mzmqImage.hpp"
 #endif
 
+#include <mx/ioutils/stringUtils.hpp>
 #include <mx/math/vectorUtils.hpp>
 #include <QCoreApplication>
 
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
 #define RTIMV_DEBUG_BREADCRUMB
+
+namespace
+{
+
+/// Parse a bool config target while preserving bare optional flags as true.
+bool configBoolOption( mx::app::appConfigurator &config, const std::string &name )
+{
+    std::string value;
+    config( value, name );
+
+    if( value.empty() )
+    {
+        return true;
+    }
+
+    return mx::ioutils::stoT<bool>( value );
+}
+
+} // namespace
 
 rtimvBase::rtimvBase()
 {
@@ -154,22 +174,22 @@ void rtimvBase::setupConfig()
     config.add( "autoscale",
                 "",
                 "autoscale",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "autoscale",
                 false,
                 "bool",
-                "Set to turn autoscaling on at startup" );
+                "Set autoscaling at startup. Bare --autoscale is true; also accepts =true or =false." );
 
     config.add( "darksub",
                 "",
                 "darksub",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "darksub",
                 false,
                 "bool",
-                "Set to false to turn off dark subtraction at startup. "
+                "Set dark subtraction at startup. Bare --darksub is true; also accepts =true or =false. "
                 "If a dark is supplied, darksub is otherwise on." );
 
     config.add( "satLevel",
@@ -185,24 +205,24 @@ void rtimvBase::setupConfig()
     config.add( "masksat",
                 "",
                 "masksat",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "masksat",
                 false,
                 "bool",
-                "Set to false to turn off sat-masking at startup. "
-                "If a satMaks is supplied, masksat is otherwise on." );
+                "Set sat-masking at startup. Bare --masksat is true; also accepts =true or =false. "
+                "If a saturation mask is supplied, masksat is otherwise on." );
 
     config.add( "mzmq.always",
                 "Z",
                 "mzmq.always",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "mzmq",
                 "always",
                 false,
                 "bool",
-                "Set to make milkzmq the protocol for bare image names.  Note that local shmims can"
-                "not be used if this is set." );
+                "Set whether milkzmq is the protocol for bare image names. Bare --mzmq.always is true; "
+                "also accepts =true or =false. Note that local shmims can not be used if this is set." );
 
     config.add( "mzmq.server",
                 "s",
@@ -261,7 +281,10 @@ void rtimvBase::loadConfig()
     std::vector<std::string> keys;
 
     // Set up milkzmq
-    config( m_mzmqAlways, "mzmq.always" );
+    if( config.isSet( "mzmq.always" ) )
+    {
+        m_mzmqAlways = configBoolOption( config, "mzmq.always" );
+    }
     config( m_mzmqServer, "mzmq.server" );
     config( m_mzmqPort, "mzmq.port" );
 
@@ -369,8 +392,15 @@ void rtimvBase::loadConfig()
         }
     }
 
-    config( m_autoScale, "autoscale" );
-    config( m_subtractDark, "darksub" );
+    if( config.isSet( "autoscale" ) )
+    {
+        m_autoScale = configBoolOption( config, "autoscale" );
+    }
+    m_subtractDarkSet = config.isSet( "darksub" );
+    if( m_subtractDarkSet )
+    {
+        m_subtractDark = configBoolOption( config, "darksub" );
+    }
 
     float satLevelDefault = m_satLevel;
     config( m_satLevel, "satLevel" );
@@ -382,7 +412,11 @@ void rtimvBase::loadConfig()
     }
 
     // except turn it off if requested
-    config( m_applySatMask, "masksat" );
+    m_applySatMaskSet = config.isSet( "masksat" );
+    if( m_applySatMaskSet )
+    {
+        m_applySatMask = configBoolOption( config, "masksat" );
+    }
 }
 
 void rtimvBase::processKeys( const std::vector<std::string> &shkeys )
@@ -478,7 +512,7 @@ void rtimvBase::processKeys( const std::vector<std::string> &shkeys )
     }
 
     // Turn on features if images exist:
-    if( m_images[1] != nullptr )
+    if( m_images[1] != nullptr && !m_subtractDarkSet )
     {
         m_subtractDark = true;
     }
@@ -488,7 +522,7 @@ void rtimvBase::processKeys( const std::vector<std::string> &shkeys )
         m_applyMask = true;
     }
 
-    if( m_images[3] != nullptr )
+    if( m_images[3] != nullptr && !m_applySatMaskSet )
     {
         m_applySatMask = true;
     }

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -417,6 +417,9 @@ class rtimvBase : public mx::app::application
     /// Whether or not the dark image is subtracted, default is false.
     bool m_subtractDark{ false };
 
+    /// True when the startup dark-subtraction state was set explicitly by config/CLI.
+    bool m_subtractDarkSet{ false };
+
     /// Whether or not the mask is applied, default is false.
     bool m_applyMask{ false };
 
@@ -425,6 +428,9 @@ class rtimvBase : public mx::app::application
      * not change the values returned by rawPixel().
      */
     bool m_applySatMask{ false };
+
+    /// True when the startup saturation-mask state was set explicitly by config/CLI.
+    bool m_applySatMaskSet{ false };
 
     /// Owned buffer that stores unfiltered calibrated pixel data.
     float *m_calDataRaw{ nullptr };

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -95,8 +95,6 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
 #endif
 
     init_panel();
-
-    m_statsBoxButtonState = false;
 }
 
 void rtimvControlPanel::setupMode()
@@ -152,7 +150,6 @@ void rtimvControlPanel::setupCombos()
 
 void rtimvControlPanel::init_panel()
 {
-
     update_panel();
 
     // initialize the button state for coordinate displays
@@ -162,9 +159,6 @@ void rtimvControlPanel::init_panel()
     targetXcChanged( m_imv->targetXc() );
     targetYcChanged( m_imv->targetYc() );
     targetVisibleChanged( m_imv->targetVisible() );
-
-    m_ui.imtimerspinBox->setValue( m_imv->imageTimeout() );
-    m_ui.statsDisplayModeCombo->setCurrentIndex( m_imv->statsDisplayMode() );
 
 #ifdef RTIMV_GRPC
     update_qualitySlider();
@@ -207,6 +201,17 @@ void rtimvControlPanel::update_panel()
     m_ui.colorbarCombo->blockSignals( true );
     m_ui.colorbarCombo->setCurrentIndex( static_cast<int>( m_imv->colorbar() ) );
     m_ui.colorbarCombo->blockSignals( false );
+
+    m_ui.imtimerspinBox->blockSignals( true );
+    m_ui.imtimerspinBox->setValue( m_imv->imageTimeout() );
+    m_ui.imtimerspinBox->blockSignals( false );
+
+    m_ui.statsDisplayModeCombo->blockSignals( true );
+    m_ui.statsDisplayModeCombo->setCurrentIndex( m_imv->statsDisplayMode() );
+    m_ui.statsDisplayModeCombo->blockSignals( false );
+
+    m_statsBoxButtonState = m_imv->statsBoxVisible();
+    m_ui.statsBoxButton->setText( m_statsBoxButtonState ? "Hide Stats Box" : "Show Stats Box" );
 
 #ifdef RTIMV_GRPC
     update_qualitySlider();

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -2065,6 +2065,11 @@ int rtimvMainWindow::statsDisplayMode() const
     return m_statsDisplayMode;
 }
 
+bool rtimvMainWindow::statsBoxVisible() const
+{
+    return m_statsBox != nullptr && m_statsBox->isVisible();
+}
+
 void rtimvMainWindow::statsBoxUpdated(
     int64_t i0, int64_t i1, int64_t j0, int64_t j1, float min, float max, float mean, float median, bool valid )
 {
@@ -2945,7 +2950,7 @@ void rtimvMainWindow::autoScale( bool as )
 
 void rtimvMainWindow::toggleAutoScale()
 {
-    if( m_autoScale )
+    if( RTIMV_BASE::autoScale() )
     {
         autoScale( false );
     }
@@ -3156,7 +3161,9 @@ void rtimvMainWindow::setDarkSub( bool ds )
 {
     subtractDark( ds );
 
-    if( subtractDark() )
+    // In gRPC mode the cached state updates on the next ImagePlease response, so
+    // the transient message needs to reflect the requested state immediately.
+    if( ds )
     {
         ui.graphicsView->zoomText( "dark sub. on" );
         mtxTry_fontLuminance( ui.graphicsView->zoomText() );
@@ -3170,21 +3177,14 @@ void rtimvMainWindow::setDarkSub( bool ds )
 
 void rtimvMainWindow::toggleDarkSub()
 {
-    if( m_subtractDark )
-    {
-        return setDarkSub( false );
-    }
-    else
-    {
-        return setDarkSub( true );
-    }
+    return setDarkSub( !subtractDark() );
 }
 
 void rtimvMainWindow::setApplyMask( bool am )
 {
     applyMask( am );
 
-    if( applyMask() )
+    if( am )
     {
         ui.graphicsView->zoomText( "mask on" );
         mtxTry_fontLuminance( ui.graphicsView->zoomText() );
@@ -3198,21 +3198,14 @@ void rtimvMainWindow::setApplyMask( bool am )
 
 void rtimvMainWindow::toggleApplyMask()
 {
-    if( m_applyMask )
-    {
-        return setApplyMask( false );
-    }
-    else
-    {
-        return setApplyMask( true );
-    }
+    return setApplyMask( !applyMask() );
 }
 
 void rtimvMainWindow::setApplySatMask( bool as )
 {
     applySatMask( as );
 
-    if( applySatMask() )
+    if( as )
     {
         ui.graphicsView->zoomText( "sat mask on" );
         mtxTry_fontLuminance( ui.graphicsView->zoomText() );
@@ -3306,7 +3299,7 @@ void rtimvMainWindow::toggleLogLinear()
 
 void rtimvMainWindow::toggleTarget()
 {
-    if( m_targetVisible )
+    if( targetVisible() )
     {
         targetVisible( false );
         ui.graphicsView->zoomText( "target off" );

--- a/src/gui/rtimvMainWindow.cpp
+++ b/src/gui/rtimvMainWindow.cpp
@@ -13,6 +13,124 @@
 #include <QMetaType>
 #include <QFontMetrics>
 
+namespace
+{
+
+/// Format an on/off state string.
+std::string onOffString( bool state )
+{
+    return state ? "on" : "off";
+}
+
+/// Get a display label for the current color mode.
+std::string colorModeString( rtimv::colormode mode )
+{
+    switch( mode )
+    {
+    case rtimv::colormode::minmaxglobal:
+        return "min/max global";
+    case rtimv::colormode::minmaxbox:
+        return "min/max box";
+    case rtimv::colormode::user:
+        return "user";
+    }
+
+    return "unknown";
+}
+
+/// Get a display label for the current stretch.
+std::string stretchString( rtimv::stretch stretch )
+{
+    switch( stretch )
+    {
+    case rtimv::stretch::linear:
+        return "linear";
+    case rtimv::stretch::log:
+        return "log";
+    case rtimv::stretch::pow:
+        return "power";
+    case rtimv::stretch::sqrt:
+        return "sqrt";
+    case rtimv::stretch::square:
+        return "square";
+    }
+
+    return "unknown";
+}
+
+/// Get a display label for the configured high-pass filter.
+std::string hpFilterString( rtimv::hpFilter filter )
+{
+    switch( filter )
+    {
+    case rtimv::hpFilter::none:
+        return "none";
+    case rtimv::hpFilter::gaussian:
+        return "gaussian";
+    case rtimv::hpFilter::median:
+        return "median";
+    case rtimv::hpFilter::mean:
+        return "mean";
+    case rtimv::hpFilter::fourier:
+        return "fourier";
+    case rtimv::hpFilter::radprof:
+        return "radprof";
+    }
+
+    return "unknown";
+}
+
+/// Get a display label for the configured low-pass filter.
+std::string lpFilterString( rtimv::lpFilter filter )
+{
+    switch( filter )
+    {
+    case rtimv::lpFilter::none:
+        return "none";
+    case rtimv::lpFilter::gaussian:
+        return "gaussian";
+    case rtimv::lpFilter::median:
+        return "median";
+    case rtimv::lpFilter::mean:
+        return "mean";
+    }
+
+    return "unknown";
+}
+
+/// Summarize the active filtering state for display.
+std::string filterStatusString( RTIMV_BASE *imv )
+{
+    std::ostringstream oss;
+    bool any = false;
+
+    if( imv->applyHPFilter() )
+    {
+        oss << "HP " << hpFilterString( imv->hpFilter() ) << " (fw=" << imv->hpfFW() << ")";
+        any = true;
+    }
+
+    if( imv->applyLPFilter() )
+    {
+        if( any )
+        {
+            oss << ", ";
+        }
+
+        oss << "LP " << lpFilterString( imv->lpFilter() ) << " (fw=" << imv->lpfFW() << ")";
+        any = true;
+    }
+
+    if( !any )
+    {
+        return "off";
+    }
+
+    return oss.str();
+}
+
+} // namespace
+
 rtimvMainWindow::rtimvMainWindow( int argc, char **argv, QWidget *Parent, Qt::WindowFlags f ) : QWidget( Parent, f )
 {
     qRegisterMetaType<uint32_t>( "uint32_t" );
@@ -3664,6 +3782,16 @@ std::string rtimvMainWindow::generateInfo()
     {
         info += "  satMask: \n";
     }
+
+    info += "\n";
+    info += "Display:\n";
+    info += "  darksub:   " + onOffString( subtractDark() ) + "\n";
+    info += "  mask:      " + onOffString( applyMask() ) + "\n";
+    info += "  sat-mask:  " + onOffString( applySatMask() ) + "\n";
+    info += "  filtering: " + filterStatusString( this ) + "\n";
+    info += "  color mode: " + colorModeString( colormode() ) + "\n";
+    info += "  stretch:   " + stretchString( stretch() ) + "\n";
+    info += "  color bar: " + std::string( rtimv::colorbarName( colorbar() ) ) + "\n";
 
     info += "\n";
     info += "Plugins:\n";

--- a/src/gui/rtimvMainWindow.hpp
+++ b/src/gui/rtimvMainWindow.hpp
@@ -629,6 +629,9 @@ class rtimvMainWindow : public QWidget, public RTIMV_BASE
     /// Get the active stats display mode.
     int statsDisplayMode() const;
 
+    /// Get whether the stats box widget is currently visible.
+    bool statsBoxVisible() const;
+
     /*---- user boxes ----*/
 
   protected:

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -20,8 +20,29 @@
 #include <QPointer>
 #include <QCoreApplication>
 
+#include <mx/ioutils/stringUtils.hpp>
+
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
 #define RTIMV_DEBUG_BREADCRUMB
+
+namespace
+{
+
+/// Parse a bool config target while preserving bare optional flags as true.
+bool configBoolOption( mx::app::appConfigurator &config, const std::string &name )
+{
+    std::string value;
+    config( value, name );
+
+    if( value.empty() )
+    {
+        return true;
+    }
+
+    return mx::ioutils::stoT<bool>( value );
+}
+
+} // namespace
 
 #define SHARED_CONN_LOCK_RET( rv )                                                                                     \
     sharedLockT connLock( m_connectedMutex );                                                                          \
@@ -261,22 +282,22 @@ void rtimvClientBase::setupConfig()
     config.add( "autoscale",
                 "",
                 "autoscale",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "autoscale",
                 false,
                 "bool",
-                "Set to turn autoscaling on at startup" );
+                "Set autoscaling at startup. Bare --autoscale is true; also accepts =true or =false." );
 
     config.add( "darksub",
                 "",
                 "darksub",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "darksub",
                 false,
                 "bool",
-                "Set to false to turn off dark subtraction at startup. "
+                "Set dark subtraction at startup. Bare --darksub is true; also accepts =true or =false. "
                 "If a dark is supplied, darksub is otherwise on." );
 
     config.add( "satLevel",
@@ -292,24 +313,24 @@ void rtimvClientBase::setupConfig()
     config.add( "masksat",
                 "",
                 "masksat",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "",
                 "masksat",
                 false,
                 "bool",
-                "Set to false to turn off sat-masking at startup. "
-                "If a satMaks is supplied, masksat is otherwise on." );
+                "Set sat-masking at startup. Bare --masksat is true; also accepts =true or =false. "
+                "If a saturation mask is supplied, masksat is otherwise on." );
 
     config.add( "mzmq.always",
                 "Z",
                 "mzmq.always",
-                mx::app::argType::True,
+                mx::app::argType::Optional,
                 "mzmq",
                 "always",
                 false,
                 "bool",
-                "Set to make milkzmq the protocol for bare image names.  Note that local shmims can"
-                "not be used if this is set." );
+                "Set whether milkzmq is the protocol for bare image names. Bare --mzmq.always is true; "
+                "also accepts =true or =false. Note that local shmims can not be used if this is set." );
 
     config.add( "mzmq.server",
                 "s",
@@ -554,16 +575,14 @@ void rtimvClientBase::loadConfig()
 
     if( config.isSet( "autoscale" ) )
     {
-        bool autoscale;
-        config( autoscale, "autoscale" );
+        bool autoscale = configBoolOption( config, "autoscale" );
         m_configReq->set_autoscale( autoscale );
         m_configReq->set_autoscale_set( true );
     }
 
     if( config.isSet( "darksub" ) )
     {
-        bool darksub;
-        config( darksub, "darksub" );
+        bool darksub = configBoolOption( config, "darksub" );
         m_configReq->set_darksub( darksub );
         m_configReq->set_darksub_set( true );
     }
@@ -578,8 +597,7 @@ void rtimvClientBase::loadConfig()
 
     if( config.isSet( "masksat" ) )
     {
-        bool masksat;
-        config( masksat, "masksat" );
+        bool masksat = configBoolOption( config, "masksat" );
         m_configReq->set_mask_sat( masksat );
         m_configReq->set_mask_sat_set( true );
     }
@@ -588,8 +606,7 @@ void rtimvClientBase::loadConfig()
 
     if( config.isSet( "mzmq.always" ) )
     {
-        bool mzmqalways;
-        config( mzmqalways, "mzmq.always" );
+        bool mzmqalways = configBoolOption( config, "mzmq.always" );
         m_configReq->set_mzmq_always( mzmqalways );
         m_configReq->set_mzmq_always_set( true );
     }

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -1208,18 +1208,12 @@ void rtimvServer::doConfigure( const configSpec *cspec )
 
     if( cspec->m_config.autoscale_set() )
     {
-        if( cspec->m_config.autoscale() )
-        {
-            argv->push_back( "--autoscale" );
-        }
+        argv->push_back( cspec->m_config.autoscale() ? "--autoscale" : "--autoscale=false" );
     }
 
     if( cspec->m_config.darksub_set() )
     {
-        if( cspec->m_config.darksub() )
-        {
-            argv->push_back( "--darksub" );
-        }
+        argv->push_back( cspec->m_config.darksub() ? "--darksub" : "--darksub=false" );
     }
 
     if( cspec->m_config.satlevel_set() )
@@ -1230,18 +1224,12 @@ void rtimvServer::doConfigure( const configSpec *cspec )
 
     if( cspec->m_config.mask_sat_set() )
     {
-        if( cspec->m_config.mask_sat() )
-        {
-            argv->push_back( "--masksat" );
-        }
+        argv->push_back( cspec->m_config.mask_sat() ? "--masksat" : "--masksat=false" );
     }
 
     if( cspec->m_config.mzmq_always_set() )
     {
-        if( cspec->m_config.mzmq_always() )
-        {
-            argv->push_back( "--mzmq.always" );
-        }
+        argv->push_back( cspec->m_config.mzmq_always() ? "--mzmq.always" : "--mzmq.always=false" );
     }
 
     if( cspec->m_config.mzmq_server() != "" )


### PR DESCRIPTION
This work was performed by Codex in response to the prompt: "rtimv is starting up with various shortcut toggles being out of sync, scrub all such toggles and make sure that they are synched with actual state in rtimv, rtimvServer, and rtimvClient; make startup bool options like --darksub=false and --autoscale=false work correctly; update the help/UserGuide; and add darksub, applyMask, satmask, filtering, color mode, and color bar status to the info display."

## Summary

This PR tightens state synchronization and startup configuration handling across `rtimv`, `rtimvClient`, and `rtimvServer`, and expands the info overlay to report the active display/calibration state.

### Included changes

- Fixed shortcut toggle reporting so dark subtraction, mask application, saturation masking, autoscale, and target visibility stay aligned with the actual backend/client state.
- Refreshed control-panel startup state so widget/button state reflects the real `rtimvMainWindow` state on initialization.
- Added `statsBoxVisible()` and used it for control-panel stats-box button state.
- Fixed startup bool parsing so these options support both bare and explicit forms:
  - `--autoscale`
  - `--darksub`
  - `--masksat`
  - `--mzmq.always`
- Preserved explicit `false` values through the gRPC client/server configure path instead of dropping them.
- Updated `--help` text and `doc/UserGuide.md` to document the supported bare / `=true` / `=false` startup bool forms.
- Expanded the info overlay to show:
  - dark subtraction
  - mask application
  - saturation masking
  - filtering state
  - color mode
  - stretch
  - color bar

## Verification

- Ran `clang-format` on touched files.
- Rebuilt:
  - `rtimv`
  - `rtimvClient`
  - `rtimvServer`
- Checked `QT_QPA_PLATFORM=offscreen ./build/rtimv --help`
- Checked `QT_QPA_PLATFORM=offscreen ./build/rtimvClient --help`

## Notes

- `log.appname` / `no-log-appname` remain a deliberate dual-option pattern rather than a single optional bool flag.

