### PR TITLE
Improve gRPC image pipeline, diagnostics, and shutdown handling

### DIFF
--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -110,205 +110,407 @@ rtimvBase::~rtimvBase()
     }
 }
 
+void rtimvBase::setupBaseConfig( mx::app::appConfigurator &configurator, bool includeShortOptions )
+{
+    const char *mzmqAlwaysShort = includeShortOptions ? "Z" : "";
+    const char *mzmqServerShort = includeShortOptions ? "s" : "";
+    const char *mzmqPortShort = includeShortOptions ? "p" : "";
+
+    configurator.add( "image.key",
+                      "",
+                      "image.key",
+                      mx::app::argType::Required,
+                      "image",
+                      "key",
+                      false,
+                      "string",
+                      "The main image key. Specifies the protocol, location, and name of the main image." );
+
+    configurator.add( "dark.key",
+                      "",
+                      "dark.key",
+                      mx::app::argType::Required,
+                      "dark",
+                      "key",
+                      false,
+                      "string",
+                      "The dark image key. Specifies the protocol, location, and name of the dark image." );
+
+    configurator.add( "mask.key",
+                      "",
+                      "mask.key",
+                      mx::app::argType::Required,
+                      "mask",
+                      "key",
+                      false,
+                      "string",
+                      "The mask image key. Specifies the protocol, location, and name of the mask image." );
+
+    configurator.add( "satMask.key",
+                      "",
+                      "satMask.key",
+                      mx::app::argType::Required,
+                      "satMask",
+                      "key",
+                      false,
+                      "string",
+                      "The saturation mask image key. Specifies the protocol, location, "
+                      "and name of the saturation mask image." );
+
+    configurator.add( "update.fps",
+                      "",
+                      "update.fps",
+                      mx::app::argType::Required,
+                      "update",
+                      "fps",
+                      false,
+                      "real",
+                      "Specify the image update timeout in FPS.  Overridden by update.timeout if set." );
+
+    configurator.add( "update.timeout",
+                      "",
+                      "update.timeout",
+                      mx::app::argType::Required,
+                      "update",
+                      "timeout",
+                      false,
+                      "real",
+                      "Specify the image update timeout in ms.  Default is 50 ms (20 FPS). Overrides update.fps." );
+
+    configurator.add( "update.cubeFPS",
+                      "",
+                      "update.cubeFPS",
+                      mx::app::argType::Required,
+                      "update",
+                      "cubeFPS",
+                      false,
+                      "real",
+                      "Specify the image cube update rate in FPS.  Default is 20 FPS." );
+
+    configurator.add(
+        "colorbar",
+        "",
+        "colorbar",
+        mx::app::argType::Required,
+        "",
+        "colorbar",
+        false,
+        "string",
+        "Set the startup colorbar. Valid values are grey, jet, hot, heat, bb, bone, red, green, and blue." );
+
+    configurator.add( "autoscale",
+                      "",
+                      "autoscale",
+                      mx::app::argType::Optional,
+                      "",
+                      "autoscale",
+                      false,
+                      "bool",
+                      "Set autoscaling at startup. Bare --autoscale is true; also accepts =true or =false." );
+
+    configurator.add( "darksub",
+                      "",
+                      "darksub",
+                      mx::app::argType::Optional,
+                      "",
+                      "darksub",
+                      false,
+                      "bool",
+                      "Set dark subtraction at startup. Bare --darksub is true; also accepts =true or =false. "
+                      "If a dark is supplied, darksub is otherwise on." );
+
+    configurator.add( "satLevel",
+                      "",
+                      "satLevel",
+                      mx::app::argType::Required,
+                      "",
+                      "satLevel",
+                      false,
+                      "float",
+                      "The saturation level for this camera" );
+
+    configurator.add( "masksat",
+                      "",
+                      "masksat",
+                      mx::app::argType::Optional,
+                      "",
+                      "masksat",
+                      false,
+                      "bool",
+                      "Set sat-masking at startup. Bare --masksat is true; also accepts =true or =false. "
+                      "If a saturation mask is supplied, masksat is otherwise on." );
+
+    configurator.add( "mzmq.always",
+                      mzmqAlwaysShort,
+                      "mzmq.always",
+                      mx::app::argType::Optional,
+                      "mzmq",
+                      "always",
+                      false,
+                      "bool",
+                      "Set whether milkzmq is the protocol for bare image names. Bare --mzmq.always is true; "
+                      "also accepts =true or =false. Note that local shmims can not be used if this is set." );
+
+    configurator.add( "mzmq.server",
+                      mzmqServerShort,
+                      "mzmq.server",
+                      mx::app::argType::Required,
+                      "mzmq",
+                      "server",
+                      false,
+                      "string",
+                      "The default server for milkzmq.  The default default is localhost.  This will be overridden "
+                      "by an image specific server specified in a key." );
+
+    configurator.add( "mzmq.port",
+                      mzmqPortShort,
+                      "mzmq.port",
+                      mx::app::argType::Required,
+                      "mzmq",
+                      "port",
+                      false,
+                      "int",
+                      "The default port for milkzmq.  The default default is 5556.  This will be overridden by an "
+                      "image specific port specified in a key." );
+
+    configurator.add( "log.appname",
+                      "",
+                      "log.appname",
+                      mx::app::argType::Required,
+                      "log",
+                      "appname",
+                      false,
+                      "bool",
+                      "Set true/false to include/exclude called-name in log prefixes." );
+
+    configurator.add( "no-log-appname",
+                      "",
+                      "no-log-appname",
+                      mx::app::argType::True,
+                      "log",
+                      "no-appname",
+                      false,
+                      "bool",
+                      "Disable called-name in log prefixes." );
+}
+
+void rtimvBase::loadBaseConfig( startupConfig &settings, mx::app::appConfigurator &configurator )
+{
+    settings = startupConfig{};
+
+    configurator( settings.m_imageKeys[0], "image.key" );
+    configurator( settings.m_imageKeys[1], "dark.key" );
+    configurator( settings.m_imageKeys[2], "mask.key" );
+    configurator( settings.m_imageKeys[3], "satMask.key" );
+
+    if( configurator.nonOptions.size() > 0 )
+    {
+        settings.m_imageKeys[0] = configurator.nonOptions[0];
+    }
+    if( configurator.nonOptions.size() > 1 )
+    {
+        settings.m_imageKeys[1] = configurator.nonOptions[1];
+    }
+    if( configurator.nonOptions.size() > 2 )
+    {
+        settings.m_imageKeys[2] = configurator.nonOptions[2];
+    }
+    if( configurator.nonOptions.size() > 3 )
+    {
+        settings.m_imageKeys[3] = configurator.nonOptions[3];
+    }
+
+    if( configurator.isSet( "mzmq.always" ) )
+    {
+        settings.m_mzmqAlways = configBoolOption( configurator, "mzmq.always" );
+        settings.m_mzmqAlwaysSet = true;
+    }
+
+    if( configurator.isSet( "mzmq.server" ) )
+    {
+        configurator( settings.m_mzmqServer, "mzmq.server" );
+        settings.m_mzmqServerSet = true;
+    }
+
+    if( configurator.isSet( "mzmq.port" ) )
+    {
+        configurator( settings.m_mzmqPort, "mzmq.port" );
+        settings.m_mzmqPortSet = true;
+    }
+
+    float fps = -999;
+    configurator( fps, "update.fps" );
+    if( fps > 0 )
+    {
+        settings.m_updateTimeout = std::round( 1000. / fps );
+        settings.m_updateTimeoutSet = true;
+    }
+
+    if( configurator.isSet( "update.timeout" ) )
+    {
+        configurator( settings.m_updateTimeout, "update.timeout" );
+        settings.m_updateTimeoutSet = true;
+    }
+
+    if( configurator.isSet( "update.cubeFPS" ) )
+    {
+        configurator( settings.m_updateCubeFPS, "update.cubeFPS" );
+        settings.m_updateCubeFPSSet = true;
+    }
+
+    if( configurator.isSet( "colorbar" ) )
+    {
+        configurator( settings.m_colorbarName, "colorbar" );
+        std::transform( settings.m_colorbarName.begin(),
+                        settings.m_colorbarName.end(),
+                        settings.m_colorbarName.begin(),
+                        []( unsigned char c ) { return static_cast<char>( std::tolower( c ) ); } );
+
+        rtimv::colorbar cb;
+        if( !rtimv::colorbarFromString( cb, settings.m_colorbarName ) )
+        {
+            throw std::runtime_error( "rtimv: invalid colorbar '" + settings.m_colorbarName + "'" );
+        }
+
+        settings.m_colorbarSet = true;
+    }
+
+    if( configurator.isSet( "autoscale" ) )
+    {
+        settings.m_autoscale = configBoolOption( configurator, "autoscale" );
+        settings.m_autoscaleSet = true;
+    }
+
+    if( configurator.isSet( "darksub" ) )
+    {
+        settings.m_darkSub = configBoolOption( configurator, "darksub" );
+        settings.m_darkSubSet = true;
+    }
+
+    if( configurator.isSet( "satLevel" ) )
+    {
+        configurator( settings.m_satLevel, "satLevel" );
+        settings.m_satLevelSet = true;
+    }
+
+    if( configurator.isSet( "masksat" ) )
+    {
+        settings.m_maskSat = configBoolOption( configurator, "masksat" );
+        settings.m_maskSatSet = true;
+    }
+
+    if( configurator.isSet( "log.appname" ) )
+    {
+        configurator( settings.m_logAppName, "log.appname" );
+        settings.m_logAppNameSet = true;
+    }
+
+    if( configurator.isSet( "no-log-appname" ) )
+    {
+        bool noLogAppName = false;
+        configurator( noLogAppName, "no-log-appname" );
+        if( noLogAppName )
+        {
+            settings.m_logAppName = false;
+            settings.m_logAppNameSet = true;
+        }
+    }
+}
+
+void rtimvBase::appendBaseConfigArgs( std::vector<std::string> &argv, const startupConfig &settings )
+{
+    auto appendOption = [&]( const std::string &name, const std::string &value )
+    {
+        argv.push_back( "--" + name );
+        argv.push_back( value );
+    };
+
+    if( !settings.m_imageKeys[0].empty() )
+    {
+        appendOption( "image.key", settings.m_imageKeys[0] );
+    }
+    if( !settings.m_imageKeys[1].empty() )
+    {
+        appendOption( "dark.key", settings.m_imageKeys[1] );
+    }
+    if( !settings.m_imageKeys[2].empty() )
+    {
+        appendOption( "mask.key", settings.m_imageKeys[2] );
+    }
+    if( !settings.m_imageKeys[3].empty() )
+    {
+        appendOption( "satMask.key", settings.m_imageKeys[3] );
+    }
+
+    if( settings.m_updateTimeoutSet )
+    {
+        appendOption( "update.timeout", std::to_string( settings.m_updateTimeout ) );
+    }
+
+    if( settings.m_updateCubeFPSSet )
+    {
+        appendOption( "update.cubeFPS", std::to_string( settings.m_updateCubeFPS ) );
+    }
+
+    if( settings.m_colorbarSet )
+    {
+        appendOption( "colorbar", settings.m_colorbarName );
+    }
+
+    if( settings.m_autoscaleSet )
+    {
+        argv.push_back( settings.m_autoscale ? "--autoscale" : "--autoscale=false" );
+    }
+
+    if( settings.m_darkSubSet )
+    {
+        argv.push_back( settings.m_darkSub ? "--darksub" : "--darksub=false" );
+    }
+
+    if( settings.m_satLevelSet )
+    {
+        appendOption( "satLevel", std::to_string( settings.m_satLevel ) );
+    }
+
+    if( settings.m_maskSatSet )
+    {
+        argv.push_back( settings.m_maskSat ? "--masksat" : "--masksat=false" );
+    }
+
+    if( settings.m_mzmqAlwaysSet )
+    {
+        argv.push_back( settings.m_mzmqAlways ? "--mzmq.always" : "--mzmq.always=false" );
+    }
+
+    if( settings.m_mzmqServerSet )
+    {
+        appendOption( "mzmq.server", settings.m_mzmqServer );
+    }
+
+    if( settings.m_mzmqPortSet )
+    {
+        appendOption( "mzmq.port", std::to_string( settings.m_mzmqPort ) );
+    }
+
+    if( settings.m_logAppNameSet )
+    {
+        appendOption( "log.appname", settings.m_logAppName ? "true" : "false" );
+    }
+}
+
 void rtimvBase::setupConfig()
 {
-    config.add( "image.key",
-                "",
-                "image.key",
-                mx::app::argType::Required,
-                "image",
-                "key",
-                false,
-                "string",
-                "The main image key. Specifies the protocol, location, and name of the main image." );
-
-    config.add( "dark.key",
-                "",
-                "dark.key",
-                mx::app::argType::Required,
-                "dark",
-                "key",
-                false,
-                "string",
-                "The dark image key. Specifies the protocol, location, and name of the dark image." );
-
-    config.add( "mask.key",
-                "",
-                "mask.key",
-                mx::app::argType::Required,
-                "mask",
-                "key",
-                false,
-                "string",
-                "The mask image key. Specifies the protocol, location, and name of the mask image." );
-
-    config.add( "satMask.key",
-                "",
-                "satMask.key",
-                mx::app::argType::Required,
-                "satMask",
-                "key",
-                false,
-                "string",
-                "The saturation mask image key. Specifies the protocol, location, "
-                "and name of the saturation mask image." );
-
-    config.add( "update.fps",
-                "",
-                "update.fps",
-                mx::app::argType::Required,
-                "update",
-                "fps",
-                false,
-                "real",
-                "Specify the image update timeout in FPS.  Overridden by update.timeout if set." );
-
-    config.add( "update.timeout",
-                "",
-                "update.timeout",
-                mx::app::argType::Required,
-                "update",
-                "timeout",
-                false,
-                "real",
-                "Specify the image update timeout in ms.  Default is 50 ms (20 FPS). Overrides update.fps." );
-
-    config.add( "update.cubeFPS",
-                "",
-                "update.cubeFPS",
-                mx::app::argType::Required,
-                "update",
-                "cubeFPS",
-                false,
-                "real",
-                "Specify the image cube update rate in FPS.  Default is 20 FPS." );
-
-    config.add( "colorbar",
-                "",
-                "colorbar",
-                mx::app::argType::Required,
-                "",
-                "colorbar",
-                false,
-                "string",
-                "Set the startup colorbar. Valid values are grey, jet, hot, heat, bb, bone, red, green, and blue." );
-
-    config.add( "autoscale",
-                "",
-                "autoscale",
-                mx::app::argType::Optional,
-                "",
-                "autoscale",
-                false,
-                "bool",
-                "Set autoscaling at startup. Bare --autoscale is true; also accepts =true or =false." );
-
-    config.add( "darksub",
-                "",
-                "darksub",
-                mx::app::argType::Optional,
-                "",
-                "darksub",
-                false,
-                "bool",
-                "Set dark subtraction at startup. Bare --darksub is true; also accepts =true or =false. "
-                "If a dark is supplied, darksub is otherwise on." );
-
-    config.add( "satLevel",
-                "",
-                "satLevel",
-                mx::app::argType::Required,
-                "",
-                "satLevel",
-                false,
-                "float",
-                "The saturation level for this camera" );
-
-    config.add( "masksat",
-                "",
-                "masksat",
-                mx::app::argType::Optional,
-                "",
-                "masksat",
-                false,
-                "bool",
-                "Set sat-masking at startup. Bare --masksat is true; also accepts =true or =false. "
-                "If a saturation mask is supplied, masksat is otherwise on." );
-
-    config.add( "mzmq.always",
-                "Z",
-                "mzmq.always",
-                mx::app::argType::Optional,
-                "mzmq",
-                "always",
-                false,
-                "bool",
-                "Set whether milkzmq is the protocol for bare image names. Bare --mzmq.always is true; "
-                "also accepts =true or =false. Note that local shmims can not be used if this is set." );
-
-    config.add( "mzmq.server",
-                "s",
-                "mzmq.server",
-                mx::app::argType::Required,
-                "mzmq",
-                "server",
-                false,
-                "string",
-                "The default server for milkzmq.  The default default is localhost.  This will be overridden by an "
-                "image specific server specified in a key." );
-
-    config.add( "mzmq.port",
-                "p",
-                "mzmq.port",
-                mx::app::argType::Required,
-                "mzmq",
-                "port",
-                false,
-                "int",
-                "The default port for milkzmq.  The default default is 5556.  This will be overridden by an image "
-                "specific port specified in a key." );
-
-    config.add( "log.appname",
-                "",
-                "log.appname",
-                mx::app::argType::Required,
-                "log",
-                "appname",
-                false,
-                "bool",
-                "Set true/false to include/exclude called-name in log prefixes." );
-
-    config.add( "no-log-appname",
-                "",
-                "no-log-appname",
-                mx::app::argType::True,
-                "log",
-                "no-appname",
-                false,
-                "bool",
-                "Disable called-name in log prefixes." );
+    setupBaseConfig( config );
 }
 
 void rtimvBase::loadConfig()
 {
-    std::string imKey;
-    std::string darkKey;
+    startupConfig settings;
+    loadBaseConfig( settings, config );
 
-    std::string flatKey;
-
-    std::string maskKey;
-
-    std::string satMaskKey;
-
-    std::vector<std::string> keys;
-
-    // Set up milkzmq
-    if( config.isSet( "mzmq.always" ) )
-    {
-        m_mzmqAlways = configBoolOption( config, "mzmq.always" );
-    }
-    config( m_mzmqServer, "mzmq.server" );
-    config( m_mzmqPort, "mzmq.port" );
+    m_mzmqAlways = settings.m_mzmqAlwaysSet ? settings.m_mzmqAlways : false;
+    m_mzmqServer = settings.m_mzmqServer;
+    m_mzmqPort = settings.m_mzmqPort;
 
     m_calledName = QCoreApplication::applicationName().toStdString();
     if( m_calledName.empty() )
@@ -316,55 +518,14 @@ void rtimvBase::loadConfig()
         m_calledName = "rtimv";
     }
 
-    if( config.isSet( "log.appname" ) )
+    if( settings.m_logAppNameSet )
     {
-        config( m_logAppName, "log.appname" );
+        m_logAppName = settings.m_logAppName;
     }
 
-    if( config.isSet( "no-log-appname" ) )
-    {
-        bool noLogAppName = false;
-        config( noLogAppName, "no-log-appname" );
-        if( noLogAppName )
-        {
-            m_logAppName = false;
-        }
-    }
+    m_imageNames = settings.m_imageKeys;
 
-    // Check for use of deprecated shmim_name keyword by itself, but use key if available
-    config( imKey, "image.key" );
-
-    config( darkKey, "dark.key" );
-
-    config( maskKey, "mask.key" );
-
-    config( satMaskKey, "satMask.key" );
-
-    // Populate the key vector, a "" means no image specified
-    keys.resize( 4 );
-
-    if( imKey != "" )
-        keys[0] = imKey;
-    if( darkKey != "" )
-        keys[1] = darkKey;
-    if( maskKey != "" )
-        keys[2] = maskKey;
-    if( satMaskKey != "" )
-        keys[3] = satMaskKey;
-
-    // The command line always overrides the config
-    if( config.nonOptions.size() > 0 )
-        keys[0] = config.nonOptions[0];
-    if( config.nonOptions.size() > 1 )
-        keys[1] = config.nonOptions[1];
-    if( config.nonOptions.size() > 2 )
-        keys[2] = config.nonOptions[2];
-    if( config.nonOptions.size() > 3 )
-        keys[3] = config.nonOptions[3];
-
-    m_imageNames = keys;
-
-    processKeys( keys );
+    processKeys( settings.m_imageKeys );
 
     if( m_images[0] == nullptr )
     {
@@ -381,63 +542,55 @@ void rtimvBase::loadConfig()
         }
     }
 
-    // Now load remaining options, respecting coded defaults.
-
-    // get timeouts.
-    float fps = -999;
-    config( fps, "update.fps" );
-
-    if( fps > 0 ) // fps sets m_imageTimeout
+    if( settings.m_updateTimeoutSet )
     {
-        m_imageTimeout = std::round( 1000. / fps );
+        m_imageTimeout = settings.m_updateTimeout;
     }
 
-    // but update.timeout can override it
-    config( m_imageTimeout, "update.timeout" );
-    config( m_cubeFPS, "update.cubeFPS" );
+    if( settings.m_updateCubeFPSSet )
+    {
+        m_cubeFPS = settings.m_updateCubeFPS;
+    }
 
     // Now set the actual timeouts
     cubeFPS( m_cubeFPS );
 
-    std::string colorbarName;
-    config( colorbarName, "colorbar" );
-    if( colorbarName != "" )
+    if( settings.m_colorbarSet )
     {
-        std::transform( colorbarName.begin(),
-                        colorbarName.end(),
-                        colorbarName.begin(),
-                        []( unsigned char c ) { return static_cast<char>( std::tolower( c ) ); } );
-
-        if( !rtimv::colorbarFromString( m_colorbar, colorbarName ) )
+        if( !rtimv::colorbarFromString( m_colorbar, settings.m_colorbarName ) )
         {
-            throw std::runtime_error( "rtimv: invalid colorbar '" + colorbarName + "'" );
+            throw std::runtime_error( "rtimv: invalid colorbar '" + settings.m_colorbarName + "'" );
         }
     }
 
-    if( config.isSet( "autoscale" ) )
+    if( settings.m_autoscaleSet )
     {
-        m_autoScale = configBoolOption( config, "autoscale" );
+        m_autoScale = settings.m_autoscale;
     }
-    m_subtractDarkSet = config.isSet( "darksub" );
+
+    m_subtractDarkSet = settings.m_darkSubSet;
     if( m_subtractDarkSet )
     {
-        m_subtractDark = configBoolOption( config, "darksub" );
+        m_subtractDark = settings.m_darkSub;
     }
 
     float satLevelDefault = m_satLevel;
-    config( m_satLevel, "satLevel" );
+    if( settings.m_satLevelSet )
+    {
+        m_satLevel = settings.m_satLevel;
+    }
 
     // If we set a sat level or mask, apply it
-    if( m_satLevel != satLevelDefault || satMaskKey != "" )
+    if( m_satLevel != satLevelDefault || !settings.m_imageKeys[3].empty() )
     {
         m_applySatMask = true;
     }
 
     // except turn it off if requested
-    m_applySatMaskSet = config.isSet( "masksat" );
+    m_applySatMaskSet = settings.m_maskSatSet;
     if( m_applySatMaskSet )
     {
-        m_applySatMask = configBoolOption( config, "masksat" );
+        m_applySatMask = settings.m_maskSat;
     }
 }
 

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -25,6 +25,7 @@
 #include <mx/ioutils/stringUtils.hpp>
 #include <mx/math/vectorUtils.hpp>
 #include <QCoreApplication>
+#include <QThread>
 
 // #define RTIMV_DEBUG_BREADCRUMB std::cerr << __FILE__ << " " << __LINE__ << "\n";
 #define RTIMV_DEBUG_BREADCRUMB
@@ -55,6 +56,18 @@ rtimvBase::rtimvBase()
 
 rtimvBase::~rtimvBase()
 {
+    if( m_foundation )
+    {
+        if( m_foundation->thread() == QThread::currentThread() )
+        {
+            m_foundation->shutdown();
+        }
+        else
+        {
+            QMetaObject::invokeMethod( m_foundation, "shutdown", Qt::BlockingQueuedConnection );
+        }
+    }
+
     if( m_calDataRaw != nullptr )
     {
         delete[] m_calDataRaw;
@@ -84,7 +97,16 @@ rtimvBase::~rtimvBase()
 
     if( m_foundation )
     {
-        m_foundation->deleteLater();
+        if( m_foundation->thread() == QThread::currentThread() )
+        {
+            delete m_foundation;
+        }
+        else
+        {
+            m_foundation->deleteLater();
+        }
+
+        m_foundation = nullptr;
     }
 }
 

--- a/src/common/rtimvBase.cpp
+++ b/src/common/rtimvBase.cpp
@@ -830,6 +830,11 @@ int rtimvBase::imageTimeout()
     return m_imageTimeout;
 }
 
+int rtimvBase::currImageTimeout()
+{
+    return m_currImageTimeout;
+}
+
 void rtimvBase::cubeMode( bool cm )
 {
     m_cubeMode = cm;

--- a/src/common/rtimvBase.hpp
+++ b/src/common/rtimvBase.hpp
@@ -83,6 +83,95 @@ class rtimvBase : public mx::app::application
      *  The mx::app::application interface for command line and config files.
      * @{
      */
+    /// Shared startup settings parsed from an appConfigurator for rtimvBase-compatible options.
+    struct startupConfig
+    {
+        /// Configured image keys by image slot, after applying any non-option overrides.
+        std::vector<std::string> m_imageKeys{ std::vector<std::string>( 4 ) };
+
+        /// True when the image update timeout was explicitly configured, directly or via update.fps.
+        bool m_updateTimeoutSet{ false };
+
+        /// Explicit image update timeout in ms, after resolving update.fps and update.timeout precedence.
+        int m_updateTimeout{ 50 };
+
+        /// True when the cube playback FPS was explicitly configured.
+        bool m_updateCubeFPSSet{ false };
+
+        /// Explicit cube playback FPS.
+        float m_updateCubeFPS{ 20 };
+
+        /// True when the startup colorbar was explicitly configured.
+        bool m_colorbarSet{ false };
+
+        /// Lower-cased startup colorbar name when explicitly configured.
+        std::string m_colorbarName;
+
+        /// True when autoscale was explicitly configured.
+        bool m_autoscaleSet{ false };
+
+        /// Explicit autoscale startup state.
+        bool m_autoscale{ false };
+
+        /// True when dark subtraction was explicitly configured.
+        bool m_darkSubSet{ false };
+
+        /// Explicit dark subtraction startup state.
+        bool m_darkSub{ false };
+
+        /// True when the saturation level was explicitly configured.
+        bool m_satLevelSet{ false };
+
+        /// Explicit saturation level.
+        float m_satLevel{ 0 };
+
+        /// True when saturation masking was explicitly configured.
+        bool m_maskSatSet{ false };
+
+        /// Explicit saturation masking startup state.
+        bool m_maskSat{ false };
+
+        /// True when milkzmq-always behavior was explicitly configured.
+        bool m_mzmqAlwaysSet{ false };
+
+        /// Explicit milkzmq-always startup state.
+        bool m_mzmqAlways{ false };
+
+        /// True when the default milkzmq server was explicitly configured.
+        bool m_mzmqServerSet{ false };
+
+        /// Explicit default milkzmq server.
+        std::string m_mzmqServer;
+
+        /// True when the default milkzmq port was explicitly configured.
+        bool m_mzmqPortSet{ false };
+
+        /// Explicit default milkzmq port.
+        int m_mzmqPort{ 0 };
+
+        /// True when called-name logging was explicitly configured.
+        bool m_logAppNameSet{ false };
+
+        /// Explicit called-name logging startup state.
+        bool m_logAppName{ true };
+    };
+
+    /// Register the shared rtimvBase startup config options on a configurator.
+    static void
+    setupBaseConfig( mx::app::appConfigurator &configurator, /**< [in] configurator to register options on */
+                     bool includeShortOptions = true         /**< [in] true to register legacy short options */
+    );
+
+    /// Load shared rtimvBase startup config values from a configurator.
+    static void loadBaseConfig( startupConfig &settings,               /**< [out] loaded shared startup settings */
+                                mx::app::appConfigurator &configurator /**< [in] configurator to read from */
+    );
+
+    /// Append explicit shared startup settings as long-form command-line arguments.
+    static void appendBaseConfigArgs( std::vector<std::string> &argv, /**< [out] argument vector to append to */
+                                      const startupConfig &settings   /**< [in] shared startup settings to serialize */
+    );
+
     virtual void setupConfig();
 
     virtual void loadConfig();

--- a/src/common/rtimvBaseObject.cpp
+++ b/src/common/rtimvBaseObject.cpp
@@ -35,6 +35,18 @@ rtimvBaseObject::rtimvBaseObject( RTIMV_BASE *parent, QObject *QParent ) : QObje
     // clang-format on
 }
 
+void rtimvBaseObject::shutdown()
+{
+    m_parent = nullptr;
+
+    m_imageTimer.stop();
+    m_cubeTimer.stop();
+    m_cubeFrameUpdateTimer.stop();
+    m_connectionTimer.stop();
+
+    disconnect();
+}
+
 void rtimvBaseObject::emit_nzUpdated( uint32_t n )
 {
     emit nzUpdated( n );
@@ -210,6 +222,19 @@ void rtimvBaseObject::reconnect()
 
     m_parent->reconnect();
 
+    #endif
+    // clang-format on
+}
+
+void rtimvBaseObject::scheduleImagePlease( int delayMs )
+{
+    // clang-format off
+    #ifdef RTIMV_GRPC
+
+    QTimer::singleShot( delayMs, this, SLOT( ImagePlease() ) );
+
+    #else
+    static_cast<void>( delayMs );
     #endif
     // clang-format on
 }

--- a/src/common/rtimvBaseObject.hpp
+++ b/src/common/rtimvBaseObject.hpp
@@ -19,6 +19,7 @@ struct rtimvBaseObject : public QObject
     Q_OBJECT
 
   private:
+    /// Raw back-pointer to the owning base/client object used by queued Qt slots.
     RTIMV_BASE *m_parent{ nullptr };
 
   public:
@@ -32,7 +33,11 @@ struct rtimvBaseObject : public QObject
 
     rtimvBaseObject() = delete;
 
+    /// Construct the Qt helper object that forwards timer and signal activity to the owning base object.
     rtimvBaseObject( RTIMV_BASE *parent, QObject *QParent );
+
+    /// Detach from the owning base object and stop all internal timers/connections for shutdown.
+    Q_INVOKABLE void shutdown();
 
     /// Update the number of images in the cube
     void emit_nzUpdated( uint32_t n /**< [in] the current number of images in the cube */ );
@@ -180,6 +185,9 @@ struct rtimvBaseObject : public QObject
   public slots:
 
     void reconnect();
+
+    /// Schedule a delayed ImagePlease call on the foundation object's Qt thread.
+    void scheduleImagePlease( int delayMs /**< [in] delay before requesting the next image, ms */ );
 
     void ImagePlease();
 

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -82,6 +82,10 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
     m_ui.avgCompressionRatioEntry->setVisible( true );
     m_ui.avgFrameRateLabel->setVisible( true );
     m_ui.avgFrameRateEntry->setVisible( true );
+    m_ui.lastRttLabel->setVisible( true );
+    m_ui.lastRttEntry->setVisible( true );
+    m_ui.avgRttLabel->setVisible( true );
+    m_ui.avgRttEntry->setVisible( true );
 #else
     m_ui.qualityLabel->setVisible( false );
     m_ui.qualitySlider->setVisible( false );
@@ -92,6 +96,10 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
     m_ui.avgCompressionRatioEntry->setVisible( false );
     m_ui.avgFrameRateLabel->setVisible( false );
     m_ui.avgFrameRateEntry->setVisible( false );
+    m_ui.lastRttLabel->setVisible( false );
+    m_ui.lastRttEntry->setVisible( false );
+    m_ui.avgRttLabel->setVisible( false );
+    m_ui.avgRttEntry->setVisible( false );
 #endif
 
     init_panel();
@@ -816,6 +824,8 @@ void rtimvControlPanel::update_transportStats()
     m_ui.lastCompressionRatioEntry->setText( QString::number( m_imv->lastCompressionRatio(), 'f', 1 ) + ":1" );
     m_ui.avgCompressionRatioEntry->setText( QString::number( m_imv->avgCompressionRatio(), 'f', 1 ) + ":1" );
     m_ui.avgFrameRateEntry->setText( QString::number( m_imv->avgFrameRate(), 'f', 1 ) );
+    m_ui.lastRttEntry->setText( QString::number( m_imv->lastRttMs(), 'f', 1 ) + " ms" );
+    m_ui.avgRttEntry->setText( QString::number( m_imv->avgRttMs(), 'f', 1 ) + " ms" );
 #endif
 }
 

--- a/src/gui/rtimvControlPanel.cpp
+++ b/src/gui/rtimvControlPanel.cpp
@@ -73,31 +73,27 @@ rtimvControlPanel::rtimvControlPanel( rtimvMainWindow *v, Qt::WindowFlags f ) : 
     connect( this, SIGNAL( targetVisible( bool ) ), m_imv, SLOT( targetVisible( bool ) ) );
 
 #ifdef RTIMV_GRPC
+    m_ui.imageWindowLabel->setVisible( true );
+    m_ui.imageWindowSpinBox->setVisible( true );
     m_ui.qualityLabel->setVisible( true );
     m_ui.qualitySlider->setVisible( true );
     m_ui.qualityEntry->setVisible( true );
-    m_ui.lastCompressionRatioLabel->setVisible( true );
-    m_ui.lastCompressionRatioEntry->setVisible( true );
     m_ui.avgCompressionRatioLabel->setVisible( true );
     m_ui.avgCompressionRatioEntry->setVisible( true );
     m_ui.avgFrameRateLabel->setVisible( true );
     m_ui.avgFrameRateEntry->setVisible( true );
-    m_ui.lastRttLabel->setVisible( true );
-    m_ui.lastRttEntry->setVisible( true );
     m_ui.avgRttLabel->setVisible( true );
     m_ui.avgRttEntry->setVisible( true );
 #else
+    m_ui.imageWindowLabel->setVisible( false );
+    m_ui.imageWindowSpinBox->setVisible( false );
     m_ui.qualityLabel->setVisible( false );
     m_ui.qualitySlider->setVisible( false );
     m_ui.qualityEntry->setVisible( false );
-    m_ui.lastCompressionRatioLabel->setVisible( false );
-    m_ui.lastCompressionRatioEntry->setVisible( false );
     m_ui.avgCompressionRatioLabel->setVisible( false );
     m_ui.avgCompressionRatioEntry->setVisible( false );
     m_ui.avgFrameRateLabel->setVisible( false );
     m_ui.avgFrameRateEntry->setVisible( false );
-    m_ui.lastRttLabel->setVisible( false );
-    m_ui.lastRttEntry->setVisible( false );
     m_ui.avgRttLabel->setVisible( false );
     m_ui.avgRttEntry->setVisible( false );
 #endif
@@ -169,6 +165,7 @@ void rtimvControlPanel::init_panel()
     targetVisibleChanged( m_imv->targetVisible() );
 
 #ifdef RTIMV_GRPC
+    update_imageRequestWindow();
     update_qualitySlider();
     update_qualityEntry();
     update_transportStats();
@@ -222,6 +219,7 @@ void rtimvControlPanel::update_panel()
     m_ui.statsBoxButton->setText( m_statsBoxButtonState ? "Hide Stats Box" : "Show Stats Box" );
 
 #ifdef RTIMV_GRPC
+    update_imageRequestWindow();
     update_qualitySlider();
     update_qualityEntry();
     update_transportStats();
@@ -818,13 +816,20 @@ void rtimvControlPanel::update_qualityEntry()
 #endif
 }
 
+void rtimvControlPanel::update_imageRequestWindow()
+{
+#ifdef RTIMV_GRPC
+    m_ui.imageWindowSpinBox->blockSignals( true );
+    m_ui.imageWindowSpinBox->setValue( m_imv->imageRequestWindow() );
+    m_ui.imageWindowSpinBox->blockSignals( false );
+#endif
+}
+
 void rtimvControlPanel::update_transportStats()
 {
 #ifdef RTIMV_GRPC
-    m_ui.lastCompressionRatioEntry->setText( QString::number( m_imv->lastCompressionRatio(), 'f', 1 ) + ":1" );
     m_ui.avgCompressionRatioEntry->setText( QString::number( m_imv->avgCompressionRatio(), 'f', 1 ) + ":1" );
     m_ui.avgFrameRateEntry->setText( QString::number( m_imv->avgFrameRate(), 'f', 1 ) );
-    m_ui.lastRttEntry->setText( QString::number( m_imv->lastRttMs(), 'f', 1 ) + " ms" );
     m_ui.avgRttEntry->setText( QString::number( m_imv->avgRttMs(), 'f', 1 ) + " ms" );
 #endif
 }
@@ -1082,6 +1087,15 @@ void rtimvControlPanel::on_qualityEntry_editingFinished()
     m_imv->showQualityMessage( q );
     update_qualitySlider();
     update_qualityEntry();
+#endif
+}
+
+void rtimvControlPanel::on_imageWindowSpinBox_valueChanged( int value )
+{
+#ifdef RTIMV_GRPC
+    m_imv->imageRequestWindow( value );
+#else
+    static_cast<void>( value );
 #endif
 }
 

--- a/src/gui/rtimvControlPanel.hpp
+++ b/src/gui/rtimvControlPanel.hpp
@@ -263,6 +263,9 @@ class rtimvControlPanel : public QWidget
     /// Synchronize JPEG quality entry from model state.
     void update_qualityEntry();
 
+    /// Synchronize the ImagePlease request-window control from model state.
+    void update_imageRequestWindow();
+
     /// Synchronize the displayed transport statistics from model state.
     void update_transportStats();
 
@@ -341,6 +344,9 @@ class rtimvControlPanel : public QWidget
 
     /// Handle JPEG quality entry edits.
     void on_qualityEntry_editingFinished();
+
+    /// Handle ImagePlease request-window changes.
+    void on_imageWindowSpinBox_valueChanged( int value /**< [in] new in-flight request window*/ );
 
     /// Toggle stats box visibility.
     void on_statsBoxButton_clicked();

--- a/src/gui/rtimvControlPanel.ui
+++ b/src/gui/rtimvControlPanel.ui
@@ -1886,6 +1886,64 @@
       <bool>true</bool>
      </property>
     </widget>
+    <widget class="QLabel" name="lastRttLabel">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>220</y>
+       <width>171</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Last RTT</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lastRttEntry">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>240</y>
+       <width>171</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QLabel" name="avgRttLabel">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>280</y>
+       <width>171</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Avg RTT</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="avgRttEntry">
+     <property name="geometry">
+      <rect>
+       <x>500</x>
+       <y>300</y>
+       <width>171</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabFilters">
     <attribute name="title">

--- a/src/gui/rtimvControlPanel.ui
+++ b/src/gui/rtimvControlPanel.ui
@@ -1799,7 +1799,7 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="lastCompressionRatioLabel">
+    <widget class="QLabel" name="avgCompressionRatioLabel">
      <property name="geometry">
       <rect>
        <x>500</x>
@@ -1809,10 +1809,10 @@
       </rect>
      </property>
      <property name="text">
-      <string>Last Compression</string>
+      <string>Avg Compression</string>
      </property>
     </widget>
-    <widget class="QLineEdit" name="lastCompressionRatioEntry">
+    <widget class="QLineEdit" name="avgCompressionRatioEntry">
      <property name="geometry">
       <rect>
        <x>500</x>
@@ -1828,7 +1828,7 @@
       <bool>true</bool>
      </property>
     </widget>
-    <widget class="QLabel" name="avgCompressionRatioLabel">
+    <widget class="QLabel" name="avgFrameRateLabel">
      <property name="geometry">
       <rect>
        <x>500</x>
@@ -1838,10 +1838,10 @@
       </rect>
      </property>
      <property name="text">
-      <string>Avg Compression</string>
+      <string>Avg Arrival Rate</string>
      </property>
     </widget>
-    <widget class="QLineEdit" name="avgCompressionRatioEntry">
+    <widget class="QLineEdit" name="avgFrameRateEntry">
      <property name="geometry">
       <rect>
        <x>500</x>
@@ -1857,69 +1857,11 @@
       <bool>true</bool>
      </property>
     </widget>
-    <widget class="QLabel" name="avgFrameRateLabel">
-     <property name="geometry">
-      <rect>
-       <x>500</x>
-       <y>160</y>
-       <width>171</width>
-       <height>16</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Avg Arrival Rate</string>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="avgFrameRateEntry">
-     <property name="geometry">
-      <rect>
-       <x>500</x>
-       <y>180</y>
-       <width>171</width>
-       <height>25</height>
-      </rect>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QLabel" name="lastRttLabel">
-     <property name="geometry">
-      <rect>
-       <x>500</x>
-       <y>220</y>
-       <width>171</width>
-       <height>16</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Last RTT</string>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="lastRttEntry">
-     <property name="geometry">
-      <rect>
-       <x>500</x>
-       <y>240</y>
-       <width>171</width>
-       <height>25</height>
-      </rect>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
     <widget class="QLabel" name="avgRttLabel">
      <property name="geometry">
       <rect>
        <x>500</x>
-       <y>280</y>
+       <y>160</y>
        <width>171</width>
        <height>16</height>
       </rect>
@@ -1932,7 +1874,7 @@
      <property name="geometry">
       <rect>
        <x>500</x>
-       <y>300</y>
+       <y>180</y>
        <width>171</width>
        <height>25</height>
       </rect>
@@ -2216,6 +2158,41 @@
      </property>
      <property name="text">
       <string>Image get timeout</string>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="imageWindowSpinBox">
+     <property name="geometry">
+      <rect>
+       <x>490</x>
+       <y>40</y>
+       <width>121</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>128</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="imageWindowLabel">
+     <property name="geometry">
+      <rect>
+       <x>340</x>
+       <y>42</y>
+       <width>141</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Image request window</string>
      </property>
     </widget>
     <widget class="QPushButton" name="statsBoxButton">

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -42,6 +42,8 @@ service rtimv
 
     rpc SetApplyLPFilter(ApplyFilterRequest) returns (ApplyFilterResponse);
 
+    rpc Ping(PingRequest) returns (PingResponse);
+
     rpc ImagePlease(ImageRequest) returns (Image);
 
     rpc CubeDir(CubeDirRequest) returns (CubeDirResponse);
@@ -196,6 +198,14 @@ message ImageTimeoutRequest
 }
 
 message ImageTimeoutResponse
+{
+}
+
+message PingRequest
+{
+}
+
+message PingResponse
 {
 }
 

--- a/src/proto/rtimv.proto
+++ b/src/proto/rtimv.proto
@@ -369,6 +369,7 @@ enum ImageStatus
 message Image
 {
     ImageStatus status = 1;
+    uint64 response_serial = 2;
 
     uint32 nx = 10; // x-size of source image
     uint32 ny = 11; // y-size of source image

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -1258,7 +1258,13 @@ void rtimvClientBase::ImageReceived()
     m_colorBox_j1 = colorBox_j1;
     m_colorBox_min = colorBox_min;
     m_colorBox_max = colorBox_max;
-    m_imageTimeout = imageTimeout;
+    bool imageTimeoutChanged = false;
+    if( m_imageTimeout != imageTimeout )
+    {
+        m_imageTimeout = imageTimeout;
+        imageTimeoutChanged = true;
+    }
+
     m_quality = quality;
     if( m_cubeDir != cubeDir )
     {
@@ -1296,6 +1302,11 @@ void rtimvClientBase::ImageReceived()
     {
         // Always switch to zoom 1 after a resize occurs
         zoomLevel( 1 );
+    }
+
+    if( imageTimeoutChanged )
+    {
+        setCurrImageTimeout();
     }
 
     updateFPS();
@@ -2109,6 +2120,7 @@ void rtimvClientBase::updateCubeFrame()
 void rtimvClientBase::setCurrImageTimeout()
 {
     int cubeTimeout;
+    int currImageTimeout;
 
     if( m_desiredCubeFPS <= 0 || m_nz <= 1 )
     {
@@ -2126,6 +2138,8 @@ void rtimvClientBase::setCurrImageTimeout()
         m_cubeFPS = 0;
 
         m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
+
+        currImageTimeout = m_imageTimeout;
     }
     else // it's a cube, cube mode is on, and FPS > 0
     {
@@ -2137,23 +2151,28 @@ void rtimvClientBase::setCurrImageTimeout()
             cubeTimeout = 1;
         }
 
-        if( cubeTimeout < m_imageTimeout )
+        if( cubeTimeout <= m_imageTimeout )
         {
-            cubeTimeout = m_imageTimeout;
+            // Report reality
+            m_cubeFPS = ( 1000.0 / cubeTimeout ) / m_cubeFPSMult;
+            currImageTimeout = cubeTimeout;
         }
-
-        // Now get reality with imageTimeout
-        int f = std::round( ( 1.0 * cubeTimeout ) / m_imageTimeout );
-        if( f <= 0 )
+        else
         {
-            f = 1;
+            // Now get reality with imageTimeout
+            int f = std::round( ( 1.0 * cubeTimeout ) / m_imageTimeout );
+            if( f <= 0 )
+            {
+                f = 1;
+            }
+
+            // Report reality
+            m_cubeFPS = ( 1000.0 / ( f * m_imageTimeout ) ) / m_cubeFPSMult;
+
+            // Implement reality
+            cubeTimeout = std::round( 1000. / ( m_cubeFPS * m_cubeFPSMult ) );
+            currImageTimeout = m_imageTimeout;
         }
-
-        // Report reality
-        m_cubeFPS = ( 1000.0 / ( f * m_imageTimeout ) ) / m_cubeFPSMult;
-
-        // Implement reality
-        cubeTimeout = std::round( 1000. / ( m_cubeFPS * m_cubeFPSMult ) );
 
         if( m_cubeMode )
         {
@@ -2168,6 +2187,8 @@ void rtimvClientBase::setCurrImageTimeout()
 
         m_foundation->emit_cubeFPSUpdated( m_cubeFPS, m_desiredCubeFPS );
     }
+
+    m_currImageTimeout = currImageTimeout;
 }
 
 void rtimvClientBase::updateRollingTransportStats(
@@ -2268,6 +2289,11 @@ void rtimvClientBase::imageTimeout( int to )
 int rtimvClientBase::imageTimeout()
 {
     return m_imageTimeout;
+}
+
+int rtimvClientBase::currImageTimeout()
+{
+    return m_currImageTimeout;
 }
 
 void rtimvClientBase::quality( int q )

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -79,15 +79,19 @@ rtimvClientBase::~rtimvClientBase()
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
         m_shuttingDown = true;
 
-        if( m_ImagePleaseContext )
+        for( auto &[requestId, state] : m_inflightImageRequests )
         {
-            m_ImagePleaseContext->TryCancel();
+            static_cast<void>( requestId );
+            if( state && state->m_context )
+            {
+                state->m_context->TryCancel();
+            }
         }
     }
 
     { // mutex scope
         std::unique_lock<std::mutex> lock( m_imageRequestMutex );
-        while( m_imageRequestPending )
+        while( !m_inflightImageRequests.empty() )
         {
             if( m_imageRequestCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
             {
@@ -753,6 +757,12 @@ void rtimvClientBase::Configure()
     {
         m_clientId = result.client_id();
         m_connected = true;
+        { // mutex scope
+            std::lock_guard<std::mutex> imageLock( m_imageRequestMutex );
+            m_completedImageReplies.clear();
+            m_lastAppliedResponseSerial = 0;
+            m_imagePipelinePrimed = false;
+        }
         updateImageNamesFromServer();
         std::cerr << formatBaseLogMessage( std::format( "connected to {}:{}", m_server, m_port ) ) << '\n';
         m_connectionFailReported = false;
@@ -806,6 +816,10 @@ void rtimvClientBase::ImagePlease()
 
     SHARED_CONN_LOCK
 
+    const uint64_t connectionGeneration = m_connections;
+
+    std::vector<std::pair<uint64_t, std::shared_ptr<imageRequestState>>> requestsToDispatch;
+
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
 
@@ -814,39 +828,41 @@ void rtimvClientBase::ImagePlease()
             return;
         }
 
-        if( m_imageRequestPending )
+        const size_t targetWindow = m_imagePipelinePrimed ? m_targetImageWindow : 1;
+
+        while( m_inflightImageRequests.size() < targetWindow )
         {
+            auto state = std::make_shared<imageRequestState>();
+            state->m_context = std::make_unique<grpc::ClientContext>();
+            state->m_context->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 10000 ) );
+            state->m_connectionGeneration = connectionGeneration;
 
-            std::cerr << formatBaseLogMessage( std::format(
-                             "bug: in ImagePlease but imageRequestPending is true {} {}", __FILE__, __LINE__ ) )
-                      << '\n';
-            return;
+            const uint64_t requestId = m_nextImageRequestId++;
+            m_inflightImageRequests.emplace( requestId, state );
+            requestsToDispatch.emplace_back( requestId, state );
         }
-
-        if( m_ImagePleaseContext )
-        {
-            std::cerr << formatBaseLogMessage( std::format(
-                             "bug: in ImagePlease but ImagePleaseContext is allocated {} {}", __FILE__, __LINE__ ) )
-                      << '\n';
-            return;
-        }
-
-        m_ImagePleaseContext = new grpc::ClientContext;
-        m_ImagePleaseContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 10000 ) );
-
-        m_imageRequestPending = true;
     }
 
     connLock.unlock();
-    dispatchImagePleaseAsync();
+
+    for( auto &[requestId, state] : requestsToDispatch )
+    {
+        dispatchImagePleaseAsync( requestId, state );
+    }
 }
 
-void rtimvClientBase::dispatchImagePleaseAsync()
+void rtimvClientBase::dispatchImagePleaseAsync( uint64_t requestId, std::shared_ptr<imageRequestState> state )
 {
-    stub_->async()->ImagePlease( m_ImagePleaseContext,
-                                 &m_grpcImageRequest,
-                                 &m_grpcImage,
-                                 [this]( grpc::Status status ) { this->ImagePlease_callback( status ); } );
+    if( !state || !state->m_context )
+    {
+        return;
+    }
+
+    stub_->async()->ImagePlease( state->m_context.get(),
+                                 &state->m_request,
+                                 &state->m_reply,
+                                 [this, requestId, state]( grpc::Status status )
+                                 { this->ImagePlease_callback( requestId, state, status ); } );
 }
 
 void rtimvClientBase::dispatchPingAsync()
@@ -1056,138 +1072,121 @@ void rtimvClientBase::requestStatsBoxValues()
 
 void rtimvClientBase::ImageReceived()
 {
+    remote_rtimv::Image grpcImage;
+    bool haveImageReply{ false };
+
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
         if( m_shuttingDown )
         {
             return;
         }
-    }
 
-    uint32_t nx, ny, nz;
-    uint32_t imageNo;
-    float fpsEst;
-    double imageTime;
-    uint32_t saturated;
-    uint32_t sourceBytesPerPixel;
-    float minsc, maxsc, minim, maxim;
-    int imageTimeout;
-    int quality;
-
-    remote_rtimv::Colorbar colorbar;
-    remote_rtimv::Colormode colormode;
-    remote_rtimv::Colorstretch stretch;
-
-    bool autoScale;
-    bool subtractDark;
-    bool applyMask;
-    bool applySatMask;
-    remote_rtimv::HPFilter hpFilter;
-    float hpfFW;
-    bool applyHPFilter;
-    remote_rtimv::LPFilter lpFilter;
-    float lpfFW;
-    bool applyLPFilter;
-    bool statsBox;
-    uint32_t statsBox_i0, statsBox_i1, statsBox_j0, statsBox_j1;
-    float statsBox_min, statsBox_max, statsBox_mean, statsBox_median;
-    bool colorBox;
-    uint32_t colorBox_i0, colorBox_i1, colorBox_j0, colorBox_j1;
-    float colorBox_min, colorBox_max;
-    int cubeDir;
-    bool hasImagePayload{ false };
-    size_t compressedBytes{ 0 };
-
-    { // mutex scope
-        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
-
-        if( m_imageRequestPending )
+        if( m_completedImageReplies.empty() )
         {
-            std::cerr << formatBaseLogMessage( std::format(
-                             "bug: in ImageRecieved but imageRequestPending is true {} {}", __FILE__, __LINE__ ) )
-                      << '\n';
             return;
         }
 
-        nx = m_grpcImage.nx();
-        ny = m_grpcImage.ny();
-        nz = m_grpcImage.nz();
-        imageNo = m_grpcImage.no();
-
-        // Always have at least one pixel
-        if( nx == 0 )
+        auto newestReplyIt = m_completedImageReplies.begin();
+        for( auto replyIt = m_completedImageReplies.begin(); replyIt != m_completedImageReplies.end(); ++replyIt )
         {
-            nx = 1;
+            if( replyIt->response_serial() >= newestReplyIt->response_serial() )
+            {
+                newestReplyIt = replyIt;
+            }
         }
 
-        if( ny == 0 )
+        if( newestReplyIt->response_serial() > m_lastAppliedResponseSerial )
         {
-            ny = 1;
+            grpcImage = std::move( *newestReplyIt );
+            m_lastAppliedResponseSerial = grpcImage.response_serial();
+            haveImageReply = true;
         }
 
-        if( nz == 0 )
-        {
-            nz = 1;
-        }
+        m_completedImageReplies.clear();
+    }
 
-        if( !m_qim )
-        {
-            m_qim = new QImage;
-        }
+    if( !haveImageReply )
+    {
+        m_foundation->emit_ImageNeeded();
+        return;
+    }
 
-        if( m_grpcImage.image().size() > 0 )
-        {
-            compressedBytes = static_cast<size_t>( m_grpcImage.image().size() );
-            hasImagePayload = m_qim->loadFromData(
-                reinterpret_cast<const uchar *>( m_grpcImage.image().data() ), m_grpcImage.image().size(), "jpeg" );
-        }
+    uint32_t nx = grpcImage.nx();
+    uint32_t ny = grpcImage.ny();
+    uint32_t nz = grpcImage.nz();
+    uint32_t imageNo = grpcImage.no();
+    float fpsEst = grpcImage.fps();
+    double imageTime = grpcImage.atime();
+    uint32_t saturated = grpcImage.saturated();
+    uint32_t sourceBytesPerPixel = grpcImage.source_bytes_per_pixel();
+    float minsc = grpcImage.min_scale_data();
+    float maxsc = grpcImage.max_scale_data();
+    float minim = grpcImage.min_image_data();
+    float maxim = grpcImage.max_image_data();
+    int imageTimeout = grpcImage.image_timeout();
+    int quality = grpcImage.quality();
 
-        imageTime = m_grpcImage.atime();
-        fpsEst = m_grpcImage.fps();
+    remote_rtimv::Colorbar colorbar = grpcImage.colorbar();
+    remote_rtimv::Colormode colormode = grpcImage.colormode();
+    remote_rtimv::Colorstretch stretch = grpcImage.colorstretch();
 
-        saturated = m_grpcImage.saturated();
-        sourceBytesPerPixel = m_grpcImage.source_bytes_per_pixel();
+    bool autoScale = grpcImage.autoscale();
+    bool subtractDark = grpcImage.subtract_dark();
+    bool applyMask = grpcImage.apply_mask();
+    bool applySatMask = grpcImage.apply_sat_mask();
+    remote_rtimv::HPFilter hpFilter = grpcImage.hp_filter();
+    float hpfFW = grpcImage.hpf_fw();
+    bool applyHPFilter = grpcImage.apply_hp_filter();
+    remote_rtimv::LPFilter lpFilter = grpcImage.lp_filter();
+    float lpfFW = grpcImage.lpf_fw();
+    bool applyLPFilter = grpcImage.apply_lp_filter();
+    bool statsBox = grpcImage.stats_box();
+    uint32_t statsBox_i0 = grpcImage.stats_box_i0();
+    uint32_t statsBox_i1 = grpcImage.stats_box_i1();
+    uint32_t statsBox_j0 = grpcImage.stats_box_j0();
+    uint32_t statsBox_j1 = grpcImage.stats_box_j1();
+    float statsBox_min = grpcImage.stats_box_min();
+    float statsBox_max = grpcImage.stats_box_max();
+    float statsBox_mean = grpcImage.stats_box_mean();
+    float statsBox_median = grpcImage.stats_box_median();
+    bool colorBox = grpcImage.color_box();
+    uint32_t colorBox_i0 = grpcImage.color_box_i0();
+    uint32_t colorBox_i1 = grpcImage.color_box_i1();
+    uint32_t colorBox_j0 = grpcImage.color_box_j0();
+    uint32_t colorBox_j1 = grpcImage.color_box_j1();
+    float colorBox_min = grpcImage.color_box_min();
+    float colorBox_max = grpcImage.color_box_max();
+    int cubeDir = grpcImage.cube_dir();
+    bool hasImagePayload{ false };
+    size_t compressedBytes{ 0 };
 
-        minim = m_grpcImage.min_image_data();
-        maxim = m_grpcImage.max_image_data();
-        minsc = m_grpcImage.min_scale_data();
-        maxsc = m_grpcImage.max_scale_data();
+    // Always have at least one pixel.
+    if( nx == 0 )
+    {
+        nx = 1;
+    }
 
-        colorbar = m_grpcImage.colorbar();
-        colormode = m_grpcImage.colormode();
-        stretch = m_grpcImage.colorstretch();
+    if( ny == 0 )
+    {
+        ny = 1;
+    }
 
-        autoScale = m_grpcImage.autoscale();
+    if( nz == 0 )
+    {
+        nz = 1;
+    }
 
-        subtractDark = m_grpcImage.subtract_dark();
-        applyMask = m_grpcImage.apply_mask();
-        applySatMask = m_grpcImage.apply_sat_mask();
-        hpFilter = m_grpcImage.hp_filter();
-        hpfFW = m_grpcImage.hpf_fw();
-        applyHPFilter = m_grpcImage.apply_hp_filter();
-        lpFilter = m_grpcImage.lp_filter();
-        lpfFW = m_grpcImage.lpf_fw();
-        applyLPFilter = m_grpcImage.apply_lp_filter();
-        statsBox = m_grpcImage.stats_box();
-        statsBox_i0 = m_grpcImage.stats_box_i0();
-        statsBox_i1 = m_grpcImage.stats_box_i1();
-        statsBox_j0 = m_grpcImage.stats_box_j0();
-        statsBox_j1 = m_grpcImage.stats_box_j1();
-        statsBox_min = m_grpcImage.stats_box_min();
-        statsBox_max = m_grpcImage.stats_box_max();
-        statsBox_mean = m_grpcImage.stats_box_mean();
-        statsBox_median = m_grpcImage.stats_box_median();
-        colorBox = m_grpcImage.color_box();
-        colorBox_i0 = m_grpcImage.color_box_i0();
-        colorBox_i1 = m_grpcImage.color_box_i1();
-        colorBox_j0 = m_grpcImage.color_box_j0();
-        colorBox_j1 = m_grpcImage.color_box_j1();
-        colorBox_min = m_grpcImage.color_box_min();
-        colorBox_max = m_grpcImage.color_box_max();
+    if( !m_qim )
+    {
+        m_qim = new QImage;
+    }
 
-        imageTimeout = m_grpcImage.image_timeout();
-        cubeDir = m_grpcImage.cube_dir();
-        quality = m_grpcImage.quality();
+    if( grpcImage.image().size() > 0 )
+    {
+        compressedBytes = static_cast<size_t>( grpcImage.image().size() );
+        hasImagePayload = m_qim->loadFromData(
+            reinterpret_cast<const uchar *>( grpcImage.image().data() ), grpcImage.image().size(), "jpeg" );
     }
 
     std::shared_mutex dummy; // Used just to satisfy the requirement, not needed
@@ -1438,48 +1437,61 @@ void rtimvClientBase::Ping_callback( grpc::Status status )
     }
 }
 
-void rtimvClientBase::ImagePlease_callback( grpc::Status status )
+void rtimvClientBase::ImagePlease_callback( uint64_t requestId,
+                                            std::shared_ptr<imageRequestState> state,
+                                            grpc::Status status )
 {
     int action = -1;
     int retryMs = 0;
     bool shuttingDown = false;
     bool disconnected = false;
-    uint64_t connections = 0;
+    bool staleConnection = false;
+
+    sharedLockT connLock( m_connectedMutex );
+    const uint64_t currentConnections = m_connections;
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
 
-        if( !m_imageRequestPending )
+        auto requestIt = m_inflightImageRequests.find( requestId );
+        if( requestIt == m_inflightImageRequests.end() )
         {
-            std::cerr << formatBaseLogMessage( "bug: in ImagePlease_callback but imageRequestPending is false" )
+            std::cerr << formatBaseLogMessage( std::format(
+                             "bug: in ImagePlease_callback missing request {} {} {}", requestId, __FILE__, __LINE__ ) )
                       << '\n';
             return;
         }
 
+        staleConnection = ( state && state->m_connectionGeneration != currentConnections );
+
         // Act upon its status.
-        if( status.ok() )
+        if( staleConnection )
         {
-            if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_VALID )
+        }
+        else if( status.ok() )
+        {
+            if( state && state->m_reply.status() == remote_rtimv::IMAGE_STATUS_VALID )
             {
                 action = 0;
                 m_imageRetryBackoffMs = 500;
+                m_imagePipelinePrimed = true;
+                m_completedImageReplies.push_back( std::move( state->m_reply ) );
             }
-            else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_NO_IMAGE )
+            else if( state && state->m_reply.status() == remote_rtimv::IMAGE_STATUS_NO_IMAGE )
             {
                 action = 1;
+                m_imagePipelinePrimed = false;
                 m_imageRetryBackoffMs = std::min( 5000, std::max( 1000, m_imageRetryBackoffMs ) * 2 );
                 retryMs = m_imageRetryBackoffMs;
             }
-            else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_TIMEOUT )
+            else if( state && state->m_reply.status() == remote_rtimv::IMAGE_STATUS_TIMEOUT )
             {
                 action = 3;
-                m_imageRetryBackoffMs = std::min( 5000, std::max( 500, m_imageRetryBackoffMs ) * 2 );
-                retryMs = m_imageRetryBackoffMs;
             }
-            else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_NOT_CONFIGURED )
+            else if( state && state->m_reply.status() == remote_rtimv::IMAGE_STATUS_NOT_CONFIGURED )
             {
             }
-            else if( m_grpcImage.status() == remote_rtimv::IMAGE_STATUS_ERROR )
+            else if( state && state->m_reply.status() == remote_rtimv::IMAGE_STATUS_ERROR )
             {
             }
         }
@@ -1496,23 +1508,18 @@ void rtimvClientBase::ImagePlease_callback( grpc::Status status )
             }
         }
 
-        delete m_ImagePleaseContext;
-        m_ImagePleaseContext = nullptr;
-
-        m_imageRequestPending = false;
+        m_inflightImageRequests.erase( requestIt );
         shuttingDown = m_shuttingDown;
     }
 
     m_imageRequestCv.notify_all();
 
-    if( disconnected )
-    {
-        sharedLockT connLock( m_connectedMutex );
-        connections = m_connections;
-        connLock.unlock();
+    connLock.unlock();
 
+    if( disconnected && !staleConnection )
+    {
         uniqueLockT lock( m_connectedMutex );
-        if( connections == m_connections )
+        if( currentConnections == m_connections )
         {
             m_connected = false;
             std::cerr << formatBaseLogMessage( std::string( "Message from rtimvServer: " ) + status.error_message() )
@@ -1556,8 +1563,8 @@ void rtimvClientBase::ImagePlease_callback( grpc::Status status )
     }
     else if( action == 3 )
     {
-        // For no-new-frame timeouts, avoid re-processing stale image state for every client.
-        scheduleImageRetry( retryMs > 0 ? retryMs : 500 );
+        // Replenish the credit window and keep waiting for the next fresh image/state update.
+        m_foundation->emit_ImageNeeded();
     }
 
     // if action stays -1 we just return

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -16,9 +16,10 @@
 #include <cmath>
 #include <thread>
 
-#include <QMetaObject>
-#include <QPointer>
 #include <QCoreApplication>
+#include <QMetaObject>
+#include <QThread>
+#include <QTimer>
 
 #include <mx/ioutils/stringUtils.hpp>
 
@@ -93,6 +94,18 @@ rtimvClientBase::~rtimvClientBase()
         }
     }
 
+    if( m_foundation )
+    {
+        if( m_foundation->thread() == QThread::currentThread() )
+        {
+            m_foundation->shutdown();
+        }
+        else
+        {
+            QMetaObject::invokeMethod( m_foundation, "shutdown", Qt::BlockingQueuedConnection );
+        }
+    }
+
     { // mutex scope
         std::unique_lock<std::mutex> lock( m_imageRequestMutex );
         while( !m_inflightImageRequests.empty() )
@@ -164,6 +177,18 @@ rtimvClientBase::~rtimvClientBase()
         }
     }
 
+    { // mutex scope
+        std::unique_lock<std::mutex> lock( m_callbackActivityMutex );
+
+        while( m_activeGrpcCallbacks > 0 )
+        {
+            if( m_callbackActivityCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
+            {
+                std::cerr << formatBaseLogMessage( "waiting for gRPC callback activity during shutdown." ) << '\n';
+            }
+        }
+    }
+
     if( m_configReq )
     {
         delete m_configReq;
@@ -171,8 +196,41 @@ rtimvClientBase::~rtimvClientBase()
 
     if( m_foundation )
     {
-        m_foundation->deleteLater();
+        if( m_foundation->thread() == QThread::currentThread() )
+        {
+            delete m_foundation;
+        }
+        else
+        {
+            m_foundation->deleteLater();
+        }
+
+        m_foundation = nullptr;
     }
+}
+
+void rtimvClientBase::beginGrpcCallbackActivity()
+{
+    std::lock_guard<std::mutex> lock( m_callbackActivityMutex );
+    ++m_activeGrpcCallbacks;
+}
+
+void rtimvClientBase::endGrpcCallbackActivity()
+{
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_callbackActivityMutex );
+
+        if( m_activeGrpcCallbacks == 0 )
+        {
+            std::cerr << formatBaseLogMessage( "bug: gRPC callback activity underflow during shutdown tracking." )
+                      << '\n';
+            return;
+        }
+
+        --m_activeGrpcCallbacks;
+    }
+
+    m_callbackActivityCv.notify_all();
 }
 
 void rtimvClientBase::setupConfig()
@@ -1409,6 +1467,10 @@ void rtimvClientBase::ImageReceived()
 
 void rtimvClientBase::Ping_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool shuttingDown{ false };
     bool disconnect{ false };
     bool updateRtt{ false };
@@ -1435,7 +1497,7 @@ void rtimvClientBase::Ping_callback( grpc::Status status )
             disconnect = true;
         }
 
-        delete m_PingContext;
+        contextHolder.reset( m_PingContext );
         m_PingContext = nullptr;
 
         m_pingPending = false;
@@ -1477,6 +1539,9 @@ void rtimvClientBase::ImagePlease_callback( uint64_t requestId,
                                             std::shared_ptr<imageRequestState> state,
                                             grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+
     int action = -1;
     int retryMs = 0;
     bool shuttingDown = false;
@@ -1570,17 +1635,12 @@ void rtimvClientBase::ImagePlease_callback( uint64_t requestId,
 
     auto scheduleImageRetry = [this]( int ms )
     {
-        QPointer<rtimvBaseObject> foundation = m_foundation;
-        std::thread(
-            [foundation, ms]()
-            {
-                std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
-                if( foundation )
-                {
-                    QMetaObject::invokeMethod( foundation, "ImagePlease", Qt::QueuedConnection );
-                }
-            } )
-            .detach();
+        if( !m_foundation )
+        {
+            return;
+        }
+
+        QMetaObject::invokeMethod( m_foundation, "scheduleImagePlease", Qt::QueuedConnection, Q_ARG( int, ms ) );
     };
 
     if( action == 0 )
@@ -1608,6 +1668,10 @@ void rtimvClientBase::ImagePlease_callback( uint64_t requestId,
 
 void rtimvClientBase::GetPixel_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     uint32_t nextX{ 0 };
     uint32_t nextY{ 0 };
@@ -1642,7 +1706,7 @@ void rtimvClientBase::GetPixel_callback( grpc::Status status )
             REPORT_SERVER_DISCONNECTED
         }
 
-        delete m_GetPixelContext;
+        contextHolder.reset( m_GetPixelContext );
         m_GetPixelContext = nullptr;
 
         m_getPixelPending = false;
@@ -1659,14 +1723,18 @@ void rtimvClientBase::GetPixel_callback( grpc::Status status )
         m_foundation->emit_pixelValueUpdated( reqX, reqY, value, valid );
     }
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        requestPixelValue( nextX, nextY );
+        QTimer::singleShot( 0, m_foundation, [this, nextX, nextY]() { requestPixelValue( nextX, nextY ); } );
     }
 }
 
 void rtimvClientBase::ColorBox_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     bool valid{ false };
     int64_t i0{ 0 }, i1{ 0 }, j0{ 0 }, j1{ 0 };
@@ -1708,7 +1776,7 @@ void rtimvClientBase::ColorBox_callback( grpc::Status status )
             REPORT_SERVER_DISCONNECTED
         }
 
-        delete m_ColorBoxContext;
+        contextHolder.reset( m_ColorBoxContext );
         m_ColorBoxContext = nullptr;
 
         m_colorBoxPending = false;
@@ -1723,14 +1791,18 @@ void rtimvClientBase::ColorBox_callback( grpc::Status status )
         m_foundation->emit_colorBoxUpdated( i0, i1, j0, j1, min, max, valid );
     }
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        requestColorBoxValues();
+        QTimer::singleShot( 0, m_foundation, [this]() { requestColorBoxValues(); } );
     }
 }
 
 void rtimvClientBase::StatsBox_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     bool valid{ false };
     int64_t i0{ 0 }, i1{ 0 }, j0{ 0 }, j1{ 0 };
@@ -1781,7 +1853,7 @@ void rtimvClientBase::StatsBox_callback( grpc::Status status )
             REPORT_SERVER_DISCONNECTED
         }
 
-        delete m_StatsBoxContext;
+        contextHolder.reset( m_StatsBoxContext );
         m_StatsBoxContext = nullptr;
 
         m_statsBoxPending = false;
@@ -1796,14 +1868,18 @@ void rtimvClientBase::StatsBox_callback( grpc::Status status )
         m_foundation->emit_statsBoxUpdated( i0, i1, j0, j1, min, max, mean, median, valid );
     }
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        requestStatsBoxValues();
+        QTimer::singleShot( 0, m_foundation, [this]() { requestStatsBoxValues(); } );
     }
 }
 
 void rtimvClientBase::SetColorstretch_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     rtimv::stretch nextStretch{ rtimv::stretch::linear };
 
@@ -1823,7 +1899,7 @@ void rtimvClientBase::SetColorstretch_callback( grpc::Status status )
             REPORT_SERVER_DISCONNECTED
         }
 
-        delete m_SetColorstretchContext;
+        contextHolder.reset( m_SetColorstretchContext );
         m_SetColorstretchContext = nullptr;
 
         m_setColorstretchPending = false;
@@ -1834,14 +1910,18 @@ void rtimvClientBase::SetColorstretch_callback( grpc::Status status )
 
     m_asyncRpcCv.notify_all();
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        stretch( nextStretch );
+        QTimer::singleShot( 0, m_foundation, [this, nextStretch]() { stretch( nextStretch ); } );
     }
 }
 
 void rtimvClientBase::SetMinScale_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     float nextValue{ 0 };
 
@@ -1867,21 +1947,25 @@ void rtimvClientBase::SetMinScale_callback( grpc::Status status )
             m_setMinScaleQueued = false;
         }
 
-        delete m_SetMinScaleContext;
+        contextHolder.reset( m_SetMinScaleContext );
         m_SetMinScaleContext = nullptr;
         m_setMinScalePending = false;
     }
 
     m_asyncRpcCv.notify_all();
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        minScaleData( nextValue );
+        QTimer::singleShot( 0, m_foundation, [this, nextValue]() { minScaleData( nextValue ); } );
     }
 }
 
 void rtimvClientBase::SetMaxScale_callback( grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder;
+
     bool queueNext{ false };
     float nextValue{ 0 };
 
@@ -1907,21 +1991,25 @@ void rtimvClientBase::SetMaxScale_callback( grpc::Status status )
             m_setMaxScaleQueued = false;
         }
 
-        delete m_SetMaxScaleContext;
+        contextHolder.reset( m_SetMaxScaleContext );
         m_SetMaxScaleContext = nullptr;
         m_setMaxScalePending = false;
     }
 
     m_asyncRpcCv.notify_all();
 
-    if( queueNext )
+    if( queueNext && m_foundation != nullptr )
     {
-        maxScaleData( nextValue );
+        QTimer::singleShot( 0, m_foundation, [this, nextValue]() { maxScaleData( nextValue ); } );
     }
 }
 
 void rtimvClientBase::EmptyRpc_callback( grpc::ClientContext *context, grpc::Status status )
 {
+    beginGrpcCallbackActivity();
+    auto callbackGuard = std::shared_ptr<void>( nullptr, [this]( void * ) { endGrpcCallbackActivity(); } );
+    std::unique_ptr<grpc::ClientContext> contextHolder( context );
+
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
 
@@ -1944,8 +2032,6 @@ void rtimvClientBase::EmptyRpc_callback( grpc::ClientContext *context, grpc::Sta
             --m_emptyRpcPending;
         }
     }
-
-    delete context;
 
     m_asyncRpcCv.notify_all();
 

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -32,7 +32,7 @@ namespace
 constexpr int minImageRequestWindow = 1;
 constexpr int maxImageRequestWindow = 128;
 constexpr auto avgFrameRatePublishInterval = std::chrono::seconds( 1 );
-constexpr auto shutdownRpcGracePeriod = std::chrono::milliseconds( 250 );
+constexpr auto shutdownRpcGracePeriod = std::chrono::milliseconds( 500 );
 
 /// Parse a bool config target while preserving bare optional flags as true.
 bool configBoolOption( mx::app::appConfigurator &config, const std::string &name )
@@ -241,8 +241,10 @@ rtimvClientBase::~rtimvClientBase()
 
 void rtimvClientBase::beginGrpcCallbackActivity()
 {
-    std::lock_guard<std::mutex> lock( m_callbackActivityMutex );
-    ++m_activeGrpcCallbacks;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_callbackActivityMutex );
+        ++m_activeGrpcCallbacks;
+    }
 }
 
 void rtimvClientBase::endGrpcCallbackActivity()
@@ -1653,8 +1655,12 @@ void rtimvClientBase::ImagePlease_callback( uint64_t requestId,
         if( currentConnections == m_connections )
         {
             m_connected = false;
-            std::cerr << formatBaseLogMessage( std::string( "Message from rtimvServer: " ) + status.error_message() )
-                      << '\n';
+            if( !( shuttingDown && status.error_code() == grpc::StatusCode::CANCELLED ) )
+            {
+                std::cerr << formatBaseLogMessage( std::string( "Message from rtimvServer: " ) +
+                                                   status.error_message() )
+                          << '\n';
+            }
         }
     }
 

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -28,6 +28,10 @@
 namespace
 {
 
+constexpr int minImageRequestWindow = 1;
+constexpr int maxImageRequestWindow = 128;
+constexpr auto avgFrameRatePublishInterval = std::chrono::seconds( 1 );
+
 /// Parse a bool config target while preserving bare optional flags as true.
 bool configBoolOption( mx::app::appConfigurator &config, const std::string &name )
 {
@@ -286,6 +290,17 @@ void rtimvClientBase::setupConfig()
                 false,
                 "int",
                 "Specify the number of frames used for rolling averages of compression ratio and frame rate. "
+                "Default is 10." );
+
+    config.add( "update.imageWindow",
+                "",
+                "update.imageWindow",
+                mx::app::argType::Required,
+                "update",
+                "imageWindow",
+                false,
+                "int",
+                "Specify the target number of in-flight ImagePlease RPCs used to hide transport latency. "
                 "Default is 10." );
 
     config.add( "autoscale",
@@ -582,6 +597,14 @@ void rtimvClientBase::loadConfig()
         }
     }
 
+    if( config.isSet( "update.imageWindow" ) )
+    {
+        int imageWindow{ 10 };
+        config( imageWindow, "update.imageWindow" );
+        m_targetImageWindow =
+            static_cast<size_t>( std::clamp( imageWindow, minImageRequestWindow, maxImageRequestWindow ) );
+    }
+
     if( config.isSet( "autoscale" ) )
     {
         bool autoscale = configBoolOption( config, "autoscale" );
@@ -763,6 +786,19 @@ void rtimvClientBase::Configure()
             m_lastAppliedResponseSerial = 0;
             m_imagePipelinePrimed = false;
         }
+        m_lastCompressionRatio = 0;
+        m_avgCompressionRatio = 0;
+        m_avgFrameRate = 0;
+        m_lastRttMs = 0;
+        m_avgRttMs = 0;
+        m_fpsRollingSum = 0;
+        m_compressionRollingSum = 0;
+        m_rttRollingSum = 0;
+        m_recentFrameIntervals.clear();
+        m_recentCompressionRatios.clear();
+        m_recentRtts.clear();
+        m_lastArrivalTime = std::chrono::steady_clock::time_point{};
+        m_lastFrameRatePublishTime = std::chrono::steady_clock::time_point{};
         updateImageNamesFromServer();
         std::cerr << formatBaseLogMessage( std::format( "connected to {}:{}", m_server, m_port ) ) << '\n';
         m_connectionFailReported = false;
@@ -2374,7 +2410,13 @@ void rtimvClientBase::updateRollingTransportStats(
                 const double avgFrameInterval = m_fpsRollingSum / static_cast<double>( m_recentFrameIntervals.size() );
                 if( avgFrameInterval > 0 )
                 {
-                    m_avgFrameRate = 1.0 / avgFrameInterval;
+                    const double computedAvgFrameRate = 1.0 / avgFrameInterval;
+                    if( m_lastFrameRatePublishTime == std::chrono::steady_clock::time_point{} ||
+                        now - m_lastFrameRatePublishTime >= avgFrameRatePublishInterval )
+                    {
+                        m_avgFrameRate = computedAvgFrameRate;
+                        m_lastFrameRatePublishTime = now;
+                    }
                 }
             }
         }
@@ -2443,6 +2485,31 @@ void rtimvClientBase::imageTimeout( int to )
 int rtimvClientBase::imageTimeout()
 {
     return m_imageTimeout;
+}
+
+void rtimvClientBase::imageRequestWindow( int window )
+{
+    const size_t clampedWindow =
+        static_cast<size_t>( std::clamp( window, minImageRequestWindow, maxImageRequestWindow ) );
+    bool requestMoreImages{ false };
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
+
+        requestMoreImages = !m_shuttingDown && clampedWindow > m_targetImageWindow;
+        m_targetImageWindow = clampedWindow;
+    }
+
+    if( requestMoreImages && m_foundation != nullptr )
+    {
+        m_foundation->emit_ImageNeeded();
+    }
+}
+
+int rtimvClientBase::imageRequestWindow()
+{
+    std::lock_guard<std::mutex> lock( m_imageRequestMutex );
+    return static_cast<int>( m_targetImageWindow );
 }
 
 int rtimvClientBase::currImageTimeout()

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -129,6 +129,11 @@ rtimvClientBase::~rtimvClientBase()
             m_SetMaxScaleContext->TryCancel();
         }
 
+        if( m_PingContext )
+        {
+            m_PingContext->TryCancel();
+        }
+
         for( auto *context : m_emptyRpcContexts )
         {
             if( context )
@@ -141,8 +146,8 @@ rtimvClientBase::~rtimvClientBase()
     { // mutex scope
         std::unique_lock<std::mutex> lock( m_asyncRpcMutex );
 
-        while( m_getPixelPending || m_colorBoxPending || m_statsBoxPending || m_setColorstretchPending ||
-               m_setMinScalePending || m_setMaxScalePending || m_emptyRpcPending > 0 )
+        while( m_pingPending || m_getPixelPending || m_colorBoxPending || m_statsBoxPending ||
+               m_setColorstretchPending || m_setMinScalePending || m_setMaxScalePending || m_emptyRpcPending > 0 )
         {
             if( m_asyncRpcCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
             {
@@ -679,6 +684,8 @@ void rtimvClientBase::reconnect()
 
     if( m_connected )
     {
+        lock.unlock();
+        dispatchPingAsync();
         return;
     }
 
@@ -840,6 +847,46 @@ void rtimvClientBase::dispatchImagePleaseAsync()
                                  &m_grpcImageRequest,
                                  &m_grpcImage,
                                  [this]( grpc::Status status ) { this->ImagePlease_callback( status ); } );
+}
+
+void rtimvClientBase::dispatchPingAsync()
+{
+    bool isConnected{ false };
+
+    { // mutex scope
+        sharedLockT connLock( m_connectedMutex );
+        isConnected = m_connected;
+    }
+
+    if( !isConnected || !stub_ )
+    {
+        return;
+    }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+        if( m_shuttingDown || m_pingPending )
+        {
+            return;
+        }
+
+        if( m_PingContext )
+        {
+            std::cerr << formatBaseLogMessage( std::format(
+                             "bug: in dispatchPingAsync but PingContext is allocated {} {}", __FILE__, __LINE__ ) )
+                      << '\n';
+            return;
+        }
+
+        m_PingContext = new grpc::ClientContext;
+        m_PingContext->set_deadline( std::chrono::system_clock::now() + std::chrono::milliseconds( 2000 ) );
+        m_pingStartTime = std::chrono::steady_clock::now();
+        m_pingPending = true;
+    }
+
+    stub_->async()->Ping(
+        m_PingContext, &m_pingRequest, &m_pingReply, [this]( grpc::Status status ) { this->Ping_callback( status ); } );
 }
 
 void rtimvClientBase::requestPixelValue( uint32_t x, uint32_t y )
@@ -1323,6 +1370,72 @@ void rtimvClientBase::ImageReceived()
 
     // We always go on and get the next one
     m_foundation->emit_ImageNeeded();
+}
+
+void rtimvClientBase::Ping_callback( grpc::Status status )
+{
+    bool shuttingDown{ false };
+    bool disconnect{ false };
+    bool updateRtt{ false };
+    uint64_t connections{ 0 };
+    double rttMs{ 0 };
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_asyncRpcMutex );
+
+        if( !m_pingPending )
+        {
+            std::cerr << formatBaseLogMessage( "bug: in Ping_callback but pingPending is false" ) << '\n';
+            return;
+        }
+
+        if( status.ok() )
+        {
+            const std::chrono::duration<double, std::milli> dt = std::chrono::steady_clock::now() - m_pingStartTime;
+            rttMs = dt.count();
+            updateRtt = true;
+        }
+        else if( status.error_code() != grpc::StatusCode::DEADLINE_EXCEEDED )
+        {
+            disconnect = true;
+        }
+
+        delete m_PingContext;
+        m_PingContext = nullptr;
+
+        m_pingPending = false;
+        shuttingDown = m_shuttingDown;
+    }
+
+    m_asyncRpcCv.notify_all();
+
+    if( shuttingDown )
+    {
+        return;
+    }
+
+    if( updateRtt )
+    {
+        updateRollingRttStats( rttMs );
+    }
+
+    if( !disconnect )
+    {
+        return;
+    }
+
+    { // mutex scope
+        sharedLockT connLock( m_connectedMutex );
+        connections = m_connections;
+    }
+
+    uniqueLockT lock( m_connectedMutex );
+    if( connections == m_connections )
+    {
+        m_connected = false;
+        std::cerr << formatBaseLogMessage( std::string( "Message from rtimvServer: " ) + status.error_message() )
+                  << '\n';
+    }
 }
 
 void rtimvClientBase::ImagePlease_callback( grpc::Status status )
@@ -1857,6 +1970,16 @@ double rtimvClientBase::avgFrameRate()
     return m_avgFrameRate;
 }
 
+double rtimvClientBase::lastRttMs()
+{
+    return m_lastRttMs;
+}
+
+double rtimvClientBase::avgRttMs()
+{
+    return m_avgRttMs;
+}
+
 std::string rtimvClientBase::imageName( size_t n )
 {
     if( n >= m_imageNames.size() )
@@ -2189,6 +2312,30 @@ void rtimvClientBase::setCurrImageTimeout()
     }
 
     m_currImageTimeout = currImageTimeout;
+}
+
+void rtimvClientBase::updateRollingRttStats( double rttMs )
+{
+    if( m_rollingStatsFrames < 1 )
+    {
+        m_rollingStatsFrames = 1;
+    }
+
+    m_lastRttMs = rttMs;
+
+    m_recentRtts.push_back( rttMs );
+    m_rttRollingSum += rttMs;
+
+    while( static_cast<int>( m_recentRtts.size() ) > m_rollingStatsFrames )
+    {
+        m_rttRollingSum -= m_recentRtts.front();
+        m_recentRtts.pop_front();
+    }
+
+    if( !m_recentRtts.empty() )
+    {
+        m_avgRttMs = m_rttRollingSum / static_cast<double>( m_recentRtts.size() );
+    }
 }
 
 void rtimvClientBase::updateRollingTransportStats(

--- a/src/server/rtimvClientBase.cpp
+++ b/src/server/rtimvClientBase.cpp
@@ -32,6 +32,7 @@ namespace
 constexpr int minImageRequestWindow = 1;
 constexpr int maxImageRequestWindow = 128;
 constexpr auto avgFrameRatePublishInterval = std::chrono::seconds( 1 );
+constexpr auto shutdownRpcGracePeriod = std::chrono::milliseconds( 250 );
 
 /// Parse a bool config target while preserving bare optional flags as true.
 bool configBoolOption( mx::app::appConfigurator &config, const std::string &name )
@@ -83,15 +84,6 @@ rtimvClientBase::~rtimvClientBase()
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
         m_shuttingDown = true;
-
-        for( auto &[requestId, state] : m_inflightImageRequests )
-        {
-            static_cast<void>( requestId );
-            if( state && state->m_context )
-            {
-                state->m_context->TryCancel();
-            }
-        }
     }
 
     if( m_foundation )
@@ -108,6 +100,29 @@ rtimvClientBase::~rtimvClientBase()
 
     { // mutex scope
         std::unique_lock<std::mutex> lock( m_imageRequestMutex );
+
+        if( !m_inflightImageRequests.empty() )
+        {
+            const auto deadline = std::chrono::steady_clock::now() + shutdownRpcGracePeriod;
+
+            while( !m_inflightImageRequests.empty() )
+            {
+                if( m_imageRequestCv.wait_until( lock, deadline ) == std::cv_status::timeout )
+                {
+                    break;
+                }
+            }
+        }
+
+        for( auto &[requestId, state] : m_inflightImageRequests )
+        {
+            static_cast<void>( requestId );
+            if( state && state->m_context )
+            {
+                state->m_context->TryCancel();
+            }
+        }
+
         while( !m_inflightImageRequests.empty() )
         {
             if( m_imageRequestCv.wait_for( lock, std::chrono::seconds( 1 ) ) == std::cv_status::timeout )
@@ -118,7 +133,22 @@ rtimvClientBase::~rtimvClientBase()
     }
 
     { // mutex scope
-        std::lock_guard<std::mutex> asyncLock( m_asyncRpcMutex );
+        std::unique_lock<std::mutex> asyncLock( m_asyncRpcMutex );
+
+        if( m_pingPending || m_getPixelPending || m_colorBoxPending || m_statsBoxPending || m_setColorstretchPending ||
+            m_setMinScalePending || m_setMaxScalePending || m_emptyRpcPending > 0 )
+        {
+            const auto deadline = std::chrono::steady_clock::now() + shutdownRpcGracePeriod;
+
+            while( m_pingPending || m_getPixelPending || m_colorBoxPending || m_statsBoxPending ||
+                   m_setColorstretchPending || m_setMinScalePending || m_setMaxScalePending || m_emptyRpcPending > 0 )
+            {
+                if( m_asyncRpcCv.wait_until( asyncLock, deadline ) == std::cv_status::timeout )
+                {
+                    break;
+                }
+            }
+        }
 
         if( m_GetPixelContext )
         {

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -173,6 +173,9 @@ class rtimvClientBase : public mx::app::application
     /// Context for the SetMaxScale rpc.
     grpc::ClientContext *m_SetMaxScaleContext{ nullptr };
 
+    /// Context for the Ping rpc.
+    grpc::ClientContext *m_PingContext{ nullptr };
+
   public:
     /// Configure the server
     /**
@@ -201,11 +204,23 @@ class rtimvClientBase : public mx::app::application
     /// Backoff delay for ImagePlease retries when no new image data is available, ms.
     int m_imageRetryBackoffMs{ 500 };
 
-    /// Mutex guarding asynchronous unary RPC state for GetPixel/ColorBox/StatsBox.
+    /// Mutex guarding asynchronous unary RPC state for Ping/GetPixel/ColorBox/StatsBox.
     std::mutex m_asyncRpcMutex;
 
-    /// Condition variable used to signal completion of GetPixel/ColorBox/StatsBox requests.
+    /// Condition variable used to signal completion of Ping/GetPixel/ColorBox/StatsBox requests.
     std::condition_variable m_asyncRpcCv;
+
+    /// Request payload for Ping.
+    remote_rtimv::PingRequest m_pingRequest;
+
+    /// Response payload for Ping.
+    remote_rtimv::PingResponse m_pingReply;
+
+    /// True while a Ping request is outstanding.
+    bool m_pingPending{ false };
+
+    /// Monotonic send time for the outstanding Ping request.
+    std::chrono::steady_clock::time_point m_pingStartTime;
 
     /// True while a GetPixel request is outstanding.
     bool m_getPixelPending{ false };
@@ -353,6 +368,9 @@ class rtimvClientBase : public mx::app::application
     void ImagePlease();
 
   protected:
+    /// Launch the asynchronous Ping RPC used for transport RTT measurement.
+    void dispatchPingAsync();
+
     /// Launch the asynchronous ImagePlease RPC.
     virtual void dispatchImagePleaseAsync();
 
@@ -371,6 +389,9 @@ class rtimvClientBase : public mx::app::application
     void ImageReceived();
 
   protected:
+    /// Handle a Ping response from the server.
+    void Ping_callback( grpc::Status status );
+
     /// Handle an ImagePlease response from the server
     void ImagePlease_callback( grpc::Status status );
 
@@ -432,13 +453,21 @@ class rtimvClientBase : public mx::app::application
 
     double m_avgFrameRate{ 0 }; ///< Rolling average frame rate over recent received frames.
 
+    double m_lastRttMs{ 0 }; ///< Round-trip time of the most recently completed Ping RPC, in ms.
+
+    double m_avgRttMs{ 0 }; ///< Rolling average Ping round-trip time, in ms.
+
     double m_fpsRollingSum{ 0 }; ///< Running sum for the rolling frame-rate average.
 
     double m_compressionRollingSum{ 0 }; ///< Running sum for the rolling compression-ratio average.
 
+    double m_rttRollingSum{ 0 }; ///< Running sum for the rolling RTT average.
+
     std::deque<double> m_recentFrameIntervals; ///< Recent inter-arrival times used to form the rolling average.
 
     std::deque<double> m_recentCompressionRatios; ///< Recent compression-ratio samples used to form the average.
+
+    std::deque<double> m_recentRtts; ///< Recent Ping RTT samples used to form the rolling average.
 
     std::chrono::steady_clock::time_point m_lastArrivalTime; ///< Monotonic arrival time of the previous received frame.
 
@@ -613,6 +642,9 @@ class rtimvClientBase : public mx::app::application
      */
 
   private:
+    /// Update rolling RTT statistics from a completed Ping RPC.
+    void updateRollingRttStats( double rttMs /**< [in] round-trip time in milliseconds */ );
+
     void setCurrImageTimeout();
 
     /// Update rolling transport statistics from the latest received frame.
@@ -679,6 +711,12 @@ class rtimvClientBase : public mx::app::application
 
     /// Get the rolling average frame rate.
     double avgFrameRate();
+
+    /// Get the RTT of the most recently completed Ping RPC.
+    double lastRttMs();
+
+    /// Get the rolling average Ping RTT.
+    double avgRttMs();
 
     /// @}
 

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -474,7 +474,7 @@ class rtimvClientBase : public mx::app::application
 
     double m_avgCompressionRatio{ 0 }; ///< Rolling average compression ratio over recent received frames.
 
-    double m_avgFrameRate{ 0 }; ///< Rolling average frame rate over recent received frames.
+    double m_avgFrameRate{ 0 }; ///< Rolling average frame rate most recently published for display.
 
     double m_lastRttMs{ 0 }; ///< Round-trip time of the most recently completed Ping RPC, in ms.
 
@@ -493,6 +493,9 @@ class rtimvClientBase : public mx::app::application
     std::deque<double> m_recentRtts; ///< Recent Ping RTT samples used to form the rolling average.
 
     std::chrono::steady_clock::time_point m_lastArrivalTime; ///< Monotonic arrival time of the previous received frame.
+
+    std::chrono::steady_clock::time_point
+        m_lastFrameRatePublishTime; ///< Monotonic time when m_avgFrameRate was last refreshed for display.
 
     double m_imageTime{ 0 };
 
@@ -698,6 +701,12 @@ class rtimvClientBase : public mx::app::application
 
     /// Get the JPEG quality
     int quality();
+
+    /// Set the target number of in-flight ImagePlease RPCs.
+    void imageRequestWindow( int window /**< [in] desired in-flight ImagePlease window */ );
+
+    /// Get the target number of in-flight ImagePlease RPCs.
+    int imageRequestWindow();
 
     /// Get the current image display timeout.
     /**

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -14,7 +14,9 @@
 #include <condition_variable>
 #include <chrono>
 #include <deque>
+#include <memory>
 #include <string_view>
+#include <unordered_map>
 
 #include <QImage>
 
@@ -149,11 +151,17 @@ class rtimvClientBase : public mx::app::application
     /// Refresh configured image names from the server.
     void updateImageNamesFromServer();
 
-    /// Context for the ImagePlease rpc.
-    /** This has to stay alive until the rpc finishes and can not be reused
-     *
-     */
-    grpc::ClientContext *m_ImagePleaseContext{ nullptr };
+    /// State for one in-flight ImagePlease RPC.
+    struct imageRequestState
+    {
+        std::unique_ptr<grpc::ClientContext> m_context; ///< RPC context kept alive until the callback completes.
+
+        remote_rtimv::ImageRequest m_request; ///< Request payload for this ImagePlease call.
+
+        remote_rtimv::Image m_reply; ///< Response payload returned by the server for this ImagePlease call.
+
+        uint64_t m_connectionGeneration{ 0 }; ///< Connection generation active when this request was dispatched.
+    };
 
     /// Context for the GetPixel rpc.
     grpc::ClientContext *m_GetPixelContext{ nullptr };
@@ -192,14 +200,23 @@ class rtimvClientBase : public mx::app::application
     /// Flag indicating client teardown is in progress.
     bool m_shuttingDown{ false };
 
-    /// True while an ImagePlease RPC is outstanding.
-    bool m_imageRequestPending{ false };
+    /// Desired steady-state number of in-flight ImagePlease RPCs after the first valid image arrives.
+    size_t m_targetImageWindow{ 10 };
 
-    /// Request payload for the ImagePlease RPC.
-    remote_rtimv::ImageRequest m_grpcImageRequest;
+    /// True once at least one valid image has been received and the full image-credit window can be used.
+    bool m_imagePipelinePrimed{ false };
 
-    /// Last ImagePlease response payload from the server.
-    remote_rtimv::Image m_grpcImage;
+    /// Next unique identifier assigned to an ImagePlease request.
+    uint64_t m_nextImageRequestId{ 1 };
+
+    /// In-flight ImagePlease RPCs keyed by their local request identifier.
+    std::unordered_map<uint64_t, std::shared_ptr<imageRequestState>> m_inflightImageRequests;
+
+    /// Completed ImagePlease replies waiting to be applied on the Qt side.
+    std::deque<remote_rtimv::Image> m_completedImageReplies;
+
+    /// Monotonic serial of the newest Image reply already applied to the client state.
+    uint64_t m_lastAppliedResponseSerial{ 0 };
 
     /// Backoff delay for ImagePlease retries when no new image data is available, ms.
     int m_imageRetryBackoffMs{ 500 };
@@ -371,8 +388,11 @@ class rtimvClientBase : public mx::app::application
     /// Launch the asynchronous Ping RPC used for transport RTT measurement.
     void dispatchPingAsync();
 
-    /// Launch the asynchronous ImagePlease RPC.
-    virtual void dispatchImagePleaseAsync();
+    /// Launch one asynchronous ImagePlease RPC state.
+    virtual void
+    dispatchImagePleaseAsync( uint64_t requestId, /**< [in] local identifier for the in-flight request */
+                              std::shared_ptr<imageRequestState> state /**< [in] owned request/reply state */
+    );
 
   public:
     /// Request an updated calibrated pixel value.
@@ -392,8 +412,11 @@ class rtimvClientBase : public mx::app::application
     /// Handle a Ping response from the server.
     void Ping_callback( grpc::Status status );
 
-    /// Handle an ImagePlease response from the server
-    void ImagePlease_callback( grpc::Status status );
+    /// Handle an ImagePlease response from the server.
+    void ImagePlease_callback( uint64_t requestId, /**< [in] local identifier for the completed request */
+                               std::shared_ptr<imageRequestState> state, /**< [in] owned request/reply state */
+                               grpc::Status status                       /**< [in] completion status */
+    );
 
     /// Handle a GetPixel response from the server.
     void GetPixel_callback( grpc::Status status );

--- a/src/server/rtimvClientBase.hpp
+++ b/src/server/rtimvClientBase.hpp
@@ -380,11 +380,26 @@ class rtimvClientBase : public mx::app::application
     /// Number of in-flight fire-and-forget empty-response unary RPCs.
     size_t m_emptyRpcPending{ 0 };
 
+    /// Mutex guarding the count of callback threads still actively executing client code.
+    std::mutex m_callbackActivityMutex;
+
+    /// Condition variable signaled when an active gRPC callback finishes using this client object.
+    std::condition_variable m_callbackActivityCv;
+
+    /// Number of gRPC callback functions currently executing client-side follow-up logic.
+    size_t m_activeGrpcCallbacks{ 0 };
+
   public:
     /// Request an image from the server
     void ImagePlease();
 
   protected:
+    /// Record entry into a gRPC callback so shutdown can wait for client-side callback work to finish.
+    void beginGrpcCallbackActivity();
+
+    /// Record exit from a gRPC callback and wake shutdown waiters when the active count reaches zero.
+    void endGrpcCallbackActivity();
+
     /// Launch the asynchronous Ping RPC used for transport RTT measurement.
     void dispatchPingAsync();
 

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -9,7 +9,9 @@
 #include "rtimvLog.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <filesystem>
+#include <vector>
 
 namespace
 {
@@ -27,6 +29,94 @@ std::string image0OrUnknown( rtimvServerThread *imageTh )
     }
 
     return im0;
+}
+
+std::string boolString( bool value )
+{
+    if( value )
+    {
+        return "true";
+    }
+
+    return "false";
+}
+
+std::string quotedOrUnset( const std::string &value )
+{
+    if( value.empty() )
+    {
+        return "<unset>";
+    }
+
+    return "'" + value + "'";
+}
+
+void appendUniqueConfigSources( std::vector<std::string> &loadedFiles, const std::vector<std::string> &sources )
+{
+    for( const auto &source : sources )
+    {
+        if( source.empty() || source == "command line" )
+        {
+            continue;
+        }
+
+        if( std::find( loadedFiles.begin(), loadedFiles.end(), source ) == loadedFiles.end() )
+        {
+            loadedFiles.push_back( source );
+        }
+    }
+}
+
+std::vector<std::string> loadedConfigFiles( const mx::app::appConfigurator &config )
+{
+    std::vector<std::string> loadedFiles;
+
+    for( const auto &[name, target] : config.m_targets )
+    {
+        static_cast<void>( name );
+        appendUniqueConfigSources( loadedFiles, target.sources );
+    }
+
+    for( const auto &[name, target] : config.m_unusedConfigs )
+    {
+        static_cast<void>( name );
+        appendUniqueConfigSources( loadedFiles, target.sources );
+    }
+
+    return loadedFiles;
+}
+
+std::string joinConfigFiles( const std::vector<std::string> &files )
+{
+    if( files.empty() )
+    {
+        return "<none>";
+    }
+
+    std::string joined;
+
+    for( size_t n = 0; n < files.size(); ++n )
+    {
+        if( n > 0 )
+        {
+            joined += ", ";
+        }
+
+        joined += files[n];
+    }
+
+    return joined;
+}
+
+std::string configValueSource( const mx::app::appConfigurator &config, const std::string &name )
+{
+    auto targetIt = config.m_targets.find( name );
+    if( targetIt == config.m_targets.end() || !targetIt->second.set || targetIt->second.sources.empty() )
+    {
+        return "default";
+    }
+
+    return targetIt->second.sources.back();
 }
 
 struct rpcActivityGuard
@@ -91,6 +181,7 @@ rtimvServer::rtimvServer( int argc, char **argv, QObject *Parent ) : QObject( Pa
     }
 
     m_configPathCLBase_env = "RTIMV_CONFIG_PATH"; // Tells mx::application to look for this env var.
+    config.m_sources = true;
 
     setup( argc, argv );
 
@@ -231,6 +322,80 @@ void rtimvServer::loadConfig()
             m_logAppName = false;
         }
     }
+
+    rtimv::logContext serverCtx;
+    serverCtx.calledName = m_calledName;
+    serverCtx.includeAppName = m_logAppName;
+
+    std::string configPathEnvValue;
+    if( !m_configPathCLBase_env.empty() )
+    {
+        const char *envValue = std::getenv( m_configPathCLBase_env.c_str() );
+        if( envValue != nullptr )
+        {
+            configPathEnvValue = envValue;
+        }
+    }
+
+    const std::vector<std::string> configFiles = loadedConfigFiles( config );
+
+    std::string logAppNameSource = configValueSource( config, "log.appname" );
+    if( config.isSet( "no-log-appname" ) )
+    {
+        bool noLogAppName = false;
+        config( noLogAppName, "no-log-appname" );
+        if( noLogAppName )
+        {
+            logAppNameSource = configValueSource( config, "no-log-appname" );
+        }
+    }
+
+    std::cout << rtimv::formatLogMessage(
+                     serverCtx,
+                     std::format( "config env {}={}", m_configPathCLBase_env, quotedOrUnset( configPathEnvValue ) ) )
+              << '\n';
+
+    std::cout << rtimv::formatLogMessage( serverCtx,
+                                          std::format( "config paths: global={} user={} local={} command_line_base={} "
+                                                       "command_line={}",
+                                                       quotedOrUnset( m_configPathGlobal ),
+                                                       quotedOrUnset( m_configPathUser ),
+                                                       quotedOrUnset( m_configPathLocal ),
+                                                       quotedOrUnset( m_configPathCLBase ),
+                                                       quotedOrUnset( m_configPathCL ) ) )
+              << '\n';
+
+    std::cout << rtimv::formatLogMessage( serverCtx,
+                                          std::format( "loaded config files: {}", joinConfigFiles( configFiles ) ) )
+              << '\n';
+
+    std::cout << rtimv::formatLogMessage(
+                     serverCtx,
+                     std::format( "effective config: server.address={} ({}) server.port={} ({}) image.timeout={} ({}) "
+                                  "image.sleep={} ({})",
+                                  m_serverAddress,
+                                  configValueSource( config, "server.address" ),
+                                  m_port,
+                                  configValueSource( config, "server.port" ),
+                                  m_waitTimeout,
+                                  configValueSource( config, "image.timeout" ),
+                                  m_waitSleep,
+                                  configValueSource( config, "image.sleep" ) ) )
+              << '\n';
+
+    std::cout << rtimv::formatLogMessage(
+                     serverCtx,
+                     std::format( "effective config: client.sleep={} ({}) client.disconnect={} ({}) quality={} ({}) "
+                                  "log.appname={} ({})",
+                                  m_clientSleep,
+                                  configValueSource( config, "client.sleep" ),
+                                  m_clientDisconnect,
+                                  configValueSource( config, "client.disconnect" ),
+                                  m_qualityDefault,
+                                  configValueSource( config, "quality" ),
+                                  boolString( m_logAppName ),
+                                  logAppNameSource ) )
+              << '\n';
 }
 
 void rtimvServer::startServer()

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -1013,10 +1013,37 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
                                               const remote_rtimv::ImageRequest *request,
                                               remote_rtimv::Image *reply )
 {
-    PREPARE_RPC_REACTOR
     static_cast<void>( request );
 
-    imageTh->enqueueImageRequest( context, reactor, reply );
+    sharedLockT slock( m_clientMutex );
+
+    auto clientIt = m_clients.find( context->peer() );
+    if( clientIt == m_clients.end() )
+    {
+        ServerUnaryReactor *reactor = context->DefaultReactor();
+        reactor->Finish( grpc::Status( grpc::FAILED_PRECONDITION, "not configured" ) );
+        return reactor;
+    }
+
+    rtimvServerThread *imageTh = clientIt->second;
+    if( imageTh == nullptr )
+    {
+        ServerUnaryReactor *reactor = context->DefaultReactor();
+        reactor->Finish( grpc::Status( grpc::FAILED_PRECONDITION, "reconnect" ) );
+        return reactor;
+    }
+
+    imageTh->lastRequest( -1 );
+
+    if( imageTh->asleep() )
+    {
+        imageTh->emit_awaken();
+    }
+
+    imageTh->rpcBegin();
+    rpcActivityGuard rpcGuard( imageTh );
+
+    ServerUnaryReactor *reactor = imageTh->newImagePleaseReactor( reply );
 
     return reactor;
 }

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -119,6 +119,109 @@ std::string configValueSource( const mx::app::appConfigurator &config, const std
     return targetIt->second.sources.back();
 }
 
+std::string summarizeBaseConfigOverrides( const rtimvBase::startupConfig &settings,
+                                          const mx::app::appConfigurator &config )
+{
+    std::vector<std::string> parts;
+
+    auto addValue = [&]( const std::string &name, const std::string &value )
+    { parts.push_back( std::format( "{}={} ({})", name, value, configValueSource( config, name ) ) ); };
+
+    if( !settings.m_imageKeys[0].empty() )
+    {
+        addValue( "image.key", settings.m_imageKeys[0] );
+    }
+
+    if( !settings.m_imageKeys[1].empty() )
+    {
+        addValue( "dark.key", settings.m_imageKeys[1] );
+    }
+
+    if( !settings.m_imageKeys[2].empty() )
+    {
+        addValue( "mask.key", settings.m_imageKeys[2] );
+    }
+
+    if( !settings.m_imageKeys[3].empty() )
+    {
+        addValue( "satMask.key", settings.m_imageKeys[3] );
+    }
+
+    if( settings.m_updateTimeoutSet )
+    {
+        const auto updateTimeoutTarget = config.m_targets.find( "update.timeout" );
+        const bool updateTimeoutExplicit =
+            updateTimeoutTarget != config.m_targets.end() && updateTimeoutTarget->second.set;
+        const std::string timeoutSource = updateTimeoutExplicit ? configValueSource( config, "update.timeout" )
+                                                                : configValueSource( config, "update.fps" );
+        parts.push_back( std::format( "update.timeout={} ({})", settings.m_updateTimeout, timeoutSource ) );
+    }
+
+    if( settings.m_updateCubeFPSSet )
+    {
+        addValue( "update.cubeFPS", std::to_string( settings.m_updateCubeFPS ) );
+    }
+
+    if( settings.m_colorbarSet )
+    {
+        addValue( "colorbar", settings.m_colorbarName );
+    }
+
+    if( settings.m_autoscaleSet )
+    {
+        addValue( "autoscale", boolString( settings.m_autoscale ) );
+    }
+
+    if( settings.m_darkSubSet )
+    {
+        addValue( "darksub", boolString( settings.m_darkSub ) );
+    }
+
+    if( settings.m_satLevelSet )
+    {
+        addValue( "satLevel", std::to_string( settings.m_satLevel ) );
+    }
+
+    if( settings.m_maskSatSet )
+    {
+        addValue( "masksat", boolString( settings.m_maskSat ) );
+    }
+
+    if( settings.m_mzmqAlwaysSet )
+    {
+        addValue( "mzmq.always", boolString( settings.m_mzmqAlways ) );
+    }
+
+    if( settings.m_mzmqServerSet )
+    {
+        addValue( "mzmq.server", settings.m_mzmqServer );
+    }
+
+    if( settings.m_mzmqPortSet )
+    {
+        addValue( "mzmq.port", std::to_string( settings.m_mzmqPort ) );
+    }
+
+    if( parts.empty() )
+    {
+        return "<none>";
+    }
+
+    std::string summary;
+
+    for( size_t n = 0; n < parts.size(); ++n )
+    {
+        if( n > 0 )
+        {
+            summary += ", ";
+        }
+
+        summary += parts[n];
+    }
+
+    return summary;
+}
+
 struct rpcActivityGuard
 {
     rtimvServerThread *m_imageTh{ nullptr };
@@ -206,6 +309,8 @@ rtimvServer::~rtimvServer()
 
 void rtimvServer::setupConfig()
 {
+    rtimvBase::setupBaseConfig( config, false );
+
     config.add( "server.port",
                 "p",
                 "server.port",
@@ -275,30 +380,12 @@ void rtimvServer::setupConfig()
                 false,
                 "int",
                 "Default JPEG quality for served images when no per-image quality is configured." );
-
-    config.add( "log.appname",
-                "",
-                "log.appname",
-                mx::app::argType::Required,
-                "log",
-                "appname",
-                false,
-                "bool",
-                "Set true/false to include/exclude called-name in log prefixes." );
-
-    config.add( "no-log-appname",
-                "",
-                "no-log-appname",
-                mx::app::argType::True,
-                "log",
-                "no-appname",
-                false,
-                "bool",
-                "Disable called-name in log prefixes." );
 }
 
 void rtimvServer::loadConfig()
 {
+    rtimvBase::loadBaseConfig( m_baseConfigDefaults, config );
+
     config( m_port, "server.port" );
     config( m_serverAddress, "server.address" );
     config( m_waitTimeout, "image.timeout" );
@@ -308,19 +395,9 @@ void rtimvServer::loadConfig()
     config( m_qualityDefault, "quality" );
     m_qualityDefault = std::clamp( m_qualityDefault, 0, 100 );
 
-    if( config.isSet( "log.appname" ) )
+    if( m_baseConfigDefaults.m_logAppNameSet )
     {
-        config( m_logAppName, "log.appname" );
-    }
-
-    if( config.isSet( "no-log-appname" ) )
-    {
-        bool noLogAppName = false;
-        config( noLogAppName, "no-log-appname" );
-        if( noLogAppName )
-        {
-            m_logAppName = false;
-        }
+        m_logAppName = m_baseConfigDefaults.m_logAppName;
     }
 
     rtimv::logContext serverCtx;
@@ -395,6 +472,11 @@ void rtimvServer::loadConfig()
                                   configValueSource( config, "quality" ),
                                   boolString( m_logAppName ),
                                   logAppNameSource ) )
+              << '\n';
+
+    std::cout << rtimv::formatLogMessage( serverCtx,
+                                          std::format( "rtimvBase default overrides: {}",
+                                                       summarizeBaseConfigOverrides( m_baseConfigDefaults, config ) ) )
               << '\n';
 }
 
@@ -1240,6 +1322,8 @@ void rtimvServer::doConfigure( const configSpec *cspec )
         argv->push_back( "-c" );
         argv->push_back( cspec->m_config.file() );
     }
+
+    rtimvBase::appendBaseConfigArgs( *argv, m_baseConfigDefaults );
 
     if( cspec->m_config.image_key() != "" )
     {

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -1040,9 +1040,6 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
         imageTh->emit_awaken();
     }
 
-    imageTh->rpcBegin();
-    rpcActivityGuard rpcGuard( imageTh );
-
     ServerUnaryReactor *reactor = imageTh->newImagePleaseReactor( reply );
 
     return reactor;

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -549,7 +549,7 @@ ServerUnaryReactor *rtimvServer::SetImageTimeout( CallbackServerContext *context
     PREPARE_RPC_REACTOR
     static_cast<void>( reply );
 
-    imageTh->imageTimeout( request->timeout() );
+    imageTh->setImageTimeout( request->timeout() );
 
     reactor->Finish( Status::OK );
     return reactor;
@@ -750,13 +750,17 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
 
     int maxWaits;
 
+    const double waitTimeoutMs = std::max(
+        1000.0 * m_waitTimeout, static_cast<double>( imageTh->currImageTimeout() + std::max( m_waitSleep, 0 ) ) );
+
     if( m_waitSleep <= 0 ) // prevent an infinite busy
     {
         maxWaits = 1;
     }
     else
     {
-        maxWaits = m_waitTimeout / ( m_waitSleep / 1000. ) + 1;
+        // Keep the RPC wait window at least as long as the image thread's current cadence.
+        maxWaits = waitTimeoutMs / m_waitSleep + 1;
     }
 
     int nwaits = 0;

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -455,11 +455,14 @@ void rtimvServer::startServer()
             }
             else
             {
+                imageTh->prunePendingImageRequests( m_waitTimeout );
+
                 double slr = imageTh->sinceLastRequest();
+                size_t pendingRequests = imageTh->pendingImageRequests();
 
                 if( slr > m_clientDisconnect )
                 {
-                    if( imageTh->rpcActive() > 0 )
+                    if( imageTh->rpcActive() > 0 || pendingRequests > 0 )
                     {
                         ++client;
                         continue;
@@ -509,7 +512,7 @@ void rtimvServer::startServer()
                 }
                 else if( slr > m_clientSleep )
                 {
-                    if( !imageTh->asleep() )
+                    if( pendingRequests == 0 && !imageTh->asleep() )
                     {
                         imageTh->emit_gotosleep();
                         std::cout << rtimv::formatServerLogMessage( m_calledName,
@@ -931,126 +934,7 @@ ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
     PREPARE_RPC_REACTOR
     static_cast<void>( request );
 
-    // Check if image has been found
-    if( !imageTh->connected() )
-    {
-        reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
-        std::string *im = new std::string;
-        reply->set_allocated_image( im );
-
-        reactor->Finish( Status::OK );
-        return reactor;
-    }
-
-    int maxWaits;
-
-    const double waitTimeoutMs = std::max(
-        1000.0 * m_waitTimeout, static_cast<double>( imageTh->currImageTimeout() + std::max( m_waitSleep, 0 ) ) );
-
-    if( m_waitSleep <= 0 ) // prevent an infinite busy
-    {
-        maxWaits = 1;
-    }
-    else
-    {
-        // Keep the RPC wait window at least as long as the image thread's current cadence.
-        maxWaits = waitTimeoutMs / m_waitSleep + 1;
-    }
-
-    int nwaits = 0;
-    while( imageTh->newImage() == false && nwaits < maxWaits )
-    {
-        mx::sys::milliSleep( m_waitSleep );
-        ++nwaits;
-    }
-
-    auto populateImageState = [imageTh, reply]()
-    {
-        reply->set_nx( imageTh->nx() );
-        reply->set_ny( imageTh->ny() );
-        reply->set_nz( imageTh->nz() );
-        reply->set_no( imageTh->imageNo( 0 ) );
-
-        reply->set_atime( imageTh->imageTime() );
-        reply->set_fps( imageTh->fpsEst() );
-
-        reply->set_saturated( imageTh->saturated() );
-
-        reply->set_min_image_data( imageTh->minImageData() );
-        reply->set_max_image_data( imageTh->maxImageData() );
-        reply->set_min_scale_data( imageTh->minScaleData() );
-        reply->set_max_scale_data( imageTh->maxScaleData() );
-        reply->set_source_bytes_per_pixel( imageTh->bytesPerPixel( 0 ) );
-
-        reply->set_colorbar( rtimv::colorbar2grpc( imageTh->colorbar() ) );
-
-        reply->set_colormode( rtimv::colormode2grpc( imageTh->colormode() ) );
-
-        reply->set_colorstretch( rtimv::stretch2grpc( imageTh->stretch() ) );
-
-        reply->set_autoscale( imageTh->autoScale() );
-
-        reply->set_subtract_dark( imageTh->subtractDark() );
-        reply->set_apply_mask( imageTh->applyMask() );
-        reply->set_apply_sat_mask( imageTh->applySatMask() );
-
-        reply->set_image_timeout( imageTh->imageTimeout() );
-        reply->set_cube_dir( imageTh->cubeDir() );
-        reply->set_quality( imageTh->quality() );
-
-        reply->set_hp_filter( rtimv::hpFilter2grpc( imageTh->hpFilter() ) );
-        reply->set_hpf_fw( imageTh->hpfFW() );
-        reply->set_apply_hp_filter( imageTh->applyHPFilter() );
-
-        reply->set_lp_filter( rtimv::lpFilter2grpc( imageTh->lpFilter() ) );
-        reply->set_lpf_fw( imageTh->lpfFW() );
-        reply->set_apply_lp_filter( imageTh->applyLPFilter() );
-
-        reply->set_stats_box( imageTh->statsBox() );
-        reply->set_stats_box_i0( imageTh->statsBox_i0() );
-        reply->set_stats_box_i1( imageTh->statsBox_i1() );
-        reply->set_stats_box_j0( imageTh->statsBox_j0() );
-        reply->set_stats_box_j1( imageTh->statsBox_j1() );
-        reply->set_stats_box_min( imageTh->statsBox_min() );
-        reply->set_stats_box_max( imageTh->statsBox_max() );
-        reply->set_stats_box_mean( imageTh->statsBox_mean() );
-        reply->set_stats_box_median( imageTh->statsBox_median() );
-
-        reply->set_color_box( imageTh->colormode() == rtimv::colormode::minmaxbox );
-        reply->set_color_box_i0( imageTh->colorBox_i0() );
-        reply->set_color_box_i1( imageTh->colorBox_i1() );
-        reply->set_color_box_j0( imageTh->colorBox_j0() );
-        reply->set_color_box_j1( imageTh->colorBox_j1() );
-        reply->set_color_box_min( imageTh->colorBox_min() );
-        reply->set_color_box_max( imageTh->colorBox_max() );
-    };
-
-    if( imageTh->newImage() == false )
-    {
-        reply->set_status( remote_rtimv::IMAGE_STATUS_TIMEOUT );
-        populateImageState();
-        std::string *im = new std::string;
-        reply->set_allocated_image( im );
-
-        imageTh->lastRequest( -1 ); // sets to now, again b/c of wait
-
-        reactor->Finish( Status::OK );
-        return reactor;
-    }
-
-    // Now we can render the latest image and send it
-    std::string *im = new std::string;
-
-    imageTh->mtxuL_render( im );
-
-    imageTh->lastRequest( -1 ); // sets to now, again b/c of wait
-
-    reply->set_status( remote_rtimv::IMAGE_STATUS_VALID );
-    populateImageState();
-
-    reply->set_allocated_image( im );
-
-    reactor->Finish( Status::OK );
+    imageTh->enqueueImageRequest( context, reactor, reply );
 
     return reactor;
 }

--- a/src/server/rtimvServer.cpp
+++ b/src/server/rtimvServer.cpp
@@ -895,6 +895,35 @@ ServerUnaryReactor *rtimvServer::SetApplyLPFilter( CallbackServerContext *contex
     return reactor;
 }
 
+ServerUnaryReactor *rtimvServer::Ping( CallbackServerContext *context,
+                                       const remote_rtimv::PingRequest *request,
+                                       remote_rtimv::PingResponse *reply )
+{
+    static_cast<void>( request );
+    static_cast<void>( reply );
+
+    ServerUnaryReactor *reactor = context->DefaultReactor();
+
+    sharedLockT slock( m_clientMutex );
+
+    auto clientIt = m_clients.find( context->peer() );
+    if( clientIt == m_clients.end() )
+    {
+        reactor->Finish( grpc::Status( grpc::FAILED_PRECONDITION, "not configured" ) );
+        return reactor;
+    }
+
+    rtimvServerThread *imageTh = clientIt->second;
+    if( imageTh == nullptr )
+    {
+        reactor->Finish( grpc::Status( grpc::FAILED_PRECONDITION, "reconnect" ) );
+        return reactor;
+    }
+
+    reactor->Finish( Status::OK );
+    return reactor;
+}
+
 ServerUnaryReactor *rtimvServer::ImagePlease( CallbackServerContext *context,
                                               const remote_rtimv::ImageRequest *request,
                                               remote_rtimv::Image *reply )

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -183,6 +183,11 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
                                           const remote_rtimv::ApplyFilterRequest *request,
                                           remote_rtimv::ApplyFilterResponse *reply ) override;
 
+    /// Respond to a client reachability ping without waking the image thread.
+    ServerUnaryReactor *Ping( CallbackServerContext *context,
+                              const remote_rtimv::PingRequest *request,
+                              remote_rtimv::PingResponse *reply ) override;
+
     ServerUnaryReactor *ImagePlease( CallbackServerContext *context,
                                      const remote_rtimv::ImageRequest *request,
                                      remote_rtimv::Image *reply ) override;

--- a/src/server/rtimvServer.hpp
+++ b/src/server/rtimvServer.hpp
@@ -64,6 +64,9 @@ class rtimvServer : public QObject, public mx::app::application, public remote_r
 
     int m_qualityDefault{ 50 }; ///< Default JPEG quality for new image threads when no per-image value is configured.
 
+    /// Shared rtimvBase-compatible startup defaults loaded from the server config.
+    rtimvBase::startupConfig m_baseConfigDefaults;
+
     bool m_logAppName{ true }; ///< True to include called-name in log prefixes.
 
     std::string m_calledName{ "rtimvServer" }; ///< Program called-name used in standardized log prefixes.

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -7,6 +7,8 @@
 
 #include "rtimvServerThread.hpp"
 #include "rtimvLog.hpp"
+#include "rtimvColorGRPC.hpp"
+#include "rtimvFilterGRPC.hpp"
 
 #include <QBuffer>
 #include <QMetaObject>
@@ -47,6 +49,7 @@ rtimvServerThread::rtimvServerThread( const std::string &uri,
 
     connect( this, SIGNAL( gotosleep() ), this, SLOT( sleep() ) );
     connect( this, SIGNAL( awaken() ), this, SLOT( wakeup() ) );
+    connect( this, SIGNAL( servicePending() ), this, SLOT( servicePendingImageRequests() ), Qt::QueuedConnection );
 
     lastRequest( -1 ); // set to now
 
@@ -169,14 +172,14 @@ void rtimvServerThread::mtxL_postRecolor( const uniqueLockT &lock )
 {
     static_cast<void>( lock );
 
-    m_newImage = true;
+    markResponseDirty();
 }
 
 void rtimvServerThread::mtxL_postRecolor( const sharedLockT &lock )
 {
     static_cast<void>( lock );
 
-    m_newImage = true;
+    markResponseDirty();
 }
 
 void rtimvServerThread::mtxL_postChangeImdata( const sharedLockT &lock )
@@ -203,13 +206,6 @@ void rtimvServerThread::mtxuL_render( std::string *image )
     m_qim->save( &buffer, "jpeg", m_quality.load( std::memory_order_relaxed ) );
 
     *image = renderedImage.toStdString();
-
-    m_newImage.store( false, std::memory_order_relaxed );
-}
-
-bool rtimvServerThread::newImage()
-{
-    return m_newImage.load( std::memory_order_relaxed );
 }
 
 void rtimvServerThread::setImageTimeout( int to )
@@ -248,7 +244,7 @@ void rtimvServerThread::quality( int q )
 
     if( oldQ != q )
     {
-        m_newImage.store( true, std::memory_order_relaxed );
+        markResponseDirty();
     }
 }
 
@@ -292,6 +288,253 @@ void rtimvServerThread::rpcEnd()
 uint32_t rtimvServerThread::rpcActive()
 {
     return m_activeRpc.load( std::memory_order_relaxed );
+}
+
+void rtimvServerThread::enqueueImageRequest( grpc::CallbackServerContext *context,
+                                             grpc::ServerUnaryReactor *reactor,
+                                             remote_rtimv::Image *reply )
+{
+    if( !connected() )
+    {
+        if( reply != nullptr )
+        {
+            reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
+            std::string *image = new std::string;
+            reply->set_allocated_image( image );
+        }
+
+        if( reactor != nullptr )
+        {
+            reactor->Finish( grpc::Status::OK );
+        }
+
+        return;
+    }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_pendingImageMutex );
+
+        pendingImageRequest request;
+        request.m_context = context;
+        request.m_reactor = reactor;
+        request.m_reply = reply;
+        request.m_enqueueTime = mx::sys::get_curr_time();
+
+        m_pendingImageRequests.push_back( request );
+    }
+
+    schedulePendingImageService();
+}
+
+void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
+{
+    std::deque<pendingImageRequest> timedOutRequests;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_pendingImageMutex );
+
+        const double now = mx::sys::get_curr_time();
+        auto requestIt = m_pendingImageRequests.begin();
+        while( requestIt != m_pendingImageRequests.end() )
+        {
+            if( requestIt->m_context != nullptr && requestIt->m_context->IsCancelled() )
+            {
+                requestIt = m_pendingImageRequests.erase( requestIt );
+                continue;
+            }
+
+            if( timeoutSeconds > 0 && now - requestIt->m_enqueueTime > timeoutSeconds )
+            {
+                timedOutRequests.push_back( *requestIt );
+                requestIt = m_pendingImageRequests.erase( requestIt );
+                continue;
+            }
+
+            ++requestIt;
+        }
+    }
+
+    for( auto &request : timedOutRequests )
+    {
+        if( request.m_reply == nullptr || request.m_reactor == nullptr )
+        {
+            continue;
+        }
+
+        std::string *image = new std::string;
+        request.m_reply->set_allocated_image( image );
+
+        if( connected() )
+        {
+            request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_TIMEOUT );
+            populateImageReply( request.m_reply );
+        }
+        else
+        {
+            request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
+        }
+
+        request.m_reactor->Finish( grpc::Status::OK );
+    }
+}
+
+size_t rtimvServerThread::pendingImageRequests()
+{
+    std::lock_guard<std::mutex> lock( m_pendingImageMutex );
+    return m_pendingImageRequests.size();
+}
+
+void rtimvServerThread::servicePendingImageRequests()
+{
+    m_servicePendingScheduled.store( false, std::memory_order_relaxed );
+
+    pendingImageRequest request;
+    bool haveRequest{ false };
+
+    prunePendingImageRequests( 0 );
+
+    if( !connected() || !m_responseDirty.load( std::memory_order_relaxed ) )
+    {
+        return;
+    }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_pendingImageMutex );
+
+        if( !m_pendingImageRequests.empty() )
+        {
+            request = m_pendingImageRequests.front();
+            m_pendingImageRequests.pop_front();
+            haveRequest = true;
+        }
+    }
+
+    if( !haveRequest )
+    {
+        return;
+    }
+
+    if( request.m_context != nullptr && request.m_context->IsCancelled() )
+    {
+        schedulePendingImageService();
+        return;
+    }
+
+    const uint64_t deliverSerial = m_responseSerial.load( std::memory_order_relaxed );
+
+    std::string *image = new std::string;
+    mtxuL_render( image );
+
+    if( request.m_reply != nullptr )
+    {
+        request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_VALID );
+        request.m_reply->set_response_serial( deliverSerial );
+        populateImageReply( request.m_reply );
+        request.m_reply->set_allocated_image( image );
+    }
+    else
+    {
+        delete image;
+    }
+
+    if( request.m_reactor != nullptr )
+    {
+        request.m_reactor->Finish( grpc::Status::OK );
+    }
+
+    if( m_responseSerial.load( std::memory_order_relaxed ) == deliverSerial )
+    {
+        m_responseDirty.store( false, std::memory_order_relaxed );
+    }
+
+    lastRequest( -1 );
+
+    if( m_responseDirty.load( std::memory_order_relaxed ) && pendingImageRequests() > 0 )
+    {
+        schedulePendingImageService();
+    }
+}
+
+void rtimvServerThread::markResponseDirty()
+{
+    m_responseSerial.fetch_add( 1, std::memory_order_relaxed );
+    m_responseDirty.store( true, std::memory_order_relaxed );
+
+    schedulePendingImageService();
+}
+
+void rtimvServerThread::populateImageReply( remote_rtimv::Image *reply )
+{
+    if( reply == nullptr )
+    {
+        return;
+    }
+
+    reply->set_nx( nx() );
+    reply->set_ny( ny() );
+    reply->set_nz( nz() );
+    reply->set_no( imageNo( 0 ) );
+
+    reply->set_atime( imageTime() );
+    reply->set_fps( fpsEst() );
+
+    reply->set_saturated( saturated() );
+
+    reply->set_min_image_data( minImageData() );
+    reply->set_max_image_data( maxImageData() );
+    reply->set_min_scale_data( minScaleData() );
+    reply->set_max_scale_data( maxScaleData() );
+    reply->set_source_bytes_per_pixel( bytesPerPixel( 0 ) );
+
+    reply->set_colorbar( rtimv::colorbar2grpc( colorbar() ) );
+    reply->set_colormode( rtimv::colormode2grpc( colormode() ) );
+    reply->set_colorstretch( rtimv::stretch2grpc( stretch() ) );
+
+    reply->set_autoscale( autoScale() );
+
+    reply->set_subtract_dark( subtractDark() );
+    reply->set_apply_mask( applyMask() );
+    reply->set_apply_sat_mask( applySatMask() );
+
+    reply->set_image_timeout( imageTimeout() );
+    reply->set_cube_dir( cubeDir() );
+    reply->set_quality( quality() );
+
+    reply->set_hp_filter( rtimv::hpFilter2grpc( hpFilter() ) );
+    reply->set_hpf_fw( hpfFW() );
+    reply->set_apply_hp_filter( applyHPFilter() );
+
+    reply->set_lp_filter( rtimv::lpFilter2grpc( lpFilter() ) );
+    reply->set_lpf_fw( lpfFW() );
+    reply->set_apply_lp_filter( applyLPFilter() );
+
+    reply->set_stats_box( statsBox() );
+    reply->set_stats_box_i0( statsBox_i0() );
+    reply->set_stats_box_i1( statsBox_i1() );
+    reply->set_stats_box_j0( statsBox_j0() );
+    reply->set_stats_box_j1( statsBox_j1() );
+    reply->set_stats_box_min( statsBox_min() );
+    reply->set_stats_box_max( statsBox_max() );
+    reply->set_stats_box_mean( statsBox_mean() );
+    reply->set_stats_box_median( statsBox_median() );
+
+    reply->set_color_box( colormode() == rtimv::colormode::minmaxbox );
+    reply->set_color_box_i0( colorBox_i0() );
+    reply->set_color_box_i1( colorBox_i1() );
+    reply->set_color_box_j0( colorBox_j0() );
+    reply->set_color_box_j1( colorBox_j1() );
+    reply->set_color_box_min( colorBox_min() );
+    reply->set_color_box_max( colorBox_max() );
+}
+
+void rtimvServerThread::schedulePendingImageService()
+{
+    if( m_servicePendingScheduled.exchange( true, std::memory_order_relaxed ) )
+    {
+        return;
+    }
+
+    emit servicePending();
 }
 
 void rtimvServerThread::emit_gotosleep()

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -51,28 +51,11 @@ class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
         }
     }
 
-    /// Finish the unary RPC exactly once.
-    void finish( const grpc::Status &status /**< [in] final RPC status */ )
-    {
-        if( !m_request )
-        {
-            return;
-        }
-
-        if( m_request->m_finished.exchange( true, std::memory_order_acq_rel ) )
-        {
-            return;
-        }
-
-        Finish( status );
-    }
-
   private:
     void OnDone() override
     {
         if( m_request )
         {
-            m_request->m_reactor = nullptr;
             m_request->m_done.store( true, std::memory_order_release );
         }
 
@@ -96,6 +79,22 @@ class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
 
     std::shared_ptr<pendingImageRequest> m_request; ///< Shared request state tracked across cancel/done reactions.
 };
+
+bool rtimvServerThread::pendingImageRequest::finish( const grpc::Status &status )
+{
+    if( m_finished.exchange( true, std::memory_order_acq_rel ) )
+    {
+        return false;
+    }
+
+    if( m_reactor == nullptr )
+    {
+        return false;
+    }
+
+    m_reactor->Finish( status );
+    return true;
+}
 
 rtimvServerThread::rtimvServerThread( const std::string &uri,
                                       std::shared_ptr<std::vector<std::string>> argv,
@@ -384,7 +383,7 @@ void rtimvServerThread::enqueueImageRequest( std::shared_ptr<pendingImageRequest
 
         if( request->m_reactor != nullptr )
         {
-            request->m_reactor->finish( grpc::Status::OK );
+            request->finish( grpc::Status::OK );
         }
 
         return;
@@ -442,18 +441,17 @@ void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
 
     for( auto &request : cancelledRequests )
     {
-        if( !request || request->m_reactor == nullptr || request->m_done.load( std::memory_order_acquire ) )
+        if( !request || request->m_done.load( std::memory_order_acquire ) )
         {
             continue;
         }
 
-        request->m_reactor->finish( grpc::Status::OK );
+        request->finish( grpc::Status::OK );
     }
 
     for( auto &request : timedOutRequests )
     {
-        if( !request || request->m_reply == nullptr || request->m_reactor == nullptr ||
-            request->m_done.load( std::memory_order_acquire ) )
+        if( !request || request->m_reply == nullptr || request->m_done.load( std::memory_order_acquire ) )
         {
             continue;
         }
@@ -471,7 +469,7 @@ void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
             request->m_reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
         }
 
-        request->m_reactor->finish( grpc::Status::OK );
+        request->finish( grpc::Status::OK );
     }
 }
 
@@ -517,10 +515,7 @@ void rtimvServerThread::servicePendingImageRequests()
 
     if( request->m_cancelled.load( std::memory_order_acquire ) )
     {
-        if( request->m_reactor != nullptr )
-        {
-            request->m_reactor->finish( grpc::Status::OK );
-        }
+        request->finish( grpc::Status::OK );
 
         schedulePendingImageService();
         return;
@@ -543,10 +538,7 @@ void rtimvServerThread::servicePendingImageRequests()
         delete image;
     }
 
-    if( request->m_reactor != nullptr )
-    {
-        request->m_reactor->finish( grpc::Status::OK );
-    }
+    request->finish( grpc::Status::OK );
 
     if( m_responseSerial.load( std::memory_order_relaxed ) == deliverSerial )
     {

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -37,8 +37,14 @@ std::string image0OrUnknown( rtimvServerThread *imageTh )
 class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
 {
   public:
-    explicit pendingImageReactor( std::shared_ptr<pendingImageRequest> request ) : m_request( std::move( request ) )
+    pendingImageReactor( rtimvServerThread *imageTh, std::shared_ptr<pendingImageRequest> request )
+        : m_imageTh( imageTh ), m_request( std::move( request ) )
     {
+        if( m_imageTh )
+        {
+            m_imageTh->rpcBegin();
+        }
+
         if( m_request )
         {
             m_request->m_reactor = this;
@@ -70,6 +76,11 @@ class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
             m_request->m_done.store( true, std::memory_order_release );
         }
 
+        if( m_imageTh )
+        {
+            m_imageTh->rpcEnd();
+        }
+
         delete this;
     }
 
@@ -80,6 +91,8 @@ class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
             m_request->m_cancelled.store( true, std::memory_order_release );
         }
     }
+
+    rtimvServerThread *m_imageTh{ nullptr }; ///< Owning server thread used to track active reactor lifetimes.
 
     std::shared_ptr<pendingImageRequest> m_request; ///< Shared request state tracked across cancel/done reactions.
 };
@@ -346,7 +359,7 @@ grpc::ServerUnaryReactor *rtimvServerThread::newImagePleaseReactor( remote_rtimv
     request->m_reply = reply;
     request->m_enqueueTime = mx::sys::get_curr_time();
 
-    auto *reactor = new pendingImageReactor( request );
+    auto *reactor = new pendingImageReactor( this, request );
 
     enqueueImageRequest( request );
 

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -9,6 +9,7 @@
 #include "rtimvLog.hpp"
 
 #include <QBuffer>
+#include <QMetaObject>
 #include <algorithm>
 
 namespace
@@ -209,6 +210,22 @@ void rtimvServerThread::mtxuL_render( std::string *image )
 bool rtimvServerThread::newImage()
 {
     return m_newImage.load( std::memory_order_relaxed );
+}
+
+void rtimvServerThread::setImageTimeout( int to )
+{
+    if( m_foundation == nullptr )
+    {
+        return;
+    }
+
+    if( QThread::currentThread() == m_foundation->thread() )
+    {
+        m_foundation->imageTimeout( to );
+        return;
+    }
+
+    QMetaObject::invokeMethod( m_foundation, "imageTimeout", Qt::BlockingQueuedConnection, Q_ARG( int, to ) );
 }
 
 int rtimvServerThread::quality()

--- a/src/server/rtimvServerThread.cpp
+++ b/src/server/rtimvServerThread.cpp
@@ -34,6 +34,56 @@ std::string image0OrUnknown( rtimvServerThread *imageTh )
 
 } // namespace
 
+class rtimvServerThread::pendingImageReactor : public grpc::ServerUnaryReactor
+{
+  public:
+    explicit pendingImageReactor( std::shared_ptr<pendingImageRequest> request ) : m_request( std::move( request ) )
+    {
+        if( m_request )
+        {
+            m_request->m_reactor = this;
+        }
+    }
+
+    /// Finish the unary RPC exactly once.
+    void finish( const grpc::Status &status /**< [in] final RPC status */ )
+    {
+        if( !m_request )
+        {
+            return;
+        }
+
+        if( m_request->m_finished.exchange( true, std::memory_order_acq_rel ) )
+        {
+            return;
+        }
+
+        Finish( status );
+    }
+
+  private:
+    void OnDone() override
+    {
+        if( m_request )
+        {
+            m_request->m_reactor = nullptr;
+            m_request->m_done.store( true, std::memory_order_release );
+        }
+
+        delete this;
+    }
+
+    void OnCancel() override
+    {
+        if( m_request )
+        {
+            m_request->m_cancelled.store( true, std::memory_order_release );
+        }
+    }
+
+    std::shared_ptr<pendingImageRequest> m_request; ///< Shared request state tracked across cancel/done reactions.
+};
+
 rtimvServerThread::rtimvServerThread( const std::string &uri,
                                       std::shared_ptr<std::vector<std::string>> argv,
                                       int defaultQuality,
@@ -290,22 +340,38 @@ uint32_t rtimvServerThread::rpcActive()
     return m_activeRpc.load( std::memory_order_relaxed );
 }
 
-void rtimvServerThread::enqueueImageRequest( grpc::CallbackServerContext *context,
-                                             grpc::ServerUnaryReactor *reactor,
-                                             remote_rtimv::Image *reply )
+grpc::ServerUnaryReactor *rtimvServerThread::newImagePleaseReactor( remote_rtimv::Image *reply )
 {
+    std::shared_ptr<pendingImageRequest> request = std::make_shared<pendingImageRequest>();
+    request->m_reply = reply;
+    request->m_enqueueTime = mx::sys::get_curr_time();
+
+    auto *reactor = new pendingImageReactor( request );
+
+    enqueueImageRequest( request );
+
+    return reactor;
+}
+
+void rtimvServerThread::enqueueImageRequest( std::shared_ptr<pendingImageRequest> request )
+{
+    if( !request )
+    {
+        return;
+    }
+
     if( !connected() )
     {
-        if( reply != nullptr )
+        if( request->m_reply != nullptr )
         {
-            reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
+            request->m_reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
             std::string *image = new std::string;
-            reply->set_allocated_image( image );
+            request->m_reply->set_allocated_image( image );
         }
 
-        if( reactor != nullptr )
+        if( request->m_reactor != nullptr )
         {
-            reactor->Finish( grpc::Status::OK );
+            request->m_reactor->finish( grpc::Status::OK );
         }
 
         return;
@@ -313,14 +379,7 @@ void rtimvServerThread::enqueueImageRequest( grpc::CallbackServerContext *contex
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_pendingImageMutex );
-
-        pendingImageRequest request;
-        request.m_context = context;
-        request.m_reactor = reactor;
-        request.m_reply = reply;
-        request.m_enqueueTime = mx::sys::get_curr_time();
-
-        m_pendingImageRequests.push_back( request );
+        m_pendingImageRequests.push_back( std::move( request ) );
     }
 
     schedulePendingImageService();
@@ -328,7 +387,8 @@ void rtimvServerThread::enqueueImageRequest( grpc::CallbackServerContext *contex
 
 void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
 {
-    std::deque<pendingImageRequest> timedOutRequests;
+    std::deque<std::shared_ptr<pendingImageRequest>> cancelledRequests;
+    std::deque<std::shared_ptr<pendingImageRequest>> timedOutRequests;
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_pendingImageMutex );
@@ -337,13 +397,26 @@ void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
         auto requestIt = m_pendingImageRequests.begin();
         while( requestIt != m_pendingImageRequests.end() )
         {
-            if( requestIt->m_context != nullptr && requestIt->m_context->IsCancelled() )
+            if( !( *requestIt ) )
             {
                 requestIt = m_pendingImageRequests.erase( requestIt );
                 continue;
             }
 
-            if( timeoutSeconds > 0 && now - requestIt->m_enqueueTime > timeoutSeconds )
+            if( ( *requestIt )->m_done.load( std::memory_order_acquire ) )
+            {
+                requestIt = m_pendingImageRequests.erase( requestIt );
+                continue;
+            }
+
+            if( ( *requestIt )->m_cancelled.load( std::memory_order_acquire ) )
+            {
+                cancelledRequests.push_back( *requestIt );
+                requestIt = m_pendingImageRequests.erase( requestIt );
+                continue;
+            }
+
+            if( timeoutSeconds > 0 && now - ( *requestIt )->m_enqueueTime > timeoutSeconds )
             {
                 timedOutRequests.push_back( *requestIt );
                 requestIt = m_pendingImageRequests.erase( requestIt );
@@ -354,27 +427,38 @@ void rtimvServerThread::prunePendingImageRequests( double timeoutSeconds )
         }
     }
 
+    for( auto &request : cancelledRequests )
+    {
+        if( !request || request->m_reactor == nullptr || request->m_done.load( std::memory_order_acquire ) )
+        {
+            continue;
+        }
+
+        request->m_reactor->finish( grpc::Status::OK );
+    }
+
     for( auto &request : timedOutRequests )
     {
-        if( request.m_reply == nullptr || request.m_reactor == nullptr )
+        if( !request || request->m_reply == nullptr || request->m_reactor == nullptr ||
+            request->m_done.load( std::memory_order_acquire ) )
         {
             continue;
         }
 
         std::string *image = new std::string;
-        request.m_reply->set_allocated_image( image );
+        request->m_reply->set_allocated_image( image );
 
         if( connected() )
         {
-            request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_TIMEOUT );
-            populateImageReply( request.m_reply );
+            request->m_reply->set_status( remote_rtimv::IMAGE_STATUS_TIMEOUT );
+            populateImageReply( request->m_reply );
         }
         else
         {
-            request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
+            request->m_reply->set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
         }
 
-        request.m_reactor->Finish( grpc::Status::OK );
+        request->m_reactor->finish( grpc::Status::OK );
     }
 }
 
@@ -388,8 +472,7 @@ void rtimvServerThread::servicePendingImageRequests()
 {
     m_servicePendingScheduled.store( false, std::memory_order_relaxed );
 
-    pendingImageRequest request;
-    bool haveRequest{ false };
+    std::shared_ptr<pendingImageRequest> request;
 
     prunePendingImageRequests( 0 );
 
@@ -405,17 +488,27 @@ void rtimvServerThread::servicePendingImageRequests()
         {
             request = m_pendingImageRequests.front();
             m_pendingImageRequests.pop_front();
-            haveRequest = true;
         }
     }
 
-    if( !haveRequest )
+    if( !request )
     {
         return;
     }
 
-    if( request.m_context != nullptr && request.m_context->IsCancelled() )
+    if( request->m_done.load( std::memory_order_acquire ) )
     {
+        schedulePendingImageService();
+        return;
+    }
+
+    if( request->m_cancelled.load( std::memory_order_acquire ) )
+    {
+        if( request->m_reactor != nullptr )
+        {
+            request->m_reactor->finish( grpc::Status::OK );
+        }
+
         schedulePendingImageService();
         return;
     }
@@ -425,21 +518,21 @@ void rtimvServerThread::servicePendingImageRequests()
     std::string *image = new std::string;
     mtxuL_render( image );
 
-    if( request.m_reply != nullptr )
+    if( request->m_reply != nullptr )
     {
-        request.m_reply->set_status( remote_rtimv::IMAGE_STATUS_VALID );
-        request.m_reply->set_response_serial( deliverSerial );
-        populateImageReply( request.m_reply );
-        request.m_reply->set_allocated_image( image );
+        request->m_reply->set_status( remote_rtimv::IMAGE_STATUS_VALID );
+        request->m_reply->set_response_serial( deliverSerial );
+        populateImageReply( request->m_reply );
+        request->m_reply->set_allocated_image( image );
     }
     else
     {
         delete image;
     }
 
-    if( request.m_reactor != nullptr )
+    if( request->m_reactor != nullptr )
     {
-        request.m_reactor->Finish( grpc::Status::OK );
+        request->m_reactor->finish( grpc::Status::OK );
     }
 
     if( m_responseSerial.load( std::memory_order_relaxed ) == deliverSerial )

--- a/src/server/rtimvServerThread.hpp
+++ b/src/server/rtimvServerThread.hpp
@@ -86,6 +86,9 @@ class rtimvServerThread : public QThread, public rtimvBase
         std::atomic<bool> m_done{ false }; ///< True once gRPC has fully completed this request.
 
         std::atomic<bool> m_finished{ false }; ///< True once Finish has been issued for this request.
+
+        /// Attempt to finish this request exactly once.
+        bool finish( const grpc::Status &status /**< [in] final RPC status */ );
     };
 
     /// Mutex guarding the pending ImagePlease queue.

--- a/src/server/rtimvServerThread.hpp
+++ b/src/server/rtimvServerThread.hpp
@@ -18,6 +18,7 @@
 #include <mx/app/application.hpp>
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <mutex>
 
 #include "rtimv.grpc.pb.h"
@@ -68,23 +69,30 @@ class rtimvServerThread : public QThread, public rtimvBase
     /// True while a queued pending-image service pass is already scheduled.
     std::atomic<bool> m_servicePendingScheduled{ false };
 
+    /// Custom unary reactor used for queued ImagePlease replies.
+    class pendingImageReactor;
+
     /// One queued ImagePlease request waiting for the next deliverable response.
     struct pendingImageRequest
     {
-        grpc::CallbackServerContext *m_context{ nullptr }; ///< gRPC callback context used to detect cancellation.
-
-        grpc::ServerUnaryReactor *m_reactor{ nullptr }; ///< Reactor finished when this pending request is served.
+        pendingImageReactor *m_reactor{ nullptr }; ///< Custom reactor finished when this pending request is served.
 
         remote_rtimv::Image *m_reply{ nullptr }; ///< Reply payload populated when the request is fulfilled.
 
         double m_enqueueTime{ 0 }; ///< Monotonic enqueue time in seconds for timeout accounting.
+
+        std::atomic<bool> m_cancelled{ false }; ///< True once gRPC reports client-side cancellation for this request.
+
+        std::atomic<bool> m_done{ false }; ///< True once gRPC has fully completed this request.
+
+        std::atomic<bool> m_finished{ false }; ///< True once Finish has been issued for this request.
     };
 
     /// Mutex guarding the pending ImagePlease queue.
     std::mutex m_pendingImageMutex;
 
     /// FIFO queue of pending ImagePlease requests representing client-side credits.
-    std::deque<pendingImageRequest> m_pendingImageRequests;
+    std::deque<std::shared_ptr<pendingImageRequest>> m_pendingImageRequests;
 
     /// Mark the current rendered response dirty and advance the response serial.
     void markResponseDirty();
@@ -165,11 +173,12 @@ class rtimvServerThread : public QThread, public rtimvBase
     uint32_t rpcActive();
 
     /// Queue one pending ImagePlease request for the next deliverable response.
-    void
-    enqueueImageRequest( grpc::CallbackServerContext *context, /**< [in] callback context for cancellation checks */
-                         grpc::ServerUnaryReactor *reactor,    /**< [in] reactor finished when a response is ready */
-                         remote_rtimv::Image *reply            /**< [in] reply payload owned by gRPC */
+    void enqueueImageRequest( std::shared_ptr<pendingImageRequest> request /**< [in] pending request to enqueue */
     );
+
+    /// Create and enqueue a custom unary reactor for one ImagePlease request.
+    grpc::ServerUnaryReactor *
+    newImagePleaseReactor( remote_rtimv::Image *reply /**< [in] reply payload owned by gRPC */ );
 
     /// Drop cancelled pending requests and expire old ones.
     void prunePendingImageRequests( double timeoutSeconds /**< [in] timeout applied to queued requests in seconds */ );

--- a/src/server/rtimvServerThread.hpp
+++ b/src/server/rtimvServerThread.hpp
@@ -102,6 +102,9 @@ class rtimvServerThread : public QThread, public rtimvBase
 
     bool newImage();
 
+    /// Apply a new minimum image timeout on the Qt event thread.
+    void setImageTimeout( int to /**< [in] the new minimum image timeout in ms */ );
+
     int quality();
 
     void quality( int q );

--- a/src/server/rtimvServerThread.hpp
+++ b/src/server/rtimvServerThread.hpp
@@ -10,11 +10,17 @@
 
 #include "rtimvBase.hpp"
 
+#include <grpcpp/grpcpp.h>
+
 #include <QThread>
 #include <QByteArray>
 
 #include <mx/app/application.hpp>
 #include <atomic>
+#include <deque>
+#include <mutex>
+
+#include "rtimv.grpc.pb.h"
 
 using namespace mx::app;
 
@@ -39,8 +45,6 @@ class rtimvServerThread : public QThread, public rtimvBase
     /// True when startup JPEG quality was explicitly configured.
     bool m_startupQualitySet{ false };
 
-    std::atomic<bool> m_newImage{ false }; ///< Flag indicating a new image is ready after the last render.
-
     std::atomic<int> m_quality{ 50 }; ///< The JPEG quality factor (0-100).  Default is 50.
 
     std::atomic<double> m_lastRequest{ 0 }; ///< The time of the last request for an image
@@ -54,6 +58,42 @@ class rtimvServerThread : public QThread, public rtimvBase
     std::string m_calledName{ "rtimvServer" }; ///< Program called-name used in standardized log prefixes.
 
     bool m_includeAppName{ true }; ///< True to include called-name in log prefixes.
+
+    /// True when a newer response than the last delivered reply is ready to send.
+    std::atomic<bool> m_responseDirty{ false };
+
+    /// Monotonic serial assigned to each newly renderable response state.
+    std::atomic<uint64_t> m_responseSerial{ 0 };
+
+    /// True while a queued pending-image service pass is already scheduled.
+    std::atomic<bool> m_servicePendingScheduled{ false };
+
+    /// One queued ImagePlease request waiting for the next deliverable response.
+    struct pendingImageRequest
+    {
+        grpc::CallbackServerContext *m_context{ nullptr }; ///< gRPC callback context used to detect cancellation.
+
+        grpc::ServerUnaryReactor *m_reactor{ nullptr }; ///< Reactor finished when this pending request is served.
+
+        remote_rtimv::Image *m_reply{ nullptr }; ///< Reply payload populated when the request is fulfilled.
+
+        double m_enqueueTime{ 0 }; ///< Monotonic enqueue time in seconds for timeout accounting.
+    };
+
+    /// Mutex guarding the pending ImagePlease queue.
+    std::mutex m_pendingImageMutex;
+
+    /// FIFO queue of pending ImagePlease requests representing client-side credits.
+    std::deque<pendingImageRequest> m_pendingImageRequests;
+
+    /// Mark the current rendered response dirty and advance the response serial.
+    void markResponseDirty();
+
+    /// Populate reply metadata from the current server-thread state.
+    void populateImageReply( remote_rtimv::Image *reply /**< [in] reply payload to populate */ );
+
+    /// Schedule queued servicing of pending image requests on the Qt side.
+    void schedulePendingImageService();
 
   public:
     rtimvServerThread( const std::string &uri,                         /**< [in] client uri */
@@ -98,9 +138,7 @@ class rtimvServerThread : public QThread, public rtimvBase
 
     virtual void mtxL_postColormode( rtimv::colormode m, const sharedLockT &lock );
 
-    void mtxuL_render( std::string *image );
-
-    bool newImage();
+    void mtxuL_render( std::string *image /**< [out] rendered JPEG payload */ );
 
     /// Apply a new minimum image timeout on the Qt event thread.
     void setImageTimeout( int to /**< [in] the new minimum image timeout in ms */ );
@@ -126,7 +164,21 @@ class rtimvServerThread : public QThread, public rtimvBase
     /// Get current active RPC count.
     uint32_t rpcActive();
 
+    /// Queue one pending ImagePlease request for the next deliverable response.
+    void
+    enqueueImageRequest( grpc::CallbackServerContext *context, /**< [in] callback context for cancellation checks */
+                         grpc::ServerUnaryReactor *reactor,    /**< [in] reactor finished when a response is ready */
+                         remote_rtimv::Image *reply            /**< [in] reply payload owned by gRPC */
+    );
+
+    /// Drop cancelled pending requests and expire old ones.
+    void prunePendingImageRequests( double timeoutSeconds /**< [in] timeout applied to queued requests in seconds */ );
+
+    /// Get the number of queued pending ImagePlease requests.
+    size_t pendingImageRequests();
+
   signals:
+    void servicePending();
 
     void gotosleep();
 
@@ -138,6 +190,8 @@ class rtimvServerThread : public QThread, public rtimvBase
     void emit_awaken();
 
   public slots:
+    /// Attempt to serve one pending ImagePlease request with the newest available response.
+    void servicePendingImageRequests();
 
     void sleep();
 

--- a/tests/client/rtimvClientBase_async_race_test.cpp
+++ b/tests/client/rtimvClientBase_async_race_test.cpp
@@ -1,3 +1,10 @@
+/** \file rtimvClientBase_async_race_test.cpp
+ * \brief Regression tests for ImagePlease async callback races in rtimvClientBase
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #include <QCoreApplication>
 
 #include <cassert>
@@ -10,46 +17,68 @@
 class TestClientBase : public rtimvClientBase
 {
   public:
-    void setConnectedForTest( bool connected )
+    /// Force the connected flag for test setup.
+    void setConnectedForTest( bool connected /**< [in] desired test connected state */ )
     {
         uniqueLockT lock( m_connectedMutex );
         m_connected = connected;
     }
 
+    /// Read the connected flag under the normal client lock.
     bool connectedForTest()
     {
         sharedLockT lock( m_connectedMutex );
         return m_connected;
     }
 
-    bool imagePendingForTest()
+    /// Get the number of ImagePlease RPCs currently tracked as in flight.
+    size_t imageRequestCountForTest()
     {
         std::lock_guard<std::mutex> lock( m_imageRequestMutex );
-        return m_imageRequestPending;
-    }
-
-    bool imageContextAllocatedForTest()
-    {
-        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
-        return m_ImagePleaseContext != nullptr;
+        return m_inflightImageRequests.size();
     }
 
   protected:
-    void mtxL_postColormode( rtimv::colormode, const sharedLockT & ) override {}
-    void mtxL_postRecolor( const uniqueLockT & ) override {}
-    void mtxL_postRecolor( const sharedLockT & ) override {}
-    void mtxL_postChangeImdata( const sharedLockT & ) override {}
-    void post_zoomLevel() override {}
+    /// Test stub: no GUI colormode work needed.
+    void mtxL_postColormode( rtimv::colormode, const sharedLockT & ) override
+    {
+    }
+
+    /// Test stub: no GUI recolor work needed.
+    void mtxL_postRecolor( const uniqueLockT & ) override
+    {
+    }
+
+    /// Test stub: no GUI recolor work needed.
+    void mtxL_postRecolor( const sharedLockT & ) override
+    {
+    }
+
+    /// Test stub: no GUI image-data work needed.
+    void mtxL_postChangeImdata( const sharedLockT & ) override
+    {
+    }
+
+    /// Test stub: no GUI zoom work needed.
+    void post_zoomLevel() override
+    {
+    }
 };
 
 class ImmediateFailClient : public TestClientBase
 {
   protected:
-    void dispatchImagePleaseAsync() override
+    /// Complete the queued ImagePlease RPC immediately with a transport failure.
+    void dispatchImagePleaseAsync( uint64_t requestId,                      /**< [in] local request identifier */
+                                   std::shared_ptr<imageRequestState> state /**< [in] request state */
+                                   ) override
     {
-        std::thread callbackThread( [this]() {
-            this->ImagePlease_callback( grpc::Status( grpc::StatusCode::UNAVAILABLE, "simulated unavailable server" ) );
-        } );
+        std::thread callbackThread(
+            [this, requestId, state]()
+            {
+                this->ImagePlease_callback(
+                    requestId, state, grpc::Status( grpc::StatusCode::UNAVAILABLE, "simulated unavailable server" ) );
+            } );
         callbackThread.join();
     }
 };
@@ -57,12 +86,18 @@ class ImmediateFailClient : public TestClientBase
 class DelayedFailClient : public TestClientBase
 {
   protected:
-    void dispatchImagePleaseAsync() override
+    /// Complete the queued ImagePlease RPC after a short delay with a transport failure.
+    void dispatchImagePleaseAsync( uint64_t requestId,                      /**< [in] local request identifier */
+                                   std::shared_ptr<imageRequestState> state /**< [in] request state */
+                                   ) override
     {
-        std::thread callbackThread( [this]() {
-            std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
-            this->ImagePlease_callback( grpc::Status( grpc::StatusCode::UNAVAILABLE, "simulated unavailable server" ) );
-        } );
+        std::thread callbackThread(
+            [this, requestId, state]()
+            {
+                std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+                this->ImagePlease_callback(
+                    requestId, state, grpc::Status( grpc::StatusCode::UNAVAILABLE, "simulated unavailable server" ) );
+            } );
         callbackThread.detach();
     }
 };
@@ -79,8 +114,7 @@ int main( int argc, char **argv )
 
         client.ImagePlease();
 
-        assert( !client.imagePendingForTest() );
-        assert( !client.imageContextAllocatedForTest() );
+        assert( client.imageRequestCountForTest() == 0 );
         assert( !client.connectedForTest() );
     }
 
@@ -91,10 +125,12 @@ int main( int argc, char **argv )
         client->ImagePlease();
 
         std::atomic<bool> deleted{ false };
-        std::thread deleteThread( [client, &deleted]() {
-            delete client;
-            deleted = true;
-        } );
+        std::thread deleteThread(
+            [client, &deleted]()
+            {
+                delete client;
+                deleted = true;
+            } );
 
         for( int i = 0; i < 200 && !deleted.load(); ++i )
         {

--- a/tests/client/rtimvClientBase_async_race_test.cpp
+++ b/tests/client/rtimvClientBase_async_race_test.cpp
@@ -102,6 +102,24 @@ class DelayedFailClient : public TestClientBase
     }
 };
 
+class NoImageRetryClient : public TestClientBase
+{
+  protected:
+    /// Complete the queued ImagePlease RPC with a NO_IMAGE response to exercise retry scheduling during teardown.
+    void dispatchImagePleaseAsync( uint64_t requestId,                      /**< [in] local request identifier */
+                                   std::shared_ptr<imageRequestState> state /**< [in] request state */
+                                   ) override
+    {
+        std::thread callbackThread(
+            [this, requestId, state]()
+            {
+                state->m_reply.set_status( remote_rtimv::IMAGE_STATUS_NO_IMAGE );
+                this->ImagePlease_callback( requestId, state, grpc::Status::OK );
+            } );
+        callbackThread.join();
+    }
+};
+
 int main( int argc, char **argv )
 {
     QCoreApplication app( argc, argv );
@@ -134,11 +152,24 @@ int main( int argc, char **argv )
 
         for( int i = 0; i < 200 && !deleted.load(); ++i )
         {
+            QCoreApplication::processEvents();
             std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
         }
 
         assert( deleted.load() );
         deleteThread.join();
+    }
+
+    // Regression: a queued no-image retry should be canceled safely during shutdown.
+    {
+        auto *client = new NoImageRetryClient;
+        client->setConnectedForTest( true );
+        client->ImagePlease();
+
+        delete client;
+
+        std::this_thread::sleep_for( std::chrono::milliseconds( 2200 ) );
+        QCoreApplication::processEvents();
     }
 
     return 0;

--- a/tests/client/rtimvClientBase_async_race_test.cpp
+++ b/tests/client/rtimvClientBase_async_race_test.cpp
@@ -38,6 +38,16 @@ class TestClientBase : public rtimvClientBase
         return m_inflightImageRequests.size();
     }
 
+    /// Force the image pipeline state for pipelined shutdown regression coverage.
+    void setImagePipelineForTest( size_t window, /**< [in] desired in-flight window */
+                                  bool primed    /**< [in] true to allow full-window dispatch immediately */
+    )
+    {
+        std::lock_guard<std::mutex> lock( m_imageRequestMutex );
+        m_targetImageWindow = window;
+        m_imagePipelinePrimed = primed;
+    }
+
   protected:
     /// Test stub: no GUI colormode work needed.
     void mtxL_postColormode( rtimv::colormode, const sharedLockT & ) override
@@ -140,6 +150,31 @@ int main( int argc, char **argv )
     {
         auto *client = new DelayedFailClient;
         client->setConnectedForTest( true );
+        client->ImagePlease();
+
+        std::atomic<bool> deleted{ false };
+        std::thread deleteThread(
+            [client, &deleted]()
+            {
+                delete client;
+                deleted = true;
+            } );
+
+        for( int i = 0; i < 200 && !deleted.load(); ++i )
+        {
+            QCoreApplication::processEvents();
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+        }
+
+        assert( deleted.load() );
+        deleteThread.join();
+    }
+
+    // Regression: shutdown while a pipelined image window is in flight should not hang.
+    {
+        auto *client = new DelayedFailClient;
+        client->setConnectedForTest( true );
+        client->setImagePipelineForTest( 8, true );
         client->ImagePlease();
 
         std::atomic<bool> deleted{ false };


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "Investigate and fix `rtimvClient`/server handling of `m_currImageTimeout`, improve high-RTT remote image delivery, and harden gRPC client/server shutdown behavior."

## Summary
- fix server-side `SetImageTimeout` handling so timeout changes are applied on the Qt thread and `ImagePlease` wait budgeting follows the effective image timeout
- add startup config logging in `rtimvServer`, including `RTIMV_CONFIG_PATH`, resolved config inputs, loaded config files, and effective server/image settings
- add lightweight gRPC `Ping` RTT diagnostics and surface average RTT in the client UI
- replace the single in-flight `ImagePlease` loop with a pipelined credit-based unary image path using `response_serial` and latest-wins client application
- add configurable client image-request windowing in config/UI and smooth transport-stat display updates
- harden client and server shutdown/lifetime handling around queued image RPCs, callback accounting, and teardown races
- reuse shared `rtimvBase` config parsing in `rtimvServer` so server config can override shared base defaults such as `update.timeout`

## Validation
- `cmake --build /tmp/rtimv-codex-build --target rtimvServer -j4`
- `cmake --build /tmp/rtimv-codex-build --target rtimvClient -j4`
- `cmake --build /tmp/rtimv-codex-build --target rtimvClientBaseAsyncRaceTest -j4`
- `ctest --test-dir /tmp/rtimv-codex-build/tests -R rtimvClientBase_async_race --output-on-failure`
- manual remote validation on a ~300 ms RTT link: pipelined image requests sustained the full 30 FPS stream rate

## Notes
- protobuf compatibility for old clients talking to the new server is preserved by additive `Image` fields and the unchanged unary `ImagePlease` RPC
- expected shutdown-time `CANCELLED` noise from locally canceled `ImagePlease` RPCs is now suppressed, and client shutdown allows a longer grace period before canceling remaining in-flight work
